### PR TITLE
[LOC-197] Updated RadioBlock styles and Truncate require

### DIFF
--- a/src/components/RadioBlock/RadioBlock.sass
+++ b/src/components/RadioBlock/RadioBlock.sass
@@ -38,8 +38,8 @@
 				left: -5px
 				z-index: 2
 				border-radius: 4px
-				width: calc(100% + 5px)
-				height: calc(100% + 5px)
+				width: calc(100% + 4px)
+				height: calc(100% + 4px)
 
 			.RadioBLock_Arrow
 				transform: scale(1)
@@ -61,8 +61,8 @@
 		@include selectors_setAsDefaults
 			padding: 29px
 		@include selectors_appendToNthParentSelector('.RadioBlock_Option__HeightSizeMedium', 1)
-			padding-top: 24px
-			padding-bottom: 24px
+			padding-top: 20px
+			padding-bottom: 20px
 
 		h4
 			margin: 0

--- a/src/components/Truncate/Truncate.tsx
+++ b/src/components/Truncate/Truncate.tsx
@@ -3,7 +3,7 @@ import IReactComponentProps from '../../common/structures/IReactComponentProps';
 import Omit from '../../common/structures/Omit';
 
 /* TruncateMarkup's types and exports are all jacked up. This makes it play nicely in Local. */
-const TruncateMarkup = require('react-truncate-markup');
+const TruncateMarkup = require('react-truncate-markup').default;
 
 interface IProps {
 


### PR DESCRIPTION
**Audience**: Users | Engineers

**Summary**: Updated RadioBlock padding and resize width to match designs and Truncate require to use default export.

**Technical**: Truncate bug is due to a third-party component with a `.d.ts` file that's not ideally exported. This was resulting in the following error: 
```
Invariant Violation: Element type is invalid: expected a string (for built-in components) or a class/function (for composite components) but got: object.

Check the render method of `Truncate`.
```