### PR TITLE
fix: properly pass array for <Spinner />'s color prop definition

### DIFF
--- a/src/components/Spinner/Spinner.jsx
+++ b/src/components/Spinner/Spinner.jsx
@@ -7,7 +7,7 @@ import styles from './Spinner.sass';
 export default class Spinner extends Component {
 	static propTypes = {
 		className: PropTypes.string,
-		color: PropTypes.oneOf('Gray25', 'GrayDark50'),
+		color: PropTypes.oneOf(['Gray25', 'GrayDark50']),
 		ellipsis: PropTypes.node,
 		lines: PropTypes.number,
 	};


### PR DESCRIPTION
**Audience**: Engineers | Third-party Developers

**Summary**: The Spinner component's `color` PropType `oneOf` was incorrectly setup to take string params instead of an array of strings.
