### PR TITLE
fix(LOC-691): remove disabled from <Checkbox /> state and use prop only

### DIFF
--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -15,7 +15,6 @@ interface IProps extends IReactComponentProps {
 
 interface IState {
 	checked: boolean | 'mixed';
-	disabled: boolean;
 }
 
 export default class Checkbox extends React.Component<IProps, IState> {
@@ -30,7 +29,6 @@ export default class Checkbox extends React.Component<IProps, IState> {
 
 		this.state = {
 			checked: props.checked === undefined ? false : props.checked,
-			disabled: !!props.disabled,
 		};
 	};
 
@@ -62,7 +60,7 @@ export default class Checkbox extends React.Component<IProps, IState> {
 					{
 						[styles.Checkbox__Checked]: this.state.checked === true,
 						[styles.Checkbox__CheckMixed]: this.state.checked === 'mixed',
-						[styles.Checkbox__Disabled]: this.state.disabled,
+						[styles.Checkbox__Disabled]: this.props.disabled,
 					},
 				)}
 			>

--- a/yarn.lock
+++ b/yarn.lock
@@ -184,10 +184,10 @@
   resolved "https://registry.yarnpkg.com/@types/q/-/q-1.5.1.tgz#48fd98c1561fe718b61733daed46ff115b496e18"
   integrity sha512-eqz8c/0kwNi/OEHQfvIuJVLTst3in0e7uTKeuY+WL/zfKn0xVujOTp42bS/vUUokhK5P2BppLd9JXMOMHcgbjA==
 
-"@types/react-dom@^16.0.11":
-  version "16.0.11"
-  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.0.11.tgz#bd10ccb0d9260343f4b9a49d4f7a8330a5c1f081"
-  integrity sha512-x6zUx9/42B5Kl2Vl9HlopV8JF64wLpX3c+Pst9kc1HgzrsH+mkehe/zmHMQTplIrR48H2gpU7ZqurQolYu8XBA==
+"@types/react-dom@^16.8.4":
+  version "16.8.4"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.8.4.tgz#7fb7ba368857c7aa0f4e4511c4710ca2c5a12a88"
+  integrity sha512-eIRpEW73DCzPIMaNBDP5pPIpK1KXyZwNgfxiVagb5iGiz6da+9A5hslSX6GAQKdO7SayVCS/Fr2kjqprgAvkfA==
   dependencies:
     "@types/react" "*"
 
@@ -7058,15 +7058,15 @@ react-docgen@3.0.0-rc.2:
     node-dir "^0.1.10"
     recast "^0.16.0"
 
-react-dom@^16.4.2:
-  version "16.7.0"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.7.0.tgz#a17b2a7ca89ee7390bc1ed5eb81783c7461748b8"
-  integrity sha512-D0Ufv1ExCAmF38P2Uh1lwpminZFRXEINJe53zRAbm4KPwSyd6DY/uDoS0Blj9jvPpn1+wivKpZYc8aAAN/nAkg==
+react-dom@^16.8.6:
+  version "16.8.6"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.8.6.tgz#71d6303f631e8b0097f56165ef608f051ff6e10f"
+  integrity sha512-1nL7PIq9LTL3fthPqwkvr2zY7phIPjYrT0jp4HjyEQrEROnw4dG41VVwi/wfoCneoleqrNX7iAD+pXebJZwrwA==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     prop-types "^15.6.2"
-    scheduler "^0.12.0"
+    scheduler "^0.13.6"
 
 react-error-overlay@^5.1.0:
   version "5.1.2"


### PR DESCRIPTION
**Summary:** The `<Checkbox />` component is passing the `disabled` prop straight into the state in `constructor` but not handling `disabled` in `componentWillReceiveProps`. Since `disabled` isn't changed in `<Checkbox />`, `disabled` has been removed from the state and will be passed as a prop only.