### PR TITLE
feat(LOC-277): add element support for Container and create styleguidist examples

### DIFF
--- a/src/components/Container/Container.tsx
+++ b/src/components/Container/Container.tsx
@@ -26,17 +26,17 @@ export const Container = (props: IContainerProps) => {
 	const propsWithoutDefaults: Partial<IContainerProps> = {...props};
 	delete propsWithoutDefaults.children;
 	delete propsWithoutDefaults.disabled;
-	const doRenderWrapper: boolean = props.disabled === true || Object.keys(propsWithoutDefaults).length === 0;
-	const doUseTag: boolean = typeof props.element === 'string' || props.element === undefined;
+	const doRenderOnlyChildren: boolean = props.disabled === true || Object.keys(propsWithoutDefaults).length === 0;
+	const doRenderContainerWithTagName: boolean = typeof props.element === 'string' || props.element === undefined;
 
 	return (
-		doRenderWrapper
+		doRenderOnlyChildren
 			?
 			<>
 				{props.children}
 			</>
 			:
-				doUseTag
+				doRenderContainerWithTagName
 				?
 				<Tag
 					className={classnames(

--- a/src/components/Container/Container.tsx
+++ b/src/components/Container/Container.tsx
@@ -4,16 +4,16 @@ import IReactComponentProps from '../../common/structures/IReactComponentProps';
 import { ContainerMarginHelper, ContainerMarginLookupType } from './ContainerMarginHelper';
 
 export interface IContainerProps extends IReactComponentProps {
-	/** whether to include the container (false) or exclude it (true) */
+	/** Whether to include the container (false) or exclude it (true) */
 	disabled?: boolean;
-	/** margin values to be set to 'style' prop */
+	/** The container element or tag (if string) to be used as the container. */
+	element?: React.ReactElement | string;
+	/** Margin values to be set to 'style' prop */
 	margin?: ContainerMarginLookupType;
 	marginBottom?: ContainerMarginLookupType;
 	marginLeft?: ContainerMarginLookupType;
 	marginRight?: ContainerMarginLookupType;
 	marginTop?: ContainerMarginLookupType;
-	/** the element name to used for the container */
-	tag?: string;
 }
 
 const defaultProps: Partial<IContainerProps> = {
@@ -21,31 +21,47 @@ const defaultProps: Partial<IContainerProps> = {
 };
 
 export const Container = (props: IContainerProps) => {
-	const Tag: any = props.tag || 'div';
+	const Tag: any = props.element || 'div';
+	const element: React.ReactElement = props.element as React.ReactElement;
 	const propsWithoutDefaults: Partial<IContainerProps> = {...props};
 	delete propsWithoutDefaults.children;
 	delete propsWithoutDefaults.disabled;
-	// disable (don't render) unless explicitly set to 'false' or one of the other settings exists
-	let disabled = props.disabled === true || Object.keys(propsWithoutDefaults).length === 0;
+	const doRenderWrapper: boolean = props.disabled === true || Object.keys(propsWithoutDefaults).length === 0;
+	const doUseTag: boolean = typeof props.element === 'string' || props.element === undefined;
 
 	return (
-		disabled
+		doRenderWrapper
 			?
 			<>
 				{props.children}
 			</>
 			:
-			<Tag
-				className={classnames(
-					props.className,
-				)}
-				style={{
-					...props.style,
-					...ContainerMarginHelper.getContainerMarginStyle(props),
-				}}
-			>
-				{props.children}
-			</Tag>
+				doUseTag
+				?
+				<Tag
+					className={classnames(
+						props.className,
+					)}
+					style={{
+						...props.style,
+						...ContainerMarginHelper.getContainerMarginStyle(props),
+					}}
+				>
+					{props.children}
+				</Tag>
+				:
+				React.cloneElement(
+					element,
+					{
+						children: Array(props.children || []).concat(element.props.children || []),
+						className: classnames(props.className, element.props.className),
+						style: {
+							...props.style,
+							...element.props.style,
+							...ContainerMarginHelper.getContainerMarginStyle(props),
+						}
+					},
+				)
 	);
 };
 

--- a/src/components/Container/README.md
+++ b/src/components/Container/README.md
@@ -1,0 +1,72 @@
+Container is a versatile wrapper element that is rendered if configured (through its props) and ignored thus rendering just its children if not configured.
+This component has several built-in, convience props that are primarily focused on styling and laying out elements.
+
+The intended use for this container is two-fold:
+- to wrap other components in this library thus allowing for an easy and consistent implementation of its props separate from the component, itself, and therefore easier to implement and maintain without conflicting styles
+- to allow developers to easily add layout-related elements without having to create one-off styles and classes just to position a particular element
+
+### Margin
+
+There's a powerful margin system built into Container that allows for:
+- using Local's set increments of margin 'sizes'
+- basic addition and subtraction formulas for complex cases
+- shorthand and individual properties forms
+
+> note: margin is applied directly to the components `style` prop which makes it great for quick, one-off variations and bad for repeatable margin patterns as well as being able to override those margins
+
+The following example shows how to use Container to add margin around an element in shorthand vertical / horizontal form:
+
+```js
+<Container margin="m s xl">
+	<Card>
+    	Hello margin shorthand!
+    </Card>
+</Container>
+```
+
+It's equally as easy to add individual margin props.
+
+```js
+<Container marginLeft="xl">
+	<Card>
+    	Hello individual <strong>marginLeft</strong> property!
+    </Card>
+</Container>
+```
+
+These margin props can also handle simple plus / minus arithmatic for both shorthand and individual margin properties.
+
+```js
+<Container margin="xl+xl -s xl-15 m">
+	<Card>
+    	Hello basic arithmatic!
+    </Card>
+</Container>
+```
+
+### The element prop
+
+By default, when the container is set to render, its container element tag will be of type `div`. 
+If however, you want to use a custom tag, it's as easy as passing a string to the `element` prop:
+
+```js
+<Container element="span" >
+	<button>
+		I am a button
+	</button>
+</Container>
+```
+
+In more complex situations, you may even need the container element to set one or more props.
+In this case, you can pass the `element` prop a full React element:
+
+```js
+<Container 
+	element={<span style={{display: 'inline-block'}} />}
+	margin="xl-1"
+>
+	<button>
+		I am a button
+	</button>
+</Container>
+```


### PR DESCRIPTION
**Audience:** Engineers | Third Party Developers

**Summary:** The `Container` component allows for switching out the container element's tag, but adding support to switch out the entire container element opens up new possibilities for this component. Specifically, this feature will be used with RadioBlock to allow for wrapping options in Tooltips. In addition, documentation has been added to Container showing how to use it in a number of scenarios.

**Screenshots:**  
![image](https://user-images.githubusercontent.com/41925404/58477760-f8368980-8119-11e9-8b19-68842677005d.png)
