### PR TITLE
feat(LOC-221): add Avatar component

### DIFF
--- a/src/components/Avatar/Avatar.sass
+++ b/src/components/Avatar/Avatar.sass
@@ -1,0 +1,40 @@
+@import '../../styles/_partials/index'
+
+.Avatar
+	position: relative
+
+	.Avatar_Initials
+		display: flex
+		align-items: center
+		justify-content: center
+		width: 100%
+		height: 100%
+		text-align: center
+		color: $white
+		font-size: 16px
+		font-weight: 700
+		text-transform: uppercase
+
+		&.Avatar_Initials__BackgroundBlue
+			background-color: $blue
+
+		&.Avatar_Initials__BackgroundGreen
+			background-color: $green
+
+		&.Avatar_Initials__BackgroundYellow
+			background-color: $yellow
+
+		&.Avatar_Initials__BackgroundOrange
+			background-color: $orange
+
+		&.Avatar_Initials__BackgroundRed
+			background-color: $red
+
+		&.Avatar_Initials__BackgroundPink
+			background-color: $pink
+
+		&.Avatar_Initials__BackgroundPurple
+			background-color: $purple
+
+	.Avatar_Image__Hidden
+		opacity: 0

--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -118,7 +118,7 @@ export default class Avatar extends React.Component<IProps, IState> {
 				{
 					this.props.src && (
 						<ImageCircle
-							className={classnames(
+							containerClassName={classnames(
 								{
 									[styles.Avatar_Image__Hidden]: !this.state.isImageLoaded || (this.props.initials && this.state.isImageError),
 								},

--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -1,0 +1,138 @@
+import * as React from 'react';
+import IReactComponentProps from '../../common/structures/IReactComponentProps';
+import * as styles from './Avatar.sass';
+import classnames from 'classnames';
+import ImageCircle from '../ImageCircle';
+import ClippedContent from '../ClippedContent';
+
+interface IProps extends IReactComponentProps {
+
+	color?: 'blue' | 'green' | 'yellow' | 'orange' | 'red' | 'pink' | 'purple';
+	initials?: string;
+	size?: 's' | 'm' | string;
+	src?: string;
+	type: 'user' | 'team';
+
+}
+
+interface IState {
+
+	isImageError: boolean;
+	isImageLoaded: boolean;
+
+}
+
+export default class Avatar extends React.Component<IProps, IState> {
+
+	static defaultProps: Partial<IProps> = {
+		color: 'blue',
+		size: 'm',
+	};
+
+	constructor (props: IProps) {
+		super(props);
+
+		this.state = {
+			isImageError: false,
+			isImageLoaded: false,
+		};
+
+		this.onError = this.onError.bind(this);
+		this.onLoad = this.onLoad.bind(this);
+	}
+
+	componentWillReceiveProps (nextProps: IProps) {
+		if (this.props.src !== nextProps.src) {
+			this.setState({
+				isImageError: false,
+				isImageLoaded: false,
+			});
+		}
+	}
+
+	onError () {
+		this.setState({
+			isImageError: true,
+		});
+	}
+
+	onLoad () {
+		this.setState({
+			isImageLoaded: true,
+		});
+	}
+
+	getSize (): string {
+		let size: string = this.props.size || Avatar.defaultProps.size as string;
+
+		switch (size) {
+			case 'm':
+				size = '40px';
+				break;
+			case 's':
+				size = '32px';
+				break;
+		}
+
+		return size;
+	}
+
+	render () {
+		const size: string = this.getSize();
+
+		return (
+			<div
+				className={classnames(
+					styles.Avatar,
+					this.props.className,
+				)}
+			>
+				{
+					this.props.initials && (!this.state.isImageLoaded || this.state.isImageError) && (
+						<ClippedContent
+							shape={this.props.type === 'team' ? 'rect-rounded' : 'circle'}
+							style={{
+								...(this.props.size && {width: size, height: size}),
+							}}
+						>
+							<div
+								className={classnames(
+									styles.Avatar_Initials,
+									{
+										[styles.Avatar_Initials__BackgroundBlue]: this.props.color === 'blue',
+										[styles.Avatar_Initials__BackgroundGreen]: this.props.color === 'green',
+										[styles.Avatar_Initials__BackgroundYellow]: this.props.color === 'yellow',
+										[styles.Avatar_Initials__BackgroundOrange]: this.props.color === 'orange',
+										[styles.Avatar_Initials__BackgroundRed]: this.props.color === 'red',
+										[styles.Avatar_Initials__BackgroundPink]: this.props.color === 'pink',
+										[styles.Avatar_Initials__BackgroundPurple]: this.props.color === 'purple',
+									},
+								)}
+								color={this.props.color}
+							>
+								{this.props.initials.trim().substring(0, 2)}
+							</div>
+						</ClippedContent>
+					)
+				}
+				{
+					this.props.src && (
+						<ImageCircle
+							className={classnames(
+								{
+									[styles.Avatar_Image__Hidden]: !this.state.isImageLoaded || (this.props.initials && this.state.isImageError),
+								},
+							)}
+							onError={this.onError}
+							onLoad={this.onLoad}
+							size={this.getSize()}
+							square={this.props.type === 'team'}
+							src={this.props.src}
+						/>
+					)
+				}
+			</div>
+		);
+	}
+
+}

--- a/src/components/Avatar/README.md
+++ b/src/components/Avatar/README.md
@@ -1,0 +1,156 @@
+Avatars provide a visual representation of a user or team through an image, initials, or both (with initials as a fallback).
+
+<h3>User type</h3>
+
+A user is visually represented by a circle shape. 
+It can be an image, initials, or both.
+
+<h6>Image</h6>
+
+```js
+<Avatar
+    src="https://getflywheel.com/wp-content/uploads/2015/02/flyheadshots-4-copy.jpg"
+    type="user"
+/>
+```
+
+<h6>Initials</h6>
+
+```js
+<Avatar
+    initials="ms"
+    type="user"
+/>
+```
+
+<h6>Image with initials Fallback</h6>
+
+If both an image `src` and the `initials` props are set, they will work together with the image appearing once loaded and the initials appearing prior to load on upon an error.
+
+*Note: These two elements should never appear at the same time.*
+
+```js
+<Avatar
+    src="https://getflywheel.com/wp-content/uploads/2015/02/flyheadshots-4-copy.jpg"
+    initials="ms"
+    type="user"
+/>
+```
+
+<h3>Team type</h3>
+
+A team is visually represented by a rounded square shape. 
+It can be an image, initials, or both.
+
+<h6>Image</h6>
+
+```js
+<Avatar 
+    src="https://avatars2.githubusercontent.com/u/2371558?s=400&v=4"
+    type="team"
+/>
+```
+
+<h3>Background colors</h3>
+
+Avatars with initials have a background color.
+By default, the background is set to Flywheel's primary brand color (blue).
+
+In addition, the following colors are available:
+
+<h6>Green</h6>
+
+```js
+<Avatar
+	color="green"
+    initials="GR"
+    type="user"
+/>
+```
+
+<h6>Yellow</h6>
+
+```js
+<Avatar
+	color="yellow"
+    initials="YE"
+    type="user"
+/>
+```
+
+<h6>Orange</h6>
+
+```js
+<Avatar
+	color="orange"
+    initials="OR"
+    type="user"
+/>
+```
+
+<h6>Red</h6>
+
+```js
+<Avatar
+	color="red"
+    initials="RE"
+    type="user"
+/>
+```
+
+<h6>Pink</h6>
+
+```js
+<Avatar
+	color="pink"
+    initials="PI"
+    type="user"
+/>
+```
+
+<h6>Purple</h6>
+
+```js
+<Avatar
+	color="purple"
+    initials="PU"
+    type="user"
+/>
+```
+
+<h3>Sizes</h3>
+
+There are two built-in sizes for avatars. The default is medium and there's also a small version.
+
+<h6>Small</h6>
+
+```js
+<Avatar
+    initials="AZ"
+    size="s"
+    type="user"
+/>
+```
+
+<h6>Medium</h6>
+
+```js
+<Avatar
+    initials="AZ"
+    size="m"
+    type="user"
+/>
+```
+
+<h3>More on images</h3>
+
+When using an image without initials, any load error will result in a blank area.
+
+<h6>onError</h6>
+
+```js
+<Avatar 
+    src="//bad-path.png"
+    type="team"
+/>
+```

--- a/src/components/Avatar/index.ts
+++ b/src/components/Avatar/index.ts
@@ -1,0 +1,1 @@
+export {default} from './Avatar';

--- a/src/components/ClippedContent/ClippedContent.sass
+++ b/src/components/ClippedContent/ClippedContent.sass
@@ -1,17 +1,21 @@
 @import '../../styles/_partials/index'
 
 .ClippedContent
-  display: flex
-  flex-direction: column
-  width: 100%
-  height: 100%
-  clip-path: inset(0 round 4px)
+	display: flex
+	flex-direction: column
+	clip-path: inset(0 round 4px)
 
-  &.ClippedContent__ShapeCircle
-    clip-path: circle(50%)
+	&.ClippedContent__AlignX
+		justify-content: center
 
-  &.ClippedContent__AlignX
-    justify-content: center
+	&.ClippedContent__AlignY
+		align-items: center
 
-  &.ClippedContent__AlignY
-    align-items: center
+	&.ClippedContent__FullHeight
+		height: 100%
+
+	&.ClippedContent__FullWidth
+		width: 100%
+
+	&.ClippedContent__ShapeCircle
+		clip-path: circle(50%)

--- a/src/components/ClippedContent/ClippedContent.sass
+++ b/src/components/ClippedContent/ClippedContent.sass
@@ -1,0 +1,17 @@
+@import '../../styles/_partials/index'
+
+.ClippedContent
+  display: flex
+  flex-direction: column
+  width: 100%
+  height: 100%
+  clip-path: inset(0 round 4px)
+
+  &.ClippedContent__ShapeCircle
+    clip-path: circle(50%)
+
+  &.ClippedContent__AlignX
+    justify-content: center
+
+  &.ClippedContent__AlignY
+    align-items: center

--- a/src/components/ClippedContent/ClippedContent.tsx
+++ b/src/components/ClippedContent/ClippedContent.tsx
@@ -1,0 +1,51 @@
+import * as React from 'react';
+import IReactComponentProps from '../../common/structures/IReactComponentProps';
+import * as styles from './ClippedContent.sass';
+import classnames from 'classnames';
+
+interface IProps extends IReactComponentProps {
+
+	alignX?: 'none' | 'center';
+	alignY?: 'none' | 'center';
+	height?: string | 'fit-content';
+	shape?: 'circle' | 'rect-rounded';
+	tag?: string;
+	width?: string | 'fit-content';
+
+}
+
+export default class ClippedContent extends React.Component<IProps> {
+
+	static defaultProps: Partial<IProps> = {
+		alignX: 'none',
+		alignY: 'none',
+		shape: 'rect-rounded',
+		tag: 'div',
+	};
+
+	render () {
+		const ContainerTag: any = this.props.tag;
+
+		return (
+			<ContainerTag
+				className={classnames(
+					styles.ClippedContent,
+					this.props.className,
+					{
+						[styles.ClippedContent__AlignX]: this.props.alignX === 'center',
+						[styles.ClippedContent__AlignY]: this.props.alignY === 'center',
+						[styles.ClippedContent__ShapeCircle]: this.props.shape === 'circle',
+					},
+				)}
+				style={{
+					...this.props.style,
+					...(this.props.height && {height: this.props.height}),
+					...(this.props.width && {width: this.props.width}),
+				}}
+			>
+				{this.props.children}
+			</ContainerTag>
+		);
+	}
+
+}

--- a/src/components/ClippedContent/ClippedContent.tsx
+++ b/src/components/ClippedContent/ClippedContent.tsx
@@ -11,6 +11,8 @@ interface IProps extends IReactComponentProps {
 	shape?: 'circle' | 'rect-rounded';
 	tag?: string;
 	width?: string | 'fit-content';
+	useFullHeight?: boolean;
+	useFullWidth?: boolean;
 
 }
 
@@ -21,6 +23,8 @@ export default class ClippedContent extends React.Component<IProps> {
 		alignY: 'none',
 		shape: 'rect-rounded',
 		tag: 'div',
+		useFullHeight: true,
+		useFullWidth: true,
 	};
 
 	render () {
@@ -34,6 +38,8 @@ export default class ClippedContent extends React.Component<IProps> {
 					{
 						[styles.ClippedContent__AlignX]: this.props.alignX === 'center',
 						[styles.ClippedContent__AlignY]: this.props.alignY === 'center',
+						[styles.ClippedContent__FullHeight]: this.props.useFullHeight,
+						[styles.ClippedContent__FullWidth]: this.props.useFullWidth,
 						[styles.ClippedContent__ShapeCircle]: this.props.shape === 'circle',
 					},
 				)}

--- a/src/components/ClippedContent/README.md
+++ b/src/components/ClippedContent/README.md
@@ -1,0 +1,196 @@
+The `ClippedContent` component clips its content to a specified shape.
+It uses `clip-path` to achieve this result.
+
+<h3>Shapes</h3>
+
+Content can be clipped to any of the predefined shapes through the `shape` prop.
+
+<h6>Rounded rectangle</h6>
+
+```js
+<div style={{width: "50px", height: "50px"}}>
+    <ClippedContent>
+        <div style={{width: "100%", height: "100%", background: "#50c6db", display: "flex", alignItems: "center", justifyContent: "center"}}>
+            ABC
+        </div>
+    </ClippedContent>
+</div>
+```
+
+<h6>Circle</h6>
+
+*Note: The circle shape is best used with square size dimensions.*
+
+```js
+<div style={{width: "50px", height: "50px"}}>
+    <ClippedContent shape="circle">
+        <div style={{width: "100%", height: "100%", background: "#50c6db", display: "flex", alignItems: "center", justifyContent: "center"}}>
+            ABC
+        </div>
+    </ClippedContent>
+</div>
+```
+
+<h3>Managing size</h3>
+
+It's important to understand the options and responsibilities of both the `ClippedContent` and its content (aka children) to get the desired outcome.
+
+By default, the `ClippedContent` component is set to clip its content and uses 100% of its parent's width and height.
+The content you pass to it, however, is completely up to you as this component adds no additional styles to it.
+
+<h4>The content</h4>
+
+The following examples will use the same content with varying styles, `ClippedContent` options (e.g. props), and parent div sizes to achieve different results.
+The content is simply 3 letters and a background color.
+Here's what it looks like:
+
+```js
+<div style={{background: "#50c6db"}}>
+    ABC
+</div>
+```
+
+<h4>The ClippedContent component</h4>
+
+Now let's wrap the content in the `ClippedContent` component.
+Notice the rounded corners.
+
+```js
+<ClippedContent>
+    <div style={{background: "#50c6db"}}>
+        ABC
+    </div>
+</ClippedContent>
+```
+
+<h4>Controlling size</h4>
+
+In the examples above, both the component and content fill the available width.
+Often times, however, we'll want to control both width and height.
+There's 3 different ways to do this.
+
+*Note: In the following examples, the `ClippedContent` has a gray background to show its width and height relative to its content.*
+
+<h6>1) Parent size</h6>
+
+Set the parent's width and height and the component will expand to fill the available space.
+
+```js
+<div style={{width: "50px", height: "50px"}}>
+    <ClippedContent style={{background: "gray"}}>
+        <div style={{background: "#50c6db"}}>
+            ABC
+        </div>
+    </ClippedContent>
+</div>
+```
+
+<h6>2) Component size</h6>
+
+If we don't want to rely on the available space provided by the parent, we can explicitly set the component's `width` and `height` through props.
+
+```js
+<div>
+    <ClippedContent width="50px" height="50px" style={{background: "gray"}}>
+        <div style={{background: "#50c6db"}}>
+            ABC
+        </div>
+    </ClippedContent>
+</div>
+```
+
+<h6>3) Content size</h6>
+
+You can also let the content dictate sizing, but the outcome might not be what you'd initially expect.
+
+```js
+<div>
+    <ClippedContent style={{background: "gray"}}>
+        <div style={{width: "50px", height: "50px", background: "#50c6db"}}>
+            ABC
+        </div>
+    </ClippedContent>
+</div>
+```
+
+What's happening here?
+
+The component, by default, has its width and height set to 100% to fill available space and it's at these dimensions that the clipping takes place.
+The content, however, is setting its own size.
+This means the left side is clipped to the expected rounded rectangle shape but the right side isn't.
+
+*Note: If using the `circle` shape, the content is completely clipped out of the above example and may result in nothing appearing.*
+
+How can we adjust this so the content is clipped as desired?
+
+<h6>3.5) Content size with fit-content</h6>
+
+The `ClippedContent` component's width and height props can also take a value of `fit-content`.
+This option resizes the component to match that of its content.
+
+```js
+<div>
+    <ClippedContent width="fit-content" height="fit-content" style={{background: "gray"}}>
+        <div style={{width: "50px", height: "50px", background: "#50c6db"}}>
+            ABC
+        </div>
+    </ClippedContent>
+</div>
+```
+
+<h3>Managing position</h3>
+
+In addition to clipping and sizing, the `ClippedContent` component uses a flex layout allowing for some easy, out-of-the-box alignments.
+
+*Note: If the component and content have the same width and height, there is no available space to change positioning and the following will have no effect.
+
+<h6>Align</h6>
+
+Using the `alignX` and `alignY` props, content can be centered.
+
+```js
+<div style={{width: "50px", height: "50px"}}>
+    <ClippedContent alignX="center" alignY="center" style={{background: "gray"}}>
+        <div style={{background: "#50c6db"}}>
+            ABC
+        </div>
+    </ClippedContent>
+</div>
+```
+
+Using the above example with a circle shape and tall content helps give a better idea of how alignment works.
+
+```js
+<div style={{width: "50px", height: "50px"}}>
+    <ClippedContent shape="circle" alignX="center" alignY="center" style={{background: "gray"}}>
+        <div style={{background: "#50c6db"}}>
+            ABC<br />DEF<br />GHI<br />JKL
+        </div>
+    </ClippedContent>
+</div>
+```
+
+And now with wider content.
+
+```js
+<div style={{width: "50px", height: "50px"}}>
+    <ClippedContent shape="circle" alignX="center" alignY="center" style={{background: "gray"}}>
+        <div style={{background: "#50c6db"}}>
+            ABCDEFGHIJKL
+        </div>
+    </ClippedContent>
+</div>
+```
+
+All of this is well and good, but if you have a background color you need to fill the clipped area, using the align props will not work.
+Instead, you'll need to manually set the content's sizing and positioning to achieve the desired result.
+
+```js
+<div style={{width: "50px", height: "50px"}}>
+    <ClippedContent shape="circle">
+        <div style={{width: "100%", height: "100%", background: "#50c6db", display: "flex", alignItems: "center", textAlign: "center"}}>
+            ABC DEF GHI JKL
+        </div>
+    </ClippedContent>
+</div>
+```

--- a/src/components/ClippedContent/index.ts
+++ b/src/components/ClippedContent/index.ts
@@ -1,0 +1,1 @@
+export {default} from './ClippedContent';

--- a/src/components/ImageCircle/ImageCircle.sass
+++ b/src/components/ImageCircle/ImageCircle.sass
@@ -1,6 +1,6 @@
 @import '../../styles/_partials/index'
 
-body .ImageCircleContainer
+.ImageCircleContainer
 	width: 40px
 	min-width: 40px
 	height: 40px

--- a/src/components/ImageCircle/ImageCircle.sass
+++ b/src/components/ImageCircle/ImageCircle.sass
@@ -1,6 +1,6 @@
 @import '../../styles/_partials/index'
 
-.ImageCircleContainer
+body .ImageCircleContainer
 	width: 40px
 	min-width: 40px
 	height: 40px
@@ -10,11 +10,7 @@
 		min-width: 32px
 		height: 32px
 
-.ImageCircle
-	width: 100%
-	height: 100%
-	object-fit: cover
-	border-radius: 50%
-
-	&.ImageCircleContainer__Square
-		border-radius: 4px
+	.ImageCircle
+		width: 100%
+		height: 100%
+		object-fit: cover

--- a/src/components/ImageCircle/ImageCircle.tsx
+++ b/src/components/ImageCircle/ImageCircle.tsx
@@ -8,6 +8,7 @@ import Handler from '../../common/structures/Handler';
 interface IProps extends IReactComponentProps {
 
 	className?: string;
+	containerClassName?: string;
 	onError?: Handler;
 	onLoad?: Handler;
 	size?: 'm' | 's' | string;
@@ -30,7 +31,7 @@ export default class ImageCircle extends React.Component<IProps> {
 			<ClippedContent
 				className={classnames(
 					styles.ImageCircleContainer,
-					this.props.className,
+					this.props.containerClassName,
 					{
 						[styles.ImageCircleContainer__SizeSmall]: this.props.size === 's',
 					},
@@ -40,10 +41,13 @@ export default class ImageCircle extends React.Component<IProps> {
 					...(this.props.size !== 's' && this.props.size !== 'm' && {width: this.props.size, minWidth: this.props.size, height: this.props.size}),
 				}}
 				tag={this.props.tag}
+				useFullHeight={false}
+				useFullWidth={false}
 			>
 				<img
 					className={classnames(
 						styles.ImageCircle,
+						this.props.className,
 						{
 							[styles.ImageCircleContainer__Square]: this.props.square,
 						},

--- a/src/components/ImageCircle/ImageCircle.tsx
+++ b/src/components/ImageCircle/ImageCircle.tsx
@@ -2,11 +2,15 @@ import * as React from 'react';
 import classnames from 'classnames';
 import * as styles from './ImageCircle.sass';
 import IReactComponentProps from '../../common/structures/IReactComponentProps';
+import ClippedContent from '../ClippedContent';
+import Handler from '../../common/structures/Handler';
 
 interface IProps extends IReactComponentProps {
 
 	className?: string;
-	size?: 'm' | 's';
+	onError?: Handler;
+	onLoad?: Handler;
+	size?: 'm' | 's' | string;
 	square?: boolean;
 	src: string;
 	tag?: string;
@@ -22,10 +26,8 @@ export default class ImageCircle extends React.Component<IProps> {
 	};
 
 	render () {
-		const ContainerTag: any = this.props.tag;
-
 		return (
-			<ContainerTag
+			<ClippedContent
 				className={classnames(
 					styles.ImageCircleContainer,
 					this.props.className,
@@ -33,6 +35,11 @@ export default class ImageCircle extends React.Component<IProps> {
 						[styles.ImageCircleContainer__SizeSmall]: this.props.size === 's',
 					},
 				)}
+				shape={this.props.square ? 'rect-rounded' : 'circle'}
+				style={{
+					...(this.props.size !== 's' && this.props.size !== 'm' && {width: this.props.size, minWidth: this.props.size, height: this.props.size}),
+				}}
+				tag={this.props.tag}
 			>
 				<img
 					className={classnames(
@@ -41,10 +48,12 @@ export default class ImageCircle extends React.Component<IProps> {
 							[styles.ImageCircleContainer__Square]: this.props.square,
 						},
 					)}
+					onError={this.props.onError}
+					onLoad={this.props.onLoad}
 					src={this.props.src}
 					style={{...this.props.style}}
 				/>
-			</ContainerTag>
+			</ClippedContent>
 		);
 	}
 

--- a/src/components/ImageCircle/README.md
+++ b/src/components/ImageCircle/README.md
@@ -2,7 +2,7 @@ Default image clipped to circle shape.
 The contained image uses 'object-fit: cover' to ensure that the entire circle area has pixel data within it regardless of the aspect ratio of the original source.
 
 ```js
-<ImageCircle src="https://getflywheel.com/wp-content/uploads/2017/06/php-7-small.png"/>
+<ImageCircle src="https://getflywheel.com/wp-content/uploads/2017/06/php-7-small.png" />
 ```
 
 Small circle.

--- a/src/components/ImageCircle/README.md
+++ b/src/components/ImageCircle/README.md
@@ -1,4 +1,4 @@
-Default image with circular mask. 
+Default image clipped to circle shape. 
 The contained image uses 'object-fit: cover' to ensure that the entire circle area has pixel data within it regardless of the aspect ratio of the original source.
 
 ```js
@@ -14,7 +14,16 @@ Small circle.
 />
 ```
 
-Image with rounded square shape.
+Custom sized circle.
+
+```js
+<ImageCircle 
+	size="100px"
+	src="https://getflywheel.com/wp-content/uploads/2017/06/php-7-small.png"
+/>
+```
+
+Image clipped to rounded square shape.
 
 ```js
 <ImageCircle 

--- a/src/components/VerticalNav/VerticalNav.sass
+++ b/src/components/VerticalNav/VerticalNav.sass
@@ -114,8 +114,13 @@
 	.WorkspaceSwitcher_PopupGridItem
 		cursor: pointer
 
-	.WorkspaceSwitcher_PopupGridItem__Active img
+	.WorkspaceSwitcher_PopupGridItem__Active
+		margin: -4px 0 0 -4px
 		border: 4px solid $green
+		border-radius: 8px
+
+		&.WorkspaceSwitcher_PopupGridItem__Team
+			border-radius: 50%
 
 	.WorkspaceSwitcher_PopupGridItemAdd
 		display: flex

--- a/src/components/VerticalNav/VerticalNav.tsx
+++ b/src/components/VerticalNav/VerticalNav.tsx
@@ -145,6 +145,7 @@ interface IWorkspaceSwitcherProps extends IReactComponentProps {
 	onClickAddTeam: Handler;
 	onClickLogout: Handler;
 	onClickWorkspace: Handler;
+	onClickWorkspaceNav: Handler;
 	routeTo: string;
 	tooltip: string;
 	workspaces: any[];
@@ -216,7 +217,10 @@ export class WorkspaceSwitcher extends React.Component<IWorkspaceSwitcherProps, 
 							padding={false}
 							position="right"
 							triggerContent={(
-								<div className={styles.VerticalNav_NonNavLinkItem}>
+								<div
+									className={styles.VerticalNav_NonNavLinkItem}
+									onClick={this.props.onClickWorkspaceNav}
+								>
 									<ImageCircle
 										size="s"
 										square={this.state.activeWorkspaceItem.isTeam}

--- a/src/components/VerticalNav/VerticalNav.tsx
+++ b/src/components/VerticalNav/VerticalNav.tsx
@@ -10,6 +10,7 @@ import Divider from '../Divider/Divider';
 import Button from '../Button/Button';
 import AddSVG from '../../svg/add';
 import Handler from '../../common/structures/Handler';
+import Avatar from '../Avatar';
 
 export class VerticalNav extends React.Component<IReactComponentProps> {
 
@@ -221,9 +222,10 @@ export class WorkspaceSwitcher extends React.Component<IWorkspaceSwitcherProps, 
 									className={styles.VerticalNav_NonNavLinkItem}
 									onClick={this.props.onClickWorkspaceNav}
 								>
-									<ImageCircle
+									<Avatar
+										initials={this.state.activeWorkspaceItem.initials}
 										size="s"
-										square={this.state.activeWorkspaceItem.isTeam}
+										type={this.state.activeWorkspaceItem.isTeam ? 'team' : 'user'}
 										src={this.state.activeWorkspaceItem.src}
 									/>
 								</div>
@@ -235,15 +237,17 @@ export class WorkspaceSwitcher extends React.Component<IWorkspaceSwitcherProps, 
 										{this.props.workspaces.map((workspaceItem) => {
 											return (
 												<div key={workspaceItem.id} onClick={() => this.onSelect(workspaceItem)}>
-													<ImageCircle
+													<Avatar
 														className={classnames(
 															styles.WorkspaceSwitcher_PopupGridItem,
 															{
 																[styles.WorkspaceSwitcher_PopupGridItem__Active]: workspaceItem.id === this.state.activeWorkspaceItem.id,
+																[styles.WorkspaceSwitcher_PopupGridItem__Team]: !workspaceItem.isTeam,
 															},
 														)}
+														initials={workspaceItem.initials}
 														size="s"
-														square={workspaceItem.isTeam}
+														type={workspaceItem.isTeam ? 'team' : 'user'}
 														src={workspaceItem.src}
 													/>
 												</div>

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import addStyles from './add-styles';
 addStyles();
 
 export const AdvancedToggle = hot(module)(require('./components/AdvancedToggle').default);
+export const Avatar = hot(module)(require('./components/Avatar').default);
 export const Banner = hot(module)(require('./components/Banner').default);
 export const BannerCarousel = hot(module)(require('./components/BannerCarousel').default);
 export const BigLoader = hot(module)(require('./components/BigLoader').default);
@@ -11,6 +12,7 @@ export const BrowseInput = hot(module)(require('./components/BrowseInput').defau
 export const Button = hot(module)(require('./components/Button').default);
 export const Card = hot(module)(require('./components/Card').default);
 export const Close = hot(module)(require('./components/Close').default);
+export const ClippedContent = hot(module)(require('./components/ClippedContent').default);
 export const Divider = hot(module)(require('./components/Divider').default);
 export const DownloaderItem = hot(module)(require('./components/DownloaderItem').default);
 export const DragBar = hot(module)(require('./components/DragBar').default);


### PR DESCRIPTION
**Audience:** Engineers | Third-party Developers

**Summary:** Added an `Avatar` component with image and initials visuals, team and user types, background colors, and sizes. To support this feature, a `ClippedContent` component has been created and the `ImageCircle` was modified to use `ClippedContent`.

**Screenshots:** 
![image](https://user-images.githubusercontent.com/41925404/51775760-71669700-20bc-11e9-9f8c-a7d5f630973f.png)
![image](https://user-images.githubusercontent.com/41925404/51775815-9eb34500-20bc-11e9-9633-b4775445d99a.png)
![image](https://user-images.githubusercontent.com/41925404/51775867-c5717b80-20bc-11e9-97f7-a850048ae6e1.png)