### PR TITLE
improvement(LOC-478): add Avatar option support for FlySelect

### DIFF
--- a/src/components/FlySelect/README.md
+++ b/src/components/FlySelect/README.md
@@ -45,3 +45,41 @@ Constrained Width:
     ]} onChange={() => console.log('onChange')} placeholder="Select Something!" />
 </div>
 ```
+
+Using an Avatar within a form FlySelect:
+```js
+<div>
+	<div className="FormRow">
+		<div className="FormField">			
+			<FlySelect 
+				style={{width: '350px'}} 
+				options={{
+					'a': {
+						label: 'Me',
+						icon: (
+							<Avatar
+								size="s"
+								src="https://getflywheel.com/wp-content/uploads/2015/02/flyheadshots-4-copy.jpg"
+								type="user"
+							/>
+						),
+					},
+					'c': {
+						label: 'Flywheel',
+						icon: (
+							<Avatar
+								size="s"
+								src="https://avatars2.githubusercontent.com/u/2371558?s=400&v=4"
+								type="team"
+							/>
+						),
+					},
+				}} 
+				onChange={() => console.log('onChange')} 
+				value="a" 
+			/>
+		</div>
+	</div>
+</div>
+
+

--- a/src/styles/forms.scss
+++ b/src/styles/forms.scss
@@ -120,6 +120,15 @@
 			}
 		}
 
+		[class^="Avatar"] {
+			margin-right: 10px;
+
+			img {
+				height: inherit;
+				margin: 0;
+			}
+		}
+
 		.FlySelect_Option {
 			height: 30px;
 			padding: 0 10px;


### PR DESCRIPTION
**Audience:** Users

**Summary:** Rather than hacking together css styles within `flywheel-local`, add support for the `Avatar` component within `FlySelect`.

**Technical:** All styles for the `FlySelect` component are still global, so it would be ideal to refactor this eventually and write in such a way that Avatars and other components work without any specific accommodations while moving to css modules.

**Out of scope:** The solution and screenshot example below shows a `FlySelect` within form elements which increases its size. Currently, the smallest `Avatar` is too large for the standard `FlySelect` and its size.

**Screenshots:** 
Original issue when using out-of-the-box:
![image](https://user-images.githubusercontent.com/41925404/53599006-d570f500-3b6b-11e9-985e-6c9b8d1041f0.png)
The solution (as shown in Styleguidist):
![image](https://user-images.githubusercontent.com/41925404/53600157-719bfb80-3b6e-11e9-95f1-4f1ad6408ec1.png)
![image](https://user-images.githubusercontent.com/41925404/53599102-ffc2b280-3b6b-11e9-993b-c64bf4d0b698.png)