### PR TITLE
improvement(LOC-320): add text support to Spinner, use onRequestClose prop in FlyModal

### DIFF
--- a/src/components/FlyModal/FlyModal.tsx
+++ b/src/components/FlyModal/FlyModal.tsx
@@ -48,7 +48,6 @@ export default class FlyModal extends React.Component<IProps> {
 		closeTimeoutMS: 0,
 		hasIcon: false,
 		isOpen: true,
-		onRequestClose: FlyModal.onRequestClose,
 		overlayClassName: styles.FlyModalOverlay,
 		parentSelector: () => document.body,
 		portalClassName: 'ReactModalPortal',
@@ -60,10 +59,19 @@ export default class FlyModal extends React.Component<IProps> {
 		ReactDOM.unmountComponentAtNode(document.getElementById('popup-container'));
 	}
 
+	onRequestClose = () => {
+		if (typeof this.props.onRequestClose === 'function') {
+			this.props.onRequestClose();
+		}
+
+		FlyModal.onRequestClose();
+	};
+
 	render () {
 		return (
 			<ReactModal
 				{...this.props}
+				onRequestClose={this.onRequestClose}
 				className={classnames(
 					styles.FlyModal,
 					'FlyModal', // in here for tests
@@ -73,7 +81,7 @@ export default class FlyModal extends React.Component<IProps> {
 					className={classnames({
 						[styles.FlyModal__HasIcon]: this.props.hasIcon,
 					})}
-					onClick={FlyModal.onRequestClose}
+					onClick={this.onRequestClose}
 				/>
 				{this.props.children}
 			</ReactModal>

--- a/src/components/Spinner/README.md
+++ b/src/components/Spinner/README.md
@@ -1,4 +1,11 @@
-Basic spinner.
+Spinner without text.
 ```js
 <Spinner />
+```
+
+Spinner with text.
+```js
+<Spinner>
+	With some text...
+</Spinner>
 ```

--- a/src/components/Spinner/Spinner.sass
+++ b/src/components/Spinner/Spinner.sass
@@ -1,12 +1,22 @@
 @import '../../styles/_partials/index'
 
-.Spinner
+.SpinnerContainer
+	font-weight: 300
+	color: $gray75
+	letter-spacing: 0
+	text-transform: none
+
+	.Spinner
+		margin-right: 10px
+
+svg.Spinner
 	vertical-align: middle
 	width: 18px
 	height: 22px
+	margin: 0 0 0 10px
+
 	\:global
 		animation: rotateSpinner 1s linear infinite
-	margin: 0 0 0 10px
 
 	&.Spinner__ColorGrayDark50
 		path
@@ -14,4 +24,3 @@
 
 	path
 		fill: $gray25
-

--- a/src/components/Spinner/Spinner.tsx
+++ b/src/components/Spinner/Spinner.tsx
@@ -5,10 +5,8 @@ import SpinnerSVG from '../../svg/spinner';
 import * as styles from './Spinner.sass';
 
 interface IProps extends IReactComponentProps {
-
-	className?: string;
-	color?: 'Gray25' | 'GrayDark50';
-
+	className?: string
+	color?: 'Gray25' | 'GrayDark50'
 }
 
 export default class Spinner extends React.Component<IProps> {
@@ -17,7 +15,7 @@ export default class Spinner extends React.Component<IProps> {
 		color: 'Gray25',
 	};
 
-	render () {
+	renderSVG () {
 		return (
 			<SpinnerSVG
 				className={classnames(
@@ -28,6 +26,19 @@ export default class Spinner extends React.Component<IProps> {
 					},
 				)}
 			/>
+		);
+	}
+
+	render () {
+		if (!this.props.children) {
+			return this.renderSVG();
+		}
+
+		return (
+			<div className={styles.SpinnerContainer}>
+				{this.renderSVG()}
+				{this.props.children}
+			</div>
 		);
 	}
 

--- a/src/styles/containers/SiteInfo.scss
+++ b/src/styles/containers/SiteInfo.scss
@@ -333,28 +333,4 @@
 			fill: $gray75;
 		}
 	}
-
-	.CommonConnectRemoteOptions_Item_Label__Margin {
-		label {
-			margin-bottom: 0 !important;
-		}
-	}
-
-	.CommonConnectRemoteOptions_TooltipContainer {
-		line-height: 1.4;
-	}
-
-	.CommonConnectRemoteOptions_TooltipLink {
-		display: block;
-		text-transform: none !important;
-		text-decoration: underline;
-	}
-
-	.CommonConnectRemoteOptions_Item__MarginTop {
-		margin-top: 26px !important;
-	}
-
-	.CommonConnectRemoteOptions_Item__MarginBottom {
-		margin-bottom: 26px !important;
-	}
 }


### PR DESCRIPTION
**Summary:** Add text/children support for `<Spinner />`, use `onRequestClose` prop on `<FlyModal />` if provided. Some SCSS was also removed that should've been in Local itself.

----

### Screenshot

<img width="977" alt="screen shot 2019-02-06 at 9 54 15 am" src="https://user-images.githubusercontent.com/375381/52353981-3423d280-29f5-11e9-818a-5d5a50b8eb16.png">

