### PR TITLE
improvement(LOC-714): add dots prop to <LoadingIndicator />

### DIFF
--- a/src/components/BigLoader/BigLoader.tsx
+++ b/src/components/BigLoader/BigLoader.tsx
@@ -25,6 +25,7 @@ export default class BigLoader extends React.Component<IProps> {
 			>
 				<LoadingIndicator
 					big={true}
+					dots={3}
 					color={this.props.color}
 				/>
 				{

--- a/src/components/LoadingIndicator/LoadingIndicator.tsx
+++ b/src/components/LoadingIndicator/LoadingIndicator.tsx
@@ -6,6 +6,7 @@ import * as styles from './LoadingIndicator.sass';
 interface IProps extends IReactComponentProps {
 
 	big?: boolean;
+	dots?: 2|3;
 	color?: 'Green' | 'Gray';
 
 }
@@ -14,6 +15,7 @@ export default class LoadingIndicator extends React.Component<IProps> {
 
 	static defaultProps: Partial<IProps> = {
 		big: false,
+		dots: 2,
 		color: 'Green',
 	};
 
@@ -30,7 +32,7 @@ export default class LoadingIndicator extends React.Component<IProps> {
 			>
 				 <div />
 				 <div />
-				 {this.props.big && <div />}
+				 {this.props.dots === 3 && <div />}
 			</div>
 		);
 	}

--- a/src/components/LoadingIndicator/README.md
+++ b/src/components/LoadingIndicator/README.md
@@ -13,5 +13,11 @@ Big:
 Gray:
 
 ```js
-<LoadingIndicator color="Gray" />
+<LoadingIndicator color="Gray" dots={3} />
+```
+
+Gray - 2 Dots:
+
+```js
+<LoadingIndicator dots={2} color="Gray" />
 ```


### PR DESCRIPTION
**Summary:** Add `dots` prop to `<LoadingIndicator />` and default it to `2`.

**Context:** We need to be able to use the three dot loading indicator with the small size.