### PR TITLE
fix(LOC-466): change max-height of FlyModal to accommodate more content

### DIFF
--- a/src/components/FlyModal/FlyModal.sass
+++ b/src/components/FlyModal/FlyModal.sass
@@ -26,7 +26,7 @@
 	> div
 		width: 100%
 		overflow-y: auto
-		max-height: 97vh
+		max-height: 93vh
 		padding: 60px
 
 	&.FlyModal__HasIcon

--- a/src/components/FlyModal/FlyModal.sass
+++ b/src/components/FlyModal/FlyModal.sass
@@ -17,7 +17,6 @@
 .FlyModal
 	width: 600px
 	height: auto
-	max-height: 90vh
 	@include theme-background-white-else-graydark50
 	border-radius: 4px
 	text-align: center
@@ -27,7 +26,7 @@
 	> div
 		width: 100%
 		overflow-y: auto
-		max-height: 90vh
+		max-height: 97vh
 		padding: 60px
 
 	&.FlyModal__HasIcon


### PR DESCRIPTION
**Audience:** Users

**Summary:** Allow for more content within a modal by increasing max-height. This is a short-term fix for pulling/pushing to unconnected sites but makes sense long-term as well.

**Screenshots:**

![image](https://user-images.githubusercontent.com/41925404/54136209-57bdac80-43e9-11e9-8be7-8ca2228229ed.png)
