### PR TITLE
[LOC-197] Add radio block to choose between staging and production when pushing/pulling

### DIFF
--- a/src/components/Divider/Divider.jsx
+++ b/src/components/Divider/Divider.jsx
@@ -4,11 +4,11 @@ import styles from './Divider.sass';
 import PropTypes from 'prop-types';
 
 const marginsClassMixin = (styles, props) => ({
-	[styles.__MarginTopSizeXS]: props.marginSize === 'xs' || props.marginSizeAfter === 'xs',
-	[styles.__MarginTopSizeS]: props.marginSize === 's' || props.marginSizeAfter === 's',
-	[styles.__MarginTopSizeM]: props.marginSize === 'm' || props.marginSizeAfter === 'm',
-	[styles.__MarginTopSizeL]: props.marginSize === 'l' || props.marginSizeAfter === 'l',
-	[styles.__MarginTopSizeXL]: props.marginSize === 'xl' || props.marginSizeAfter === 'xl',
+	[styles.__MarginTopSizeXS]: props.marginSize === 'xs' || props.marginSizeTop === 'xs',
+	[styles.__MarginTopSizeS]: props.marginSize === 's' || props.marginSizeTop === 's',
+	[styles.__MarginTopSizeM]: props.marginSize === 'm' || props.marginSizeTop === 'm',
+	[styles.__MarginTopSizeL]: props.marginSize === 'l' || props.marginSizeTop === 'l',
+	[styles.__MarginTopSizeXL]: props.marginSize === 'xl' || props.marginSizeTop === 'xl',
 	[styles.__MarginBottomSizeXS]: props.marginSize === 'xs' || props.marginSizeBottom === 'xs',
 	[styles.__MarginBottomSizeS]: props.marginSize === 's' || props.marginSizeBottom === 's',
 	[styles.__MarginBottomSizeM]: props.marginSize === 'm' || props.marginSizeBottom === 'm',
@@ -29,7 +29,7 @@ const Divider = (props) =>
 
 Divider.propTypes = {
 	marginSize: PropTypes.oneOf(['xs', 's', 'm', 'l', 'xl']),
-	marginSizeAfter: PropTypes.oneOf(['xs', 's', 'm', 'l', 'xl']),
+	marginSizeTop: PropTypes.oneOf(['xs', 's', 'm', 'l', 'xl']),
 	marginSizeBottom: PropTypes.oneOf(['xs', 's', 'm', 'l', 'xl']),
 };
 

--- a/src/components/Divider/README.md
+++ b/src/components/Divider/README.md
@@ -2,7 +2,19 @@ A horizontal divider with medium (20px) top and bottom margin.
 
 ```js
 <div>
+	<div>Some text</div>
 	<Divider marginSize="m" />
+	<div>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin tincidunt nec orci ac elementum. Sed vitae ligula non dolor egestas congue. Etiam at luctus sem. Sed metus lorem, dapibus non congue nec, mattis eu leo. In condimentum mi nec tristique pretium. Aliquam vel urna vitae justo accumsan auctor. Mauris purus orci, hendrerit et dignissim eu, efficitur non dui. Donec fringilla ipsum eu rutrum ultricies. Mauris vel neque fermentum, porta justo id, pretium mauris. Donec rhoncus, ante et laoreet tincidunt, leo lorem dapibus dolor, vel ultrices metus odio et felis.</div>
+</div>
+```
+
+A horizontal divider with large (30px) margin above it.
+
+```js
+<div>
+	<div>Some text</div>
+	<Divider marginSizeTop="l" />
+	<div>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin tincidunt nec orci ac elementum. Sed vitae ligula non dolor egestas congue. Etiam at luctus sem. Sed metus lorem, dapibus non congue nec, mattis eu leo. In condimentum mi nec tristique pretium. Aliquam vel urna vitae justo accumsan auctor. Mauris purus orci, hendrerit et dignissim eu, efficitur non dui. Donec fringilla ipsum eu rutrum ultricies. Mauris vel neque fermentum, porta justo id, pretium mauris. Donec rhoncus, ante et laoreet tincidunt, leo lorem dapibus dolor, vel ultrices metus odio et felis.</div>
 </div>
 ```
 
@@ -12,5 +24,6 @@ A horizontal divider with extra-large (40px) margin below it.
 <div>
 	<div>Some text</div>
 	<Divider marginSizeBottom="xl" />
+	<div>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin tincidunt nec orci ac elementum. Sed vitae ligula non dolor egestas congue. Etiam at luctus sem. Sed metus lorem, dapibus non congue nec, mattis eu leo. In condimentum mi nec tristique pretium. Aliquam vel urna vitae justo accumsan auctor. Mauris purus orci, hendrerit et dignissim eu, efficitur non dui. Donec fringilla ipsum eu rutrum ultricies. Mauris vel neque fermentum, porta justo id, pretium mauris. Donec rhoncus, ante et laoreet tincidunt, leo lorem dapibus dolor, vel ultrices metus odio et felis.</div>
 </div>
 ```

--- a/src/components/FlyTooltip/FlyTooltip.jsx
+++ b/src/components/FlyTooltip/FlyTooltip.jsx
@@ -12,12 +12,14 @@ export default class FlyTooltip extends Component {
 		forceHoverState: PropTypes.bool,
 		hoverIntent: PropTypes.bool,
 		position: PropTypes.oneOf(['top', 'bottom', 'right']),
+		widthIsAuto: PropTypes.bool,
 	};
 
 	static defaultProps = {
 		exclamation: false,
 		forceHoverState: false,
 		position: 'top',
+		widthIsAuto: false,
 	};
 
 	render () {
@@ -40,6 +42,7 @@ export default class FlyTooltip extends Component {
                             [styles.FlyTooltip__PositionBottom]: this.props.position === 'bottom',
                             [styles.FlyTooltip__PositionRight]: this.props.position === 'right',
                             [styles.FlyTooltip__PositionTop]: this.props.position === 'top',
+							[styles.FlyTooltip__WidthIsAuto]: this.props.widthIsAuto,
                     	},
 						this.props.className,
 					)}

--- a/src/components/FlyTooltip/FlyTooltip.sass
+++ b/src/components/FlyTooltip/FlyTooltip.sass
@@ -18,7 +18,7 @@
 	@extend .FlyDropdown_Items
 
 	top: auto
-	z-index: 2
+	z-index: 5
 	right: 50%
 	display: inline-block
 	width: 300px
@@ -29,6 +29,9 @@
 	@include theme-color-graydark50-else-gray25
 	@include theme-input-background-color
 	@include theme-border
+
+	&.FlyTooltip__WidthIsAuto
+		width: auto
 
 	&::before
 		box-shadow: 0 0 20px 0 rgba($gray-dark, .15)

--- a/src/components/RadioBlock/README.md
+++ b/src/components/RadioBlock/README.md
@@ -1,6 +1,35 @@
+Simple RadioBlock example:
+
 ```js
 <RadioBlock onChange={() => console.log('onChange')} default={'test1'} options={{
     'test1': {
+        label: 'Test 1',
+    },
+    'test2': {
+        label: 'Test 2',
+    },
+}} />
+```
+
+Disable the entire component:
+
+```js
+<RadioBlock disabled={true} onChange={() => console.log('onChange')} default={'test1'} options={{
+    'test1': {
+        label: 'Test 1',
+    },
+    'test2': {
+        label: 'Test 2',
+    },
+}} />
+```
+
+Disable a single option and select the other:
+
+```js
+<RadioBlock onChange={() => console.log('onChange')} default={'test2'} options={{
+    'test1': {
+    	disabled: true,
         label: 'Test 1',
     },
     'test2': {

--- a/src/components/RadioBlock/README.md
+++ b/src/components/RadioBlock/README.md
@@ -50,3 +50,18 @@ Medium size RadioBlock:
     },
 }} />
 ```
+
+Tooltip for the second, disabled option:
+
+```js
+<RadioBlock heightSize="m" onChange={() => console.log('onChange')} default={'test1'} options={{
+    'test1': {
+        label: 'Test 1',
+    },
+    'test2': {
+    	disabled: true,
+        label: 'Test 2',
+        tooltipContent: <p>Hey, this is why this is disabled. It all started when you clicked...</p>,
+    },
+}} />
+```

--- a/src/components/RadioBlock/README.md
+++ b/src/components/RadioBlock/README.md
@@ -37,3 +37,16 @@ Disable a single option and select the other:
     },
 }} />
 ```
+
+Medium size RadioBlock:
+
+```js
+<RadioBlock heightSize="m" onChange={() => console.log('onChange')} default={'test1'} options={{
+    'test1': {
+        label: 'Test 1',
+    },
+    'test2': {
+        label: 'Test 2',
+    },
+}} />
+```

--- a/src/components/RadioBlock/RadioBlock.jsx
+++ b/src/components/RadioBlock/RadioBlock.jsx
@@ -3,11 +3,13 @@ import classnames from 'classnames';
 import CheckmarkSVG from '../../svg/checkmark--big.svg';
 import PropTypes from 'prop-types';
 import styles from './RadioBlock.sass';
+import Header from '../Header/Header';
 
 class RadioBlock extends Component {
 
 	static propTypes = {
 		disabled: PropTypes.bool,
+		heightSize: PropTypes.oneOf(['m', 'l']),
 		options: PropTypes.object,
 		default: PropTypes.any,
 		onChange: PropTypes.func,
@@ -15,6 +17,7 @@ class RadioBlock extends Component {
 
 	static defaultProps = {
 		disabled: false,
+		heightSize: 'l',
 		bullets: true,
 		headerFontSize: 's',
 		headerTag: 'div',
@@ -54,6 +57,7 @@ class RadioBlock extends Component {
 							onClick={this.onClick}
 							className={this.props.options[optionValue].className}
 							disabled={this.props.disabled || this.props.options[optionValue].disabled}
+							heightSize={this.props.heightSize}
 							label={this.props.options[optionValue].label}
 							value={optionValue}
 							key={i}
@@ -72,6 +76,7 @@ class RadioBlockItem extends Component {
 
 	static propTypes = {
 		disabled: PropTypes.bool,
+		heightSize: PropTypes.oneOf(['m', 'l']),
 		label: PropTypes.string,
 		value: PropTypes.any,
 		selected: PropTypes.bool,
@@ -81,6 +86,7 @@ class RadioBlockItem extends Component {
 
 	static defaultProps = {
 		disabled: false,
+		heightSize: 'l',
 	};
 
 	constructor (props) {
@@ -108,12 +114,18 @@ class RadioBlockItem extends Component {
 					this.props.className,
 					{
 						[styles.RadioBlock_Option__Disabled]: this.props.disabled,
+						[styles.RadioBlock_Option__HeightSizeMedium]: this.props.heightSize === 'm',
 						[styles.RadioBlock_Option__Selected]: this.props.selected,
 					}
 				)}
 			>
 				<label className={styles.RadioBLock_Label}>
-					<h4>{this.props.label}</h4>
+					<Header
+						fontSize={this.props.heightSize === 'l' ? 's' : 'xs'}
+						fontWeight="500"
+					>
+						{this.props.label}
+					</Header>
 					<div className={styles.RadioBLock_Arrow}>
 						{svg}
 					</div>

--- a/src/components/RadioBlock/RadioBlock.jsx
+++ b/src/components/RadioBlock/RadioBlock.jsx
@@ -4,10 +4,12 @@ import CheckmarkSVG from '../../svg/checkmark--big.svg';
 import PropTypes from 'prop-types';
 import styles from './RadioBlock.sass';
 import Header from '../Header/Header';
+import FlyTooltip from '../FlyTooltip/FlyTooltip';
 
 class RadioBlock extends Component {
 
 	static propTypes = {
+		className: PropTypes.string,
 		disabled: PropTypes.bool,
 		heightSize: PropTypes.oneOf(['m', 'l']),
 		options: PropTypes.object,
@@ -50,7 +52,10 @@ class RadioBlock extends Component {
 
 	render () {
 		return (
-			<div className={styles.RadioBlock}>
+			<div className={classnames(
+				styles.RadioBlock,
+				this.props.className,
+			)}>
 				{
 					Object.keys(this.props.options).map((optionValue, i) =>
 						<RadioBlockItem
@@ -63,6 +68,7 @@ class RadioBlock extends Component {
 							key={i}
 							svg={this.props.options[optionValue].svg}
 							selected={this.state.value === optionValue}
+							tooltipContent={this.props.options[optionValue].tooltipContent}
 						/>
 					)
 				}
@@ -82,6 +88,7 @@ class RadioBlockItem extends Component {
 		selected: PropTypes.bool,
 		onClick: PropTypes.func,
 		svg: PropTypes.element,
+		tooltipContent: PropTypes.node,
 	};
 
 	static defaultProps = {
@@ -103,10 +110,28 @@ class RadioBlockItem extends Component {
 		this.props.onClick(this.props.value);
 	}
 
+	renderOptionalTooltipAndContent (content) {
+		if(this.props.tooltipContent) {
+			return (
+				<FlyTooltip
+					content={this.props.tooltipContent}
+					position="top"
+					hoverIntent={true}
+					className={styles.RadioBlock_Option_TooltipWrapper}
+					widthIsAuto={true}
+				>
+					{ content }
+				</FlyTooltip>
+			)
+		}
+
+		return content;
+	}
+
 	render () {
 		const svg = this.props.svg ? this.props.svg : <CheckmarkSVG />;
 
-		return (
+		return this.renderOptionalTooltipAndContent((
 			<div
 				onClick={this.onClick}
 				className={classnames(
@@ -131,7 +156,7 @@ class RadioBlockItem extends Component {
 					</div>
 				</label>
 			</div>
-		);
+		));
 	}
 
 }

--- a/src/components/RadioBlock/RadioBlock.jsx
+++ b/src/components/RadioBlock/RadioBlock.jsx
@@ -5,10 +5,22 @@ import PropTypes from 'prop-types';
 import styles from './RadioBlock.sass';
 
 class RadioBlock extends Component {
-	PropTypes = {
+
+	static propTypes = {
+		disabled: PropTypes.bool,
 		options: PropTypes.object,
 		default: PropTypes.any,
 		onChange: PropTypes.func,
+	};
+
+	static defaultProps = {
+		disabled: false,
+		bullets: true,
+		headerFontSize: 's',
+		headerTag: 'div',
+		headerWeight: '500',
+		listItemWrapElement: true,
+		tag: 'ul',
 	};
 
 	constructor (props) {
@@ -41,6 +53,7 @@ class RadioBlock extends Component {
 						<RadioBlockItem
 							onClick={this.onClick}
 							className={this.props.options[optionValue].className}
+							disabled={this.props.disabled || this.props.options[optionValue].disabled}
 							label={this.props.options[optionValue].label}
 							value={optionValue}
 							key={i}
@@ -52,15 +65,22 @@ class RadioBlock extends Component {
 			</div>
 		);
 	}
+
 }
 
 class RadioBlockItem extends Component {
-	PropTypes = {
+
+	static propTypes = {
+		disabled: PropTypes.bool,
 		label: PropTypes.string,
 		value: PropTypes.any,
 		selected: PropTypes.bool,
 		onClick: PropTypes.func,
 		svg: PropTypes.element,
+	};
+
+	static defaultProps = {
+		disabled: false,
 	};
 
 	constructor (props) {
@@ -70,6 +90,10 @@ class RadioBlockItem extends Component {
 	}
 
 	onClick () {
+		if (this.props.disabled) {
+			return;
+		}
+
 		this.props.onClick(this.props.value);
 	}
 
@@ -83,6 +107,7 @@ class RadioBlockItem extends Component {
 					styles.RadioBlock_Option,
 					this.props.className,
 					{
+						[styles.RadioBlock_Option__Disabled]: this.props.disabled,
 						[styles.RadioBlock_Option__Selected]: this.props.selected,
 					}
 				)}
@@ -96,6 +121,7 @@ class RadioBlockItem extends Component {
 			</div>
 		);
 	}
+
 }
 
 export default RadioBlock;

--- a/src/components/RadioBlock/RadioBlock.sass
+++ b/src/components/RadioBlock/RadioBlock.sass
@@ -16,6 +16,8 @@
 	font-size: 18px
 	flex: 1
 
+	&.RadioBlock_Option__HeightSizeMedium
+
 	&.RadioBlock_Option__Disabled
 		color: $gray75
 		background: $disabled-background
@@ -50,9 +52,14 @@
 		left: 0
 		transition: all .15s ease 0s
 		@include theme-input-border
-		padding: 29px
 		width: 100%
 		height: 100%
+
+		@include selectors_setAsDefaults
+			padding: 29px
+		@include selectors_appendToNthParentSelector('.RadioBlock_Option__HeightSizeMedium', 1)
+			padding-top: 24px
+			padding-bottom: 24px
 
 		h4
 			margin: 0

--- a/src/components/RadioBlock/RadioBlock.sass
+++ b/src/components/RadioBlock/RadioBlock.sass
@@ -7,12 +7,18 @@
 	width: 100%
 
 .RadioBlock_Option
+	$disabled-background: $gray15
+
 	position: relative
 	z-index: 1
 	@include theme-background-white-else-graydark
 	text-align: center
 	font-size: 18px
 	flex: 1
+
+	&.RadioBlock_Option__Disabled
+		color: $gray75
+		background: $disabled-background
 
 	&.RadioBlock_Option__Selected
 		z-index: 4
@@ -35,80 +41,85 @@
 				transition: all .2s ease 0s !important
 				opacity: 1
 
-.RadioBLock_Label
-	cursor: pointer
-	display: block
-	top: 0
-	right: 0
-	bottom: 0
-	left: 0
-	transition: all .15s ease 0s
-	@include theme-input-border
-	padding: 29px
-	width: 100%
-	height: 100%
-
-	h4
-		margin: 0
+	.RadioBLock_Label
 		cursor: pointer
-
-	&::before
-		content: ""
 		display: block
-		position: absolute
 		top: 0
 		right: 0
 		bottom: 0
 		left: 0
 		transition: all .15s ease 0s
-		opacity: 0
-		z-index: 0
-		border: 2px solid $green
-		border-radius: inherit
-		@include theme-background-white-else-graydark
+		@include theme-input-border
+		padding: 29px
 		width: 100%
 		height: 100%
 
-	*
-		position: relative
-		z-index: 2
+		h4
+			margin: 0
+			cursor: pointer
 
-.RadioBLock_Arrow
-	$width: 50px
+		&::before
+			content: ""
+			display: block
+			position: absolute
+			top: 0
+			right: 0
+			bottom: 0
+			left: 0
+			transition: all .15s ease 0s
+			opacity: 0
+			z-index: 0
+			border: 2px solid $green
+			border-radius: inherit
 
-	position: absolute
-	transform: scale(0)
-	transform-origin: 100% 0
-	transition: all 0s ease 0s
-	opacity: 0
+			width: 100%
+			height: 100%
 
-	svg
+			@include selectors_setAsDefaults
+				@include theme-background-white-else-graydark
+			@include selectors_appendToNthParentSelector('.RadioBlock_Option__Disabled', 1)
+				background: $disabled-background
+
+		*
+			position: relative
+			z-index: 2
+
+	.RadioBLock_Arrow
+		$width: 50px
+
 		position: absolute
-		top: 6.4px
-		right: 9.6px
-		z-index: 9
-		width: 10px
-		height: 14px
-		color: $white
+		transform: scale(0)
+		transform-origin: 100% 0
+		transition: all 0s ease 0s
+		opacity: 0
 
-		path
-			fill: $white
+		svg
+			position: absolute
+			top: 6.4px
+			right: 9.6px
+			z-index: 9
+			width: 10px
+			height: 14px
+			color: $white
 
-	&::after
-		content: ""
-		display: block
-		position: absolute
-		top: 0
-		border-width: 0 $width $width 0
-		border-style: solid
-		border-color: transparent $green transparent transparent
-		width: 0
-		height: 0
+			path
+				fill: $white
 
-	top: -3px
-	right: -3px
-	width: $width
-	height: $width
+		&::after
+			content: ""
+			display: block
+			position: absolute
+			top: 0
+			border-width: 0 $width $width 0
+			border-style: solid
+			border-color: transparent $green transparent transparent
+			width: 0
+			height: 0
 
-	&::after
-		border-width: 0 $width $width 0
+		top: -3px
+		right: -3px
+		width: $width
+		height: $width
+
+		&::after
+			border-width: 0 $width $width 0

--- a/src/components/RadioBlock/RadioBlock.sass
+++ b/src/components/RadioBlock/RadioBlock.sass
@@ -6,6 +6,9 @@
 	justify-content: space-between
 	width: 100%
 
+.RadioBlock_Option_TooltipWrapper
+	flex: 1
+
 .RadioBlock_Option
 	$disabled-background: $gray15
 

--- a/src/styles/_partials/_selectors.scss
+++ b/src/styles/_partials/_selectors.scss
@@ -22,6 +22,7 @@
 	}
 }
 
+// this works its way up the dom tree $appendToParentN levels and appends itself
 @mixin selectors_appendToNthParentSelector($simpleSelectorModifier, $appendToParentN: 1) {
 	$finalSelectors: ();
 

--- a/src/styles/containers/SiteInfo.scss
+++ b/src/styles/containers/SiteInfo.scss
@@ -333,4 +333,28 @@
 			fill: $gray75;
 		}
 	}
+
+	.CommonConnectRemoteOptions_Item_Label__Margin {
+		label {
+			margin-bottom: 0 !important;
+		}
+	}
+
+	.CommonConnectRemoteOptions_TooltipContainer {
+		line-height: 1.4;
+	}
+
+	.CommonConnectRemoteOptions_TooltipLink {
+		display: block;
+		text-transform: none !important;
+		text-decoration: underline;
+	}
+
+	.CommonConnectRemoteOptions_Item__MarginTop {
+		margin-top: 26px !important;
+	}
+
+	.CommonConnectRemoteOptions_Item__MarginBottom {
+		margin-bottom: 26px !important;
+	}
 }

--- a/src/styles/forms.scss
+++ b/src/styles/forms.scss
@@ -271,7 +271,7 @@
 				@include theme-color-graydark-else-white;
 			}
 
-			input {
+			input:not([type="checkbox"]) {
 				@include flywheelInput;
 			}
 

--- a/src/styles/util.scss
+++ b/src/styles/util.scss
@@ -129,4 +129,12 @@
 		flex: 1;
 		overflow-y: auto;
 	}
+
+	.__Width100p {
+		width: 100%;
+	}
+
+	.__WhitespaceNowrap {
+		white-space: nowrap;
+	}
 }


### PR DESCRIPTION
**Audience**: Users  | Engineers | Third-party Developers

**Summary**: The purpose of this PR is to add component props and styles to RadioBlock to support switching between staging and production when pushing/pulling within `flywheel-local`. In addition to this, a number of other components and globals styles were added and/or modified to meet the requirements of the design.

**Technical**: 
- added disabled, heightSize (medium is new), tooltip feature, and className support for RadioBlock
- added several Styleguidist examples for RadioBlock
- added widthIsAuto support for FlyTooltip and fixed a z-index issue
- added/refactored margin top support for Divider 
- added several global utility styles
- fixed form checkbox issue