### PR TITLE
[LOC-236] add style for links in Banner component

### DIFF
--- a/src/components/Banner/Banner.sass
+++ b/src/components/Banner/Banner.sass
@@ -16,6 +16,12 @@
 		@include theme-border
 		@include theme-stripes-white-else-graydark
 
+		a
+			color: $green
+
+			&:hover
+				color: $green-dark
+
 	&.Banner__Error
 		@include stripes(#f05b6f, #ef4e65)
 
@@ -45,6 +51,9 @@
 		color: $white
 		font-weight: 500
 		text-decoration: underline
+
+		&:hover
+			color: $gray15
 
 	strong
 		margin-right: 5px

--- a/src/components/Banner/Banner.sass
+++ b/src/components/Banner/Banner.sass
@@ -41,6 +41,11 @@
 			path
 				fill: $yellow
 
+	a
+		color: $white
+		font-weight: 500
+		text-decoration: underline
+
 	strong
 		margin-right: 5px
 		font-weight: 700

--- a/src/components/Banner/Banner.sass
+++ b/src/components/Banner/Banner.sass
@@ -26,13 +26,13 @@
 		@include stripes(#f05b6f, #ef4e65)
 
 		a:hover
-			color: #8c2738
+			color: $red-dark
 
 	&.Banner__Success
 		@include stripes($green, mix($black, $green, 5%))
 
 		a:hover
-			color: #267048
+			color: $green-dark
 
 	.Content
 		line-height: 18px

--- a/src/components/Banner/Banner.sass
+++ b/src/components/Banner/Banner.sass
@@ -25,8 +25,14 @@
 	&.Banner__Error
 		@include stripes(#f05b6f, #ef4e65)
 
+		a:hover
+			color: #8c2738
+
 	&.Banner__Success
 		@include stripes($green, mix($black, $green, 5%))
+
+		a:hover
+			color: #267048
 
 	.Content
 		line-height: 18px
@@ -53,7 +59,7 @@
 		text-decoration: underline
 
 		&:hover
-			color: $gray15
+			color: $orange-dark
 
 	strong
 		margin-right: 5px

--- a/src/components/Banner/README.md
+++ b/src/components/Banner/README.md
@@ -29,3 +29,11 @@ Success:
     <strong>Typewriter!</strong> Poke selvage fam retro pug, offal butcher occupy banh mi artisan tousled.
 </Banner>
 ```
+
+Success with inline link.
+   
+```js
+<Banner variant="success" icon="warning">
+    <strong>Typewriter!</strong> Poke selvage fam retro pug, offal butcher occupy <a>banh mi artisan tousled</a>.
+</Banner>
+```

--- a/src/components/Banner/README.md
+++ b/src/components/Banner/README.md
@@ -2,7 +2,7 @@ Neutral:
    
 ```js
 <Banner variant="neutral" icon="warning" buttonText="Click Me!" buttonOnClick={() => console.log('buttonOnClick')}>
-    <strong>Typewriter!</strong> Poke selvage fam retro pug, offal butcher occupy banh mi artisan tousled.
+    <strong>Typewriter!</strong> Poke selvage fam retro pug, offal butcher occupy or <a>learn more</a>.
 </Banner>
 ```
 
@@ -10,7 +10,7 @@ Warning:
    
 ```js
 <Banner variant="warning" icon="warning" buttonText="Click Me!" buttonOnClick={() => console.log('buttonOnClick')}>
-    <strong>Typewriter!</strong> Poke selvage fam retro pug, offal butcher occupy banh mi artisan tousled.
+    <strong>Typewriter!</strong> Poke selvage fam retro pug, offal butcher occupy or <a>learn more</a>.
 </Banner>
 ```
 
@@ -18,7 +18,7 @@ Error:
    
 ```js
 <Banner variant="error" icon="warning" buttonText="Click Me!" buttonOnClick={() => console.log('buttonOnClick')}>
-    <strong>Typewriter!</strong> Poke selvage fam retro pug, offal butcher occupy banh mi artisan tousled.
+    <strong>Typewriter!</strong> Poke selvage fam retro pug, offal butcher occupy or <a>learn more</a>.
 </Banner>
 ```
 
@@ -26,14 +26,6 @@ Success:
    
 ```js
 <Banner variant="success" icon="warning" buttonText="Click Me!" buttonOnClick={() => console.log('buttonOnClick')}>
-    <strong>Typewriter!</strong> Poke selvage fam retro pug, offal butcher occupy banh mi artisan tousled.
-</Banner>
-```
-
-Success with inline link.
-   
-```js
-<Banner variant="success" icon="warning">
-    <strong>Typewriter!</strong> Poke selvage fam retro pug, offal butcher occupy <a>banh mi artisan tousled</a>.
+    <strong>Typewriter!</strong> Poke selvage fam retro pug, offal butcher occupy or <a>learn more</a>.
 </Banner>
 ```

--- a/src/components/Spinner/Spinner.jsx
+++ b/src/components/Spinner/Spinner.jsx
@@ -7,7 +7,7 @@ import styles from './Spinner.sass';
 export default class Spinner extends Component {
 	static propTypes = {
 		className: PropTypes.string,
-		color: PropTypes.oneOf(['Gray25', 'GrayDark50']),
+		color: PropTypes.oneOf('Gray25', 'GrayDark50'),
 		ellipsis: PropTypes.node,
 		lines: PropTypes.number,
 	};

--- a/src/components/Spinner/Spinner.jsx
+++ b/src/components/Spinner/Spinner.jsx
@@ -7,7 +7,7 @@ import styles from './Spinner.sass';
 export default class Spinner extends Component {
 	static propTypes = {
 		className: PropTypes.string,
-		color: PropTypes.oneOf('Gray25', 'GrayDark50'),
+		color: PropTypes.oneOf(['Gray25', 'GrayDark50']),
 		ellipsis: PropTypes.node,
 		lines: PropTypes.number,
 	};


### PR DESCRIPTION
**Audience**: Users | Engineers | Third-party Developers

**Summary**: Banner's need to be able to support links inside them. This adds a scoped, color appropriate style for `<a />` tag descendants within the Banner component.

**Screenshots**: 

| Link      | Link Hover |
| ----------- | ----------- |
| ![image](https://user-images.githubusercontent.com/41925404/50181787-f2b75680-02d2-11e9-97d5-157af30c6de9.png) | ![image](https://user-images.githubusercontent.com/41925404/50181830-0fec2500-02d3-11e9-811e-4a2c3c5148f8.png) |
