### PR TITLE
improvement(LOC-505): add vertical layout to RadioBlock

### DIFF
--- a/src/components/RadioBlock/README.md
+++ b/src/components/RadioBlock/README.md
@@ -79,3 +79,18 @@ Tooltip for the second, disabled option:
     },
 }} />
 ```
+
+Vertical layout:
+
+```js
+<RadioBlock direction="vert" heightSize="m" default={'test1'} options={{
+    'test1': {
+        label: 'Test 1',
+    },
+    'test2': {
+    	disabled: true,
+        label: 'Test 2',
+        tooltipContent: <p>Hey, this is why this is disabled. It all started when you clicked...</p>,
+    },
+}} />
+```

--- a/src/components/RadioBlock/README.md
+++ b/src/components/RadioBlock/README.md
@@ -88,9 +88,7 @@ Vertical layout:
         label: 'Test 1',
     },
     'test2': {
-    	disabled: true,
         label: 'Test 2',
-        tooltipContent: <p>Hey, this is why this is disabled. It all started when you clicked...</p>,
     },
 }} />
 ```

--- a/src/components/RadioBlock/RadioBlock.sass
+++ b/src/components/RadioBlock/RadioBlock.sass
@@ -41,8 +41,8 @@
 
 			&::before
 				opacity: 1
-				top: -5px
-				left: -5px
+				top: -4px
+				left: -4px
 				z-index: 2
 				border-radius: 4px
 				width: calc(100% + 4px)

--- a/src/components/RadioBlock/RadioBlock.sass
+++ b/src/components/RadioBlock/RadioBlock.sass
@@ -6,6 +6,9 @@
 	justify-content: space-between
 	width: 100%
 
+	&.RadioBlock__DirectionVert
+		flex-direction: column
+
 .RadioBlock_Option_TooltipWrapper
 	flex: 1
 

--- a/src/components/RadioBlock/RadioBlock.tsx
+++ b/src/components/RadioBlock/RadioBlock.tsx
@@ -11,6 +11,7 @@ import Handler from '../../common/structures/Handler';
 interface IProps extends IReactComponentProps {
 
 	default: string | null;
+	direction: 'horiz' | 'vert';
 	disabled?: boolean;
 	warn?: boolean;
 	heightSize?: 'm' | 'l';
@@ -30,6 +31,7 @@ interface IState {
 class RadioBlock extends React.Component<IProps, IState> {
 
 	static defaultProps: Partial<IProps> = {
+		direction: 'horiz',
 		disabled: false,
 		heightSize: 'l',
 	};
@@ -62,6 +64,9 @@ class RadioBlock extends React.Component<IProps, IState> {
 				className={classnames(
 					styles.RadioBlock,
 					this.props.className,
+					{
+						[styles.RadioBlock__DirectionVert]: this.props.direction === 'vert',
+					},
 				)}
 			>
 				{


### PR DESCRIPTION
**Audience:** Users | Developers

**Summary:** Added direction prop and vertical layout/styles to the Radio Block component. An example has been added to Styleguidist as well.

**Screenshots:** 

![image](https://user-images.githubusercontent.com/41925404/54386200-6f559900-4666-11e9-9d58-2426c00367f6.png)
