### PR TITLE
fix(LOC-737): decrease WindowsToolbar z-index down to 1 to avoid competing with other views

### DIFF
--- a/src/components/WindowsToolbar/WindowsToolbar.sass
+++ b/src/components/WindowsToolbar/WindowsToolbar.sass
@@ -14,7 +14,7 @@
 	display: flex
 	font-family: "Segoe UI", Roboto, Helvetica, Arial, sans-serif
 	font-size: 12px
-	z-index: 999
+	z-index: 1
 
 	@at-root :global(.WindowsToolbar .DragRegion),
 	.DragRegion


### PR DESCRIPTION
**Audience:** Users | Engineers

**Summary:** Windows top bar covers up part of the workspace switcher.

**Outstanding Concerns:** There's a risk of unaccounted for elements with a z-index greater than `1` appearing above the WindowsToolbar. Some are by design (e.g. drag and drop, workspace switcher), but others might appear in unaccounted for scenarios like scrolling content.

**Screenshots:** 
(prior issue that's now fixed)
![image](https://user-images.githubusercontent.com/41925404/57808068-3bf7bf00-7728-11e9-8846-bb80fd2dee53.png)
