### PR TITLE
feat(LOC-556): create Container component with advanced margin expressions and auto disable feature

### DIFF
--- a/src/common/structures/ILocalContainerProps.ts
+++ b/src/common/structures/ILocalContainerProps.ts
@@ -1,0 +1,6 @@
+import IReactComponentProps from './IReactComponentProps';
+import { IContainerProps } from '../../components/Container/Container';
+
+export default interface ILocalContainerProps extends IReactComponentProps {
+	container: IContainerProps;
+}

--- a/src/components/Container/Container.scss
+++ b/src/components/Container/Container.scss
@@ -1,5 +1,0 @@
-@import '../../styles/_partials/index';
-
-.Container {
-
-}

--- a/src/components/Container/Container.scss
+++ b/src/components/Container/Container.scss
@@ -1,0 +1,5 @@
+@import '../../styles/_partials/index';
+
+.Container {
+
+}

--- a/src/components/Container/Container.tsx
+++ b/src/components/Container/Container.tsx
@@ -1,18 +1,17 @@
 import * as React from 'react';
 import classnames from 'classnames';
-import * as styles from './Container.scss';
 import IReactComponentProps from '../../common/structures/IReactComponentProps';
-import { ContainerMarginHelper, ContainerMarginType } from './ContainerMarginHelper';
+import { ContainerMarginHelper, ContainerMarginLookupType } from './ContainerMarginHelper';
 
 export interface IContainerProps extends IReactComponentProps {
 	/** whether to include the container (false) or exclude it (true) */
 	disabled?: boolean;
 	/** margin values to be set to 'style' prop */
-	margin?: ContainerMarginType;
-	marginBottom?: ContainerMarginType;
-	marginLeft?: ContainerMarginType;
-	marginRight?: ContainerMarginType;
-	marginTop?: ContainerMarginType;
+	margin?: ContainerMarginLookupType;
+	marginBottom?: ContainerMarginLookupType;
+	marginLeft?: ContainerMarginLookupType;
+	marginRight?: ContainerMarginLookupType;
+	marginTop?: ContainerMarginLookupType;
 	/** the element name to used for the container */
 	tag?: string;
 }
@@ -38,7 +37,6 @@ export const Container = (props: IContainerProps) => {
 			:
 			<Tag
 				className={classnames(
-					styles.Container,
 					props.className,
 				)}
 				style={{

--- a/src/components/Container/Container.tsx
+++ b/src/components/Container/Container.tsx
@@ -1,0 +1,54 @@
+import * as React from 'react';
+import classnames from 'classnames';
+import * as styles from './Container.scss';
+import IReactComponentProps from '../../common/structures/IReactComponentProps';
+import { ContainerMarginHelper, ContainerMarginType } from './ContainerMarginHelper';
+
+export interface IContainerProps extends IReactComponentProps {
+	/** whether to include the container (false) or exclude it (true) */
+	disabled?: boolean;
+	/** margin values to be set to 'style' prop */
+	margin?: ContainerMarginType;
+	marginBottom?: ContainerMarginType;
+	marginLeft?: ContainerMarginType;
+	marginRight?: ContainerMarginType;
+	marginTop?: ContainerMarginType;
+	/** the element name to used for the container */
+	tag?: string;
+}
+
+const defaultProps: Partial<IContainerProps> = {
+
+};
+
+export const Container = (props: IContainerProps) => {
+	const Tag: any = props.tag || 'div';
+	const propsWithoutDefaults: Partial<IContainerProps> = {...props};
+	delete propsWithoutDefaults.children;
+	delete propsWithoutDefaults.disabled;
+	// disable (don't render) unless explicitly set to 'false' or one of the other settings exists
+	let disabled = props.disabled === true || Object.keys(propsWithoutDefaults).length === 0;
+
+	return (
+		disabled
+			?
+			<>
+				{props.children}
+			</>
+			:
+			<Tag
+				className={classnames(
+					styles.Container,
+					props.className,
+				)}
+				style={{
+					...props.style,
+					...ContainerMarginHelper.getContainerMarginStyle(props),
+				}}
+			>
+				{props.children}
+			</Tag>
+	);
+};
+
+Container.defaultProps = defaultProps;

--- a/src/components/Container/ContainerMarginHelper.test.ts
+++ b/src/components/Container/ContainerMarginHelper.test.ts
@@ -1,0 +1,81 @@
+import { ContainerMarginHelper } from './ContainerMarginHelper';
+
+it ('test expressions lookups', () => {
+	expect(ContainerMarginHelper.parseExpression('xs')).toBe(ContainerMarginHelper.sizeLookups.get('xs'));
+	expect(ContainerMarginHelper.parseExpression('xs')).not.toBe(ContainerMarginHelper.sizeLookups.get('s'));
+	expect(ContainerMarginHelper.parseExpression('s')).toBe(ContainerMarginHelper.sizeLookups.get('s'));
+	expect(ContainerMarginHelper.parseExpression('m')).toBe(ContainerMarginHelper.sizeLookups.get('m'));
+	expect(ContainerMarginHelper.parseExpression('l')).toBe(ContainerMarginHelper.sizeLookups.get('l'));
+	expect(ContainerMarginHelper.parseExpression('xl')).toBe(ContainerMarginHelper.sizeLookups.get('xl'));
+	expect(ContainerMarginHelper.parseExpression('0')).toBe(ContainerMarginHelper.sizeLookups.get('0'));
+	expect(ContainerMarginHelper.parseExpression('none')).toBe(ContainerMarginHelper.sizeLookups.get('none'));
+});
+
+it ('test expressions negative lookups', () => {
+	expect(ContainerMarginHelper.parseExpression('-m')).not.toBe(ContainerMarginHelper.sizeLookups.get('m'));
+	expect(ContainerMarginHelper.parseExpression('-m')).toBe(-ContainerMarginHelper.sizeLookups.get('m')!);
+});
+
+it ('test expressions multiple lookups', () => {
+	expect(ContainerMarginHelper.parseExpression('m+m')).toBe(ContainerMarginHelper.sizeLookups.get('m')! + ContainerMarginHelper.sizeLookups.get('m')!);
+	expect(ContainerMarginHelper.parseExpression('m-m')).toBe(ContainerMarginHelper.sizeLookups.get('m')! - ContainerMarginHelper.sizeLookups.get('m')!);
+	expect(ContainerMarginHelper.parseExpression('-m-m')).toBe(-ContainerMarginHelper.sizeLookups.get('m')! - ContainerMarginHelper.sizeLookups.get('m')!);
+	expect(ContainerMarginHelper.parseExpression('m+s-xs')).toBe(ContainerMarginHelper.sizeLookups.get('m')! + ContainerMarginHelper.sizeLookups.get('s')! - ContainerMarginHelper.sizeLookups.get('xs')!);
+});
+
+it ('test expressions empty', () => {
+	expect(ContainerMarginHelper.parseExpression('')).toBe(0);
+	expect(ContainerMarginHelper.parseExpression(' ')).toBe(0);
+});
+
+it ('test expressions single numbers', () => {
+	expect(ContainerMarginHelper.parseExpression('0')).toBe(0);
+	expect(ContainerMarginHelper.parseExpression('10')).toBe(10);
+	expect(ContainerMarginHelper.parseExpression('10')).not.toBe(9);
+	expect(ContainerMarginHelper.parseExpression('-0')).toBe(0);
+	expect(ContainerMarginHelper.parseExpression('-1')).toBe(-1);
+	expect(ContainerMarginHelper.parseExpression('--1')).toBe(1);
+});
+
+it ('test expressions two numbers', () => {
+	expect(ContainerMarginHelper.parseExpression('0+0')).toBe(0);
+	expect(ContainerMarginHelper.parseExpression('0+1')).toBe(1);
+	expect(ContainerMarginHelper.parseExpression('-0+1')).toBe(1);
+	expect(ContainerMarginHelper.parseExpression('-0+0')).toBe(0);
+	expect(ContainerMarginHelper.parseExpression('-0-0')).toBe(0);
+	expect(ContainerMarginHelper.parseExpression('-1+1')).toBe(0);
+	expect(ContainerMarginHelper.parseExpression('1+1')).toBe(2);
+	expect(ContainerMarginHelper.parseExpression('1-1')).toBe(0);
+	expect(ContainerMarginHelper.parseExpression('-1-1')).toBe(-2);
+	expect(ContainerMarginHelper.parseExpression('8+1')).toBe(9);
+	expect(ContainerMarginHelper.parseExpression('8-1')).toBe(7);
+	expect(ContainerMarginHelper.parseExpression('-8+1')).toBe(-7);
+	expect(ContainerMarginHelper.parseExpression('-8-1')).toBe(-9);
+});
+
+it ('test expressions lookups and numbers', () => {
+	expect(ContainerMarginHelper.parseExpression('m-10')).toBe(ContainerMarginHelper.sizeLookups.get('m')! - 10);
+	expect(ContainerMarginHelper.parseExpression('m-10+1')).toBe(ContainerMarginHelper.sizeLookups.get('m')! - 10 + 1);
+	expect(ContainerMarginHelper.parseExpression('-m-10+1')).toBe(-ContainerMarginHelper.sizeLookups.get('m')! - 10 + 1);
+	expect(ContainerMarginHelper.parseExpression('-m-10-1')).toBe(-ContainerMarginHelper.sizeLookups.get('m')! - 10 - 1);
+	expect(ContainerMarginHelper.parseExpression('-m-m-1')).toBe(-ContainerMarginHelper.sizeLookups.get('m')! - ContainerMarginHelper.sizeLookups.get('m')! - 1);
+	expect(ContainerMarginHelper.parseExpression('-m-m+1')).toBe(-ContainerMarginHelper.sizeLookups.get('m')! - ContainerMarginHelper.sizeLookups.get('m')! + 1);
+	expect(ContainerMarginHelper.parseExpression('s+1-xs-1+2')).toBe(ContainerMarginHelper.sizeLookups.get('s')! + 1 - ContainerMarginHelper.sizeLookups.get('xs')! - 1 + 2);
+});
+
+it ('test invalid expressions', () => {
+	expect(ContainerMarginHelper.parseExpression('zzz')).toBe(0);
+	expect(ContainerMarginHelper.parseExpression('-zzz')).toBe(0);
+	expect(ContainerMarginHelper.parseExpression('-zzz-zzz')).toBe(0);
+	expect(ContainerMarginHelper.parseExpression('zzz-zzz')).toBe(0);
+	expect(ContainerMarginHelper.parseExpression('zzz+zzz')).toBe(0);
+});
+
+it ('test invalid expressions mixed with valid', () => {
+	expect(ContainerMarginHelper.parseExpression('zzz+1')).toBe(1);
+	expect(ContainerMarginHelper.parseExpression('-zzz-1')).toBe(-1);
+	expect(ContainerMarginHelper.parseExpression('-zzz-m+1')).toBe(-ContainerMarginHelper.sizeLookups.get('m')! + 1);
+	expect(ContainerMarginHelper.parseExpression('-zzz+m+1')).toBe(ContainerMarginHelper.sizeLookups.get('m')! + 1);
+	expect(ContainerMarginHelper.parseExpression('1+zzz-zzz+1')).toBe(2);
+	expect(ContainerMarginHelper.parseExpression('-1zzz+zzz-1')).toBe(-2);
+});

--- a/src/components/Container/ContainerMarginHelper.ts
+++ b/src/components/Container/ContainerMarginHelper.ts
@@ -1,0 +1,120 @@
+import { IContainerProps } from './Container';
+
+export type ContainerMarginType = 'xs' | 's' | 'm' | 'l' | 'xl' | 0 | 'none' | string;
+type ReturnValue =  {margin?: string | number} | undefined;
+
+
+export class ContainerMarginHelper {
+
+	public static sizeLookups = new Map<string | number, number>(Object.entries({
+		0: 0,
+		none: 0,
+		xs: 5,
+		s: 10,
+		m: 20,
+		l: 30,
+		xl: 40,
+	}));
+
+	public static getContainerMarginStyle (props: IContainerProps): ReturnValue | undefined {
+		return {
+			...this.processMarginType(props.margin, 'margin'),
+			...this.processMarginType(props.marginTop, 'marginTop'),
+			...this.processMarginType(props.marginRight, 'marginRight'),
+			...this.processMarginType(props.marginBottom, 'marginBottom'),
+			...this.processMarginType(props.marginLeft, 'marginLeft'),
+		};
+	}
+
+	public static processMarginType (marginValue: string | number | undefined, propName: string) {
+		if (marginValue === undefined) {
+			return undefined;
+		}
+
+		return this.wrapReturnValue(this.parseMargin(marginValue), propName);
+	}
+
+	public static parseMargin (margin: string | number): string | number | undefined {
+		const values = (margin as string).split(' ');
+
+		const value = values.reduce((list: any[], value: string) => {
+			list.push(this.formatFinalValue(this.parseExpression(value)));
+			return list;
+		}, []);
+
+		return value.join(' ');
+	}
+
+	public static formatFinalValue (value: string | number | undefined)  {
+		if (value === undefined) {
+			return undefined;
+		}
+
+		return typeof(value) === 'number' && value !== 0 ? `${value}px` : value;
+	}
+
+	public static lookupValue (value: string | number | undefined): number | undefined {
+		if (value === undefined) {
+			return value;
+		}
+
+		return this.sizeLookups.get(value);
+	}
+
+	public static wrapReturnValue (value: string | number | undefined, propName: string): ReturnValue {
+		if (value === undefined) {
+			return undefined;
+		}
+
+		return {
+			[propName]: value,
+		};
+	}
+
+	public static parseExpression (s: string) {
+		const expressionShiftedValues = s.match(/[+\-]*(\.\w+|\w+(\.\w+)?)/g) || [];
+		let total: number = 0;
+
+		while (expressionShiftedValues.length) {
+			const result = this.getExpressionShiftedValuesAndSign (expressionShiftedValues.shift());
+
+			if (result === undefined || isNaN(parseInt(result.value))) {
+				console.warn(`Warning - ContainerMargin: The margin value '${result && result.value}' from the original expression '${s}' is not valid and will be ignored.`);
+				continue;
+			}
+
+			if (result.sign === '+') {
+				total += parseFloat(result.value);
+			}
+			else {
+				total -= parseFloat(result.value);
+			}
+		}
+
+		return total;
+	}
+
+	public static getExpressionShiftedValuesAndSign (shiftedValue: string | undefined): {shiftedValue: string | undefined, sign: '-' | '+', value: string} | undefined {
+		if (shiftedValue === undefined) {
+			return shiftedValue;
+		}
+
+		let sign: '-' | '+' = shiftedValue.startsWith('-') ? '-' : '+';
+		let value: string = shiftedValue;
+		let lookup: number | undefined;
+
+		// if either negative or subtraction
+		if (shiftedValue.startsWith('-') || shiftedValue.startsWith('+')) {
+			value = shiftedValue.slice(1, shiftedValue.length);
+		}
+
+		lookup = this.lookupValue(value);
+
+		return {
+			shiftedValue,
+			sign,
+			value: lookup !== undefined ? String(lookup) : value,
+		}
+	}
+
+}

--- a/src/components/Container/ContainerMarginHelper.ts
+++ b/src/components/Container/ContainerMarginHelper.ts
@@ -1,32 +1,69 @@
 import { IContainerProps } from './Container';
 
-export type ContainerMarginType = 'xs' | 's' | 'm' | 'l' | 'xl' | 0 | 'none' | string;
-type ReturnValue =  {margin?: string | number} | undefined;
+enum ContainerMarginLookupEnum {
+	none = 'none',
+	xs = 'xs',
+	s = 's',
+	m = 'm',
+	l = 'l',
+	xl = 'xl',
+}
 
+export type ContainerMarginLookupType = ContainerMarginLookupEnum.none
+	| ContainerMarginLookupEnum.s
+	| ContainerMarginLookupEnum.m
+	| ContainerMarginLookupEnum.l
+	| ContainerMarginLookupEnum.xl
+	| 0
+	| string
+;
+
+enum ContainerMarginPropNameEnum {
+	margin = 'margin',
+	marginBottom = 'marginBottom',
+	marginLeft = 'marginLeft',
+	marginRight = 'marginRight',
+	marginTop = 'marginTop',
+}
+
+type ContainerMarginPropNameType = ContainerMarginPropNameEnum.margin
+	| ContainerMarginPropNameEnum.marginBottom
+	| ContainerMarginPropNameEnum.marginLeft
+	| ContainerMarginPropNameEnum.marginRight
+	| ContainerMarginPropNameEnum.marginTop
+;
+
+type ReturnValue =  {
+	[ContainerMarginPropNameEnum.margin]?: string | number,
+	[ContainerMarginPropNameEnum.marginBottom]?: string | number,
+	[ContainerMarginPropNameEnum.marginLeft]?: string | number,
+	[ContainerMarginPropNameEnum.marginRight]?: string | number,
+	[ContainerMarginPropNameEnum.marginTop]?: string | number,
+} | undefined;
 
 export class ContainerMarginHelper {
 
-	public static sizeLookups = new Map<string | number, number>(Object.entries({
+	public static sizeLookups = new Map<ContainerMarginLookupType, number>(Object.entries({
 		0: 0,
-		none: 0,
-		xs: 5,
-		s: 10,
-		m: 20,
-		l: 30,
-		xl: 40,
+		[ContainerMarginLookupEnum.none]: 0,
+		[ContainerMarginLookupEnum.xs]: 5,
+		[ContainerMarginLookupEnum.s]: 10,
+		[ContainerMarginLookupEnum.m]: 20,
+		[ContainerMarginLookupEnum.l]: 30,
+		[ContainerMarginLookupEnum.xl]: 40,
 	}));
 
 	public static getContainerMarginStyle (props: IContainerProps): ReturnValue | undefined {
 		return {
-			...this.processMarginType(props.margin, 'margin'),
-			...this.processMarginType(props.marginTop, 'marginTop'),
-			...this.processMarginType(props.marginRight, 'marginRight'),
-			...this.processMarginType(props.marginBottom, 'marginBottom'),
-			...this.processMarginType(props.marginLeft, 'marginLeft'),
+			...this.processMarginType(props.margin, ContainerMarginPropNameEnum.margin),
+			...this.processMarginType(props.marginTop, ContainerMarginPropNameEnum.marginTop),
+			...this.processMarginType(props.marginRight, ContainerMarginPropNameEnum.marginRight),
+			...this.processMarginType(props.marginBottom, ContainerMarginPropNameEnum.marginBottom),
+			...this.processMarginType(props.marginLeft, ContainerMarginPropNameEnum.marginLeft),
 		};
 	}
 
-	public static processMarginType (marginValue: string | number | undefined, propName: string) {
+	public static processMarginType (marginValue: string | number | undefined, propName: ContainerMarginPropNameType) {
 		if (marginValue === undefined) {
 			return undefined;
 		}
@@ -53,7 +90,7 @@ export class ContainerMarginHelper {
 		return typeof(value) === 'number' && value !== 0 ? `${value}px` : value;
 	}
 
-	public static lookupValue (value: string | number | undefined): number | undefined {
+	public static lookupValue (value: ContainerMarginLookupType | undefined): number | undefined {
 		if (value === undefined) {
 			return value;
 		}
@@ -61,7 +98,7 @@ export class ContainerMarginHelper {
 		return this.sizeLookups.get(value);
 	}
 
-	public static wrapReturnValue (value: string | number | undefined, propName: string): ReturnValue {
+	public static wrapReturnValue (value: string | number | undefined, propName: ContainerMarginPropNameType): ReturnValue {
 		if (value === undefined) {
 			return undefined;
 		}

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,10 +1,11 @@
 import * as React from 'react';
-import IReactComponentProps from '../../common/structures/IReactComponentProps';
 import classnames from 'classnames';
 import * as styles from './Header.sass';
 import Handler from '../../common/structures/Handler';
+import { Container } from '../Container/Container';
+import ILocalContainerProps from '../../common/structures/ILocalContainerProps';
 
-interface IProps extends IReactComponentProps {
+interface IProps extends ILocalContainerProps {
 
 	fontSize?: 'xs' | 's' | 'm' | 'l' | 'xl';
 	fontWeight?: '300' | '400' | '500' | '700' | '900';
@@ -25,27 +26,29 @@ export default class Header extends React.Component<IProps> {
 		const HeaderTag: any = this.props.tag;
 
 		return (
-			<HeaderTag
-				className={classnames(
-					styles.Header,
-					this.props.className,
-					{
-						[styles.Header__FontSizeXS]: this.props.fontSize === 'xs',
-						[styles.Header__FontSizeS]: this.props.fontSize === 's',
-						[styles.Header__FontSizeM]: this.props.fontSize === 'm',
-						[styles.Header__FontSizeL]: this.props.fontSize === 'l',
-						[styles.Header__FontSizeXL]: this.props.fontSize === 'xl',
-						[styles.Header__FontWeight300]: this.props.fontWeight === '300',
-						[styles.Header__FontWeight400]: this.props.fontWeight === '400',
-						[styles.Header__FontWeight500]: this.props.fontWeight === '500',
-						[styles.Header__FontWeight700]: this.props.fontWeight === '700',
-						[styles.Header__FontWeight900]: this.props.fontWeight === '900',
-					},
-				)}
-				onClick={this.props.onClick}
-			>
-				{this.props.children}
-			</HeaderTag>
+			<Container {...this.props.container}>
+				<HeaderTag
+					className={classnames(
+						styles.Header,
+						this.props.className,
+						{
+							[styles.Header__FontSizeXS]: this.props.fontSize === 'xs',
+							[styles.Header__FontSizeS]: this.props.fontSize === 's',
+							[styles.Header__FontSizeM]: this.props.fontSize === 'm',
+							[styles.Header__FontSizeL]: this.props.fontSize === 'l',
+							[styles.Header__FontSizeXL]: this.props.fontSize === 'xl',
+							[styles.Header__FontWeight300]: this.props.fontWeight === '300',
+							[styles.Header__FontWeight400]: this.props.fontWeight === '400',
+							[styles.Header__FontWeight500]: this.props.fontWeight === '500',
+							[styles.Header__FontWeight700]: this.props.fontWeight === '700',
+							[styles.Header__FontWeight900]: this.props.fontWeight === '900',
+						},
+					)}
+					onClick={this.props.onClick}
+				>
+					{this.props.children}
+				</HeaderTag>
+			</Container>
 		);
 	}
 


### PR DESCRIPTION
**Audience:** Engineers | Third-party Developers

**Summary:** Most components within the `local-components` package are wrapped in a container to allow for more flexibility (which allows for more style and layout flexibility while being able to more gracefully handle unplanned edge-cases). `Container` provides a predictable wrapper component, with a consistent API, and convenient way to access the Container's "shape" through a single `component` prop within the component utilizing it (e.g. Header).

The `Container` component also adds some extremely helpful and convenient props/features. One of those features is to disable/exclude the container DOM element if not being explicitly used. This is useful if you want the flexibility of using the container if needed without creating an additional element when not used.

The most dynamic feature of the `Container` component is its margin expression system. This will allow developers to layout a component (that's wrapped in a Container) to set its own margin without having to create a CSS rule and apply it to `className`. This is particularly useful and practical for vertical layouts where there are a number of elements, one after another, that need various margins set to create whitespace between them. While the traditional approach would to either bake those margins into the original component to follow existing patterns (inflexible and assumption-based) or to create CSS for a group or individual elements, neither really provides 1) consistency, 2) convenience, and 3) flexibility.

The margin system built within the `Container` component attempts to solve all three:
1. Consistency: the margin system utilizes existing margin sizes used throughout Local (e.g. xs, s, m, l, xl) and makes those available to developers. And if applied to every component within the `local-components` ecosystem, this consistency and predictability would greatly simplify UI implementation.
2. Convenience: the margin system allows develops to set margins directly on the component they're implements. No longer do developers need to write CSS rules just to create whitespace between elements (which tends to needlessly pollute CSS stylesheets with static and otherwise meaningly px values)
3. Flexibility: the margin system uses expressions that allow developers to handle nearly any situation imaginable. Need to utilize the `m` margin sizing but the component has an extra couple of pixels worth of padding around it thus throwing off the whitespace no longer making it appear like a `m` margin size worth of spacing? Simply use an expression like `m-2` to account for this otherwise painful edge-case.

**Examples:**

Usage examples of the margin system:

_simple margin sizing (result: `margin: 20px;`)_
```
<Header container={{margin: 'm'}}>
```
_margin shorthand sizing (result: `margin: 20px 5px 10px;`)_
```
<Header container={{margin: 'm xs s'}}>
```
_mixing margin shorthand sizing and basic arithmetic (result: `margin: 18px 25px;`)_
```
<Header container={{margin: 'm-2 m+s'}}>
```
_mixing margin-bottom and explicit margin-left (result: `margin-bottom: 20px; margin-left: 13px;`)_
```
<Header container={{marginBottom: 'm', marginLeft: '13px'}}>
```

**Out of scope:** All components outside of `Header`. This is a proof of concept that needs to be accessed and determined whether it should be applied across the `local-components` family of components.