### PR TITLE
feat(LOC-277): create popper-based Tooltip component to replace FlyTooltip 

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
 		"react-lowlight": "^2.0.0",
 		"react-markdown": "^4.0.3",
 		"react-modal": "^3.5.1",
+		"react-popper": "^1.3.3",
 		"react-resize-observer": "^1.1.1",
 		"react-router-dom": "^4.3.1",
 		"react-truncate-markup": "^3.0.0",

--- a/src/components/Tooltip/README.md
+++ b/src/components/Tooltip/README.md
@@ -1,7 +1,35 @@
+Default tooltip with `auto` position.
+
 ```js
-<div style={{ height: '80px' }}>
+<div style={{ height: '200px', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
     <Tooltip
     	content={<button className="__Pill __Green __Medium">Hover over me</button>}
+    >
+    	This is a tooltip
+    </Tooltip>
+</div>
+```
+
+Position set to `right`.
+
+```js
+<div style={{ height: '200px', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+    <Tooltip
+    	content={<button className="__Pill __Green __Medium">Hover over me</button>}
+    	position="right"
+    >
+    	This is a tooltip
+    </Tooltip>
+</div>
+```
+
+Set `forceHover` to true
+
+```js
+<div style={{ height: '200px', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+    <Tooltip
+    	content={<button className="__Pill __Green __Medium">Hover over me</button>}
+    	forceHover={true}
     >
     	This is a tooltip
     </Tooltip>

--- a/src/components/Tooltip/README.md
+++ b/src/components/Tooltip/README.md
@@ -3,9 +3,9 @@ Default tooltip with `auto` position.
 ```js
 <div style={{ height: '200px', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
     <Tooltip
-    	content={<button className="__Pill __Green __Medium">Hover over me</button>}
+    	content={<div>This is a tooltip</div>}
     >
-    	This is a tooltip
+    	<button className="__Pill __Green __Medium">Hover over me</button>
     </Tooltip>
 </div>
 ```
@@ -15,23 +15,36 @@ Position set to `right`.
 ```js
 <div style={{ height: '200px', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
     <Tooltip
-    	content={<button className="__Pill __Green __Medium">Hover over me</button>}
+    	content={<div>This is a tooltip</div>}
     	position="right"
     >
-    	This is a tooltip
+    	<button className="__Pill __Green __Medium">Hover over me</button>
     </Tooltip>
 </div>
 ```
 
-Set `forceHover` to true
+Position set to `right` but moves to the left because there's no space to the right.
+
+```js
+<div style={{ height: '200px', display: 'flex', alignItems: 'center', justifyContent: 'flex-end' }}>
+    <Tooltip
+    	content={<div>This is a tooltip</div>}
+    	position="right"
+    >
+    	<button className="__Pill __Green __Medium">Hover over me</button>
+    </Tooltip>
+</div>
+```
+
+Set `forceHover` to `true`.
 
 ```js
 <div style={{ height: '200px', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
     <Tooltip
-    	content={<button className="__Pill __Green __Medium">Hover over me</button>}
+    	content={<p><strong>Yo! This is a test.</strong><br />I'm a tooltip.</p>}
     	forceHover={true}
     >
-    	This is a tooltip
+    	<button className="__Pill __Green __Medium">I am a button</button>
     </Tooltip>
 </div>
 ```

--- a/src/components/Tooltip/README.md
+++ b/src/components/Tooltip/README.md
@@ -1,0 +1,9 @@
+```js
+<div style={{ height: '80px' }}>
+    <Tooltip
+    	content={<button className="__Pill __Green __Medium">Hover over me</button>}
+    >
+    	This is a tooltip
+    </Tooltip>
+</div>
+```

--- a/src/components/Tooltip/README.md
+++ b/src/components/Tooltip/README.md
@@ -1,29 +1,13 @@
+The `Tooltip` component allows content to display additional information on hover. Tooltips can be set to top, right, bottom, and left positions.
+
+> Note: Tooltips are drawn relative to a component's initial size. As such, any component that transitions to its final, needs to load content first, or has any delay in its rendering of its final size will likely result in being positioned incorrectly. Enable `useJsHover` for these use cases.
+
 Default tooltip with default `top` position.
 
 ```js
 <div style={{ height: '200px', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
     <Tooltip
     	content={<div>This is a tooltip</div>}
-    >
-    	<button className="__Pill __Green __Medium">Look at me, I'm a button</button>
-    </Tooltip>
-</div>
-```
-```js
-<div style={{ height: '50px', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-    <Tooltip
-    	content={<div>This is a tooltip</div>}
-		position="right"
-    >
-    	<button className="__Pill __Green __Medium">Hover over me</button>
-    </Tooltip>
-</div>
-```
-```js
-<div style={{ height: '50px', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-    <Tooltip
-    	content={<div>This is a tooltip</div>}
-		position="left"
     >
     	<button className="__Pill __Green __Medium">Hover over me</button>
     </Tooltip>
@@ -56,7 +40,7 @@ Position set to `right`.
 </div>
 ```
 
-Position set to `right` but moves to the left because there's no space to the right.
+Position set to `right` but is repositioned to the left because there's not enough space to the right.
 
 ```js
 <div style={{ height: '200px', display: 'flex', alignItems: 'center', justifyContent: 'flex-end' }}>

--- a/src/components/Tooltip/README.md
+++ b/src/components/Tooltip/README.md
@@ -1,11 +1,50 @@
-Default tooltip with `auto` position.
+Default tooltip with default `top` position.
 
 ```js
 <div style={{ height: '200px', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
     <Tooltip
     	content={<div>This is a tooltip</div>}
     >
+    	<button className="__Pill __Green __Medium">e</button>
+    </Tooltip>
+    <Tooltip
+        	content={<div>This is a tooltip</div>}
+        	position="bottom"
+        >
+        	<button className="__Pill __Green __Medium">e</button>
+        </Tooltip>
+</div>
+```
+```js
+<div style={{ height: '50px', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+    <Tooltip
+    	content={<div>This is a tooltip</div>}
+		position="right"
+    >
     	<button className="__Pill __Green __Medium">Hover over me</button>
+    </Tooltip>
+</div>
+```
+```js
+<div style={{ height: '50px', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+    <Tooltip
+    	content={<div>This is a tooltip</div>}
+		position="left"
+    >
+    	<button className="__Pill __Green __Medium">Hover over me</button>
+    </Tooltip>
+</div>
+```
+
+Set `forceHover` to `true`.
+
+```js
+<div style={{ height: '200px', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+    <Tooltip
+    	content={<p><strong>Yo! This is a test.</strong><br />I'm a tooltip.</p>}
+    	forceHover={true}
+    >
+    	<button className="__Pill __Green __Medium">I am a button</button>
     </Tooltip>
 </div>
 ```
@@ -32,19 +71,6 @@ Position set to `right` but moves to the left because there's no space to the ri
     	position="right"
     >
     	<button className="__Pill __Green __Medium">Hover over me</button>
-    </Tooltip>
-</div>
-```
-
-Set `forceHover` to `true`.
-
-```js
-<div style={{ height: '200px', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-    <Tooltip
-    	content={<p><strong>Yo! This is a test.</strong><br />I'm a tooltip.</p>}
-    	forceHover={true}
-    >
-    	<button className="__Pill __Green __Medium">I am a button</button>
     </Tooltip>
 </div>
 ```

--- a/src/components/Tooltip/README.md
+++ b/src/components/Tooltip/README.md
@@ -5,14 +5,8 @@ Default tooltip with default `top` position.
     <Tooltip
     	content={<div>This is a tooltip</div>}
     >
-    	<button className="__Pill __Green __Medium">e</button>
+    	<button className="__Pill __Green __Medium">Look at me, I'm a button</button>
     </Tooltip>
-    <Tooltip
-        	content={<div>This is a tooltip</div>}
-        	position="bottom"
-        >
-        	<button className="__Pill __Green __Medium">e</button>
-        </Tooltip>
 </div>
 ```
 ```js

--- a/src/components/Tooltip/Tooltip.scss
+++ b/src/components/Tooltip/Tooltip.scss
@@ -1,5 +1,16 @@
 @import '../../styles/_partials/index';
 
+@mixin tooltipBoxShadow {
+	box-shadow: 0 0 5px 0 rgba(0, 0, 0, 0.14);
+}
+
+$arrowSize: 10px;
+
+@function getRotatedSquaresLength ($originalLength) {
+	// note: 0.785398 radias = 45 degrees
+	@return $originalLength * abs(cos(0.785398)) + $originalLength * abs(sin(0.785398));
+}
+
 .Tooltip_Content {
 	&:hover + .Tooltip_Popper {
 		visibility: visible;
@@ -7,11 +18,80 @@
 }
 
 .Tooltip_Popper {
-	visibility: hidden; // this sets visibility through CSS first, JS second and  allows for use of Chrome Dev Tools :hov
-	background: white;
-	border: 1px solid gray;
+	visibility: hidden; // this sets visibility through CSS first, JS second and allows for use of Chrome Dev Tools :hov
+	position: absolute;
+	padding: 10px 30px;
+	font-weight: 300;
+	@include theme-color-graydark50-else-gray25;
+	@include theme-input-background-color;
+	@include theme-input-border;
+	@include tooltipBoxShadow;
 
 	&.Tooltip_Popper__ForceHover {
 		visibility: visible;
+	}
+	//top: -10px !important;
+
+	&[data-placement*='top'] {
+		top: -(getRotatedSquaresLength($arrowSize) / 2) !important;
+	}
+
+	&[data-placement*='right'] {
+		left: (getRotatedSquaresLength($arrowSize) / 2) !important;
+	}
+
+	&[data-placement*='bottom'] {
+		top: (getRotatedSquaresLength($arrowSize) / 2) !important;
+	}
+
+	&[data-placement*='left'] {
+		left: -(getRotatedSquaresLength($arrowSize) / 2) !important;
+	}
+}
+
+.Tooltip_Arrow {
+	$extraShadowArea: 100%;
+
+	position: absolute;
+	width: $arrowSize;
+	height: $arrowSize;
+	@include theme-input-background-color;
+	@include theme-input-border;
+	border-radius: 0 0 4px 0;
+	@include tooltipBoxShadow;
+	pointer-events: none;
+	transition: all 0.05s cubic-bezier(0.2, 0.3, 0.25, 0.9) 0s;
+	// pre-rotate poly used to clip the content
+	clip-path: polygon(
+		(0% - $extraShadowArea) (100% + $extraShadowArea), // bottom-left (left after rotate)
+		(100% + $extraShadowArea) (0% - $extraShadowArea), // top-right (right after rotate)
+		(100% + $extraShadowArea) (100% + $extraShadowArea) // bottom-right (bottom after rotate)
+	);
+
+	&[data-placement*='top'] {
+		bottom: 0;
+		left: 100%;
+		//margin-left: (-$arrowSize / 2) + (-$arrowSize / 4);
+		margin-left: -$arrowSize / 4;
+		transform-origin: 0 100%;
+		transform: rotate(45deg);
+	}
+
+	&[data-placement*='right'] {
+		left: -$arrowSize / 2;
+		transform-origin: 50% 50%;
+		transform: rotate(135deg);
+	}
+
+	&[data-placement*='bottom'] {
+		top: -$arrowSize / 2;
+		left: 100%;
+		transform-origin: 50% 50%;
+		transform: rotate(225deg);
+	}
+
+	&[data-placement*='left'] {
+		right: -$arrowSize / 2;
+		transform: rotate(-45deg);
 	}
 }

--- a/src/components/Tooltip/Tooltip.scss
+++ b/src/components/Tooltip/Tooltip.scss
@@ -1,7 +1,9 @@
 @import '../../styles/_partials/index';
 
 $arrowSize: 15px;
-$ease-in: cubic-bezier(.2,.3,.25,.9);
+$arrowSizeRotated: calculateRotatedSquaresLength($arrowSize, 45deg);
+$transitionEaseIn: cubic-bezier(.2,.3,.25,.9);
+$transitionDuration: 80ms;
 
 @mixin tooltipBoxShadow {
 	box-shadow: 0 0 5px 0 rgba(0, 0, 0, 0.14);
@@ -16,11 +18,6 @@ $ease-in: cubic-bezier(.2,.3,.25,.9);
 	}
 }
 
-@function getRotatedSquaresLength ($originalLength) {
-	// note: 0.785398 radias = 45 degrees
-	@return $originalLength * abs(cos(0.785398)) + $originalLength * abs(sin(0.785398));
-}
-
 .Tooltip_Content {
 	&:hover + .Tooltip_Popper {
 		@include showTooltip;
@@ -28,32 +25,36 @@ $ease-in: cubic-bezier(.2,.3,.25,.9);
 }
 
 .Tooltip_Popper {
-	position: absolute;
+	visibility: hidden;
+
+	&.Tooltip_Popper__TransitionLeaving {
+		visibility: visible; // stay visible while transitioning out
+	}
 
 	&.Tooltip_Popper__ForceHover {
 		@include showTooltip;
 	}
 
 	&[data-placement*='top'] {
-		top: -(getRotatedSquaresLength($arrowSize) / 2) !important;
+		top: -($arrowSizeRotated / 2) !important;
 	}
 
 	&[data-placement*='right'] {
-		left: (getRotatedSquaresLength($arrowSize) / 2) !important;
+		left: ($arrowSizeRotated / 2) !important;
 	}
 
 	&[data-placement*='bottom'] {
-		top: (getRotatedSquaresLength($arrowSize) / 2) !important;
+		top: ($arrowSizeRotated / 2) !important;
 	}
 
 	&[data-placement*='left'] {
-		left: -(getRotatedSquaresLength($arrowSize) / 2) !important;
+		left: -($arrowSizeRotated / 2) !important;
 	}
 }
 
 .Tooltip_Popper_Inner {
 	transform: scale(0) translateX(0%) translateY(0%) translateZ(0);
-	transition: transform 80ms $ease-in 80ms, transform-origin 1800ms $ease-in 80ms;
+	transition: transform $transitionDuration $transitionEaseIn 80ms, transform-origin 1800ms $transitionEaseIn 80ms;
 
 	&[data-placement*='top'] {
 		transform-origin: 50% 100%;
@@ -103,28 +104,28 @@ $ease-in: cubic-bezier(.2,.3,.25,.9);
 
 	&[data-placement*='top'] {
 		bottom: $borderThickness; // overlay border
-		left: calc(50% - #{getRotatedSquaresLength($arrowSize) / 2});
+		left: calc(50% - #{$arrowSizeRotated / 2});
 		transform-origin: 0 100%;
 		transform: rotate(45deg);
 	}
 
 	&[data-placement*='right'] {
 		left: -$arrowSize / 2 + $borderThickness;
-		top: calc(50% - #{getRotatedSquaresLength($arrowSize) / 2});
+		top: calc(50% - #{$arrowSizeRotated / 2});
 		transform-origin: 49% 57%;
 		transform: rotate(135deg);
 	}
 
 	&[data-placement*='bottom'] {
 		top: -$arrowSize / 2 + $borderThickness;
-		left: calc(50% - #{getRotatedSquaresLength($arrowSize) / 2});
+		left: calc(50% - #{$arrowSizeRotated / 2});
 		transform-origin: 60% 46%;
 		transform: rotate(225deg);
 	}
 
 	&[data-placement*='left'] {
 		right: -$arrowSize / 2 + $borderThickness;
-		top: calc(50% - #{getRotatedSquaresLength($arrowSize) / 2});
+		top: calc(50% - #{$arrowSizeRotated/ 2});
 		transform-origin: 70% 63%;
 		transform: rotate(-45deg);
 	}

--- a/src/components/Tooltip/Tooltip.scss
+++ b/src/components/Tooltip/Tooltip.scss
@@ -1,10 +1,20 @@
 @import '../../styles/_partials/index';
 
+$arrowSize: 15px;
+$ease-in: cubic-bezier(.2,.3,.25,.9);
+
 @mixin tooltipBoxShadow {
 	box-shadow: 0 0 5px 0 rgba(0, 0, 0, 0.14);
 }
 
-$arrowSize: 10px;
+@mixin showTooltip {
+	visibility: visible;
+
+	& > .Tooltip_Popper_Inner {
+		transform: scale(1.0) translateX(0%) translateY(0%) translateZ(0);
+		transform-origin: 50% 50%;
+	}
+}
 
 @function getRotatedSquaresLength ($originalLength) {
 	// note: 0.785398 radias = 45 degrees
@@ -13,24 +23,16 @@ $arrowSize: 10px;
 
 .Tooltip_Content {
 	&:hover + .Tooltip_Popper {
-		visibility: visible;
+		@include showTooltip;
 	}
 }
 
 .Tooltip_Popper {
-	visibility: hidden; // this sets visibility through CSS first, JS second and allows for use of Chrome Dev Tools :hov
 	position: absolute;
-	padding: 10px 30px;
-	font-weight: 300;
-	@include theme-color-graydark50-else-gray25;
-	@include theme-input-background-color;
-	@include theme-input-border;
-	@include tooltipBoxShadow;
 
 	&.Tooltip_Popper__ForceHover {
-		visibility: visible;
+		@include showTooltip;
 	}
-	//top: -10px !important;
 
 	&[data-placement*='top'] {
 		top: -(getRotatedSquaresLength($arrowSize) / 2) !important;
@@ -49,8 +51,39 @@ $arrowSize: 10px;
 	}
 }
 
-.Tooltip_Arrow {
+.Tooltip_Popper_Inner {
+	transform: scale(0) translateX(0%) translateY(0%) translateZ(0);
+	transition: transform 80ms $ease-in 80ms, transform-origin 1800ms $ease-in 80ms;
+
+	&[data-placement*='top'] {
+		transform-origin: 50% 100%;
+	}
+
+	&[data-placement*='right'] {
+		transform-origin: 0 50%;
+	}
+
+	&[data-placement*='bottom'] {
+		transform-origin: 50% 0;
+	}
+
+	&[data-placement*='left'] {
+		transform-origin: 100% 50%;
+	}
+}
+
+.Tooltip_Popper_Content {
+	padding: 10px 30px;
+	font-weight: 300;
+	@include theme-color-graydark50-else-gray25;
+	@include theme-input-background-color;
+	@include theme-input-border;
+	@include tooltipBoxShadow;
+}
+
+.Tooltip_Popper_Arrow {
 	$extraShadowArea: 100%;
+	$borderThickness: 1px;
 
 	position: absolute;
 	width: $arrowSize;
@@ -60,7 +93,7 @@ $arrowSize: 10px;
 	border-radius: 0 0 4px 0;
 	@include tooltipBoxShadow;
 	pointer-events: none;
-	transition: all 0.05s cubic-bezier(0.2, 0.3, 0.25, 0.9) 0s;
+	//transition: all 0.05s cubic-bezier(0.2, 0.3, 0.25, 0.9) 0s;
 	// pre-rotate poly used to clip the content
 	clip-path: polygon(
 		(0% - $extraShadowArea) (100% + $extraShadowArea), // bottom-left (left after rotate)
@@ -69,29 +102,30 @@ $arrowSize: 10px;
 	);
 
 	&[data-placement*='top'] {
-		bottom: 0;
-		left: 100%;
-		//margin-left: (-$arrowSize / 2) + (-$arrowSize / 4);
-		margin-left: -$arrowSize / 4;
+		bottom: $borderThickness; // overlay border
+		left: calc(50% - #{getRotatedSquaresLength($arrowSize) / 2});
 		transform-origin: 0 100%;
 		transform: rotate(45deg);
 	}
 
 	&[data-placement*='right'] {
-		left: -$arrowSize / 2;
-		transform-origin: 50% 50%;
+		left: -$arrowSize / 2 + $borderThickness;
+		top: calc(50% - #{getRotatedSquaresLength($arrowSize) / 2});
+		transform-origin: 49% 57%;
 		transform: rotate(135deg);
 	}
 
 	&[data-placement*='bottom'] {
-		top: -$arrowSize / 2;
-		left: 100%;
-		transform-origin: 50% 50%;
+		top: -$arrowSize / 2 + $borderThickness;
+		left: calc(50% - #{getRotatedSquaresLength($arrowSize) / 2});
+		transform-origin: 60% 46%;
 		transform: rotate(225deg);
 	}
 
 	&[data-placement*='left'] {
-		right: -$arrowSize / 2;
+		right: -$arrowSize / 2 + $borderThickness;
+		top: calc(50% - #{getRotatedSquaresLength($arrowSize) / 2});
+		transform-origin: 70% 63%;
 		transform: rotate(-45deg);
 	}
 }

--- a/src/components/Tooltip/Tooltip.scss
+++ b/src/components/Tooltip/Tooltip.scss
@@ -1,6 +1,7 @@
 @import '../../styles/_partials/index';
 
 $arrowSize: 15px;
+$arrowOffset: 14px;
 $arrowSizeRotated: calculateRotatedSquaresLength($arrowSize, 45deg);
 $transitionEaseIn: cubic-bezier(.2,.3,.25,.9);
 $transitionDuration: 80ms;
@@ -36,19 +37,19 @@ $transitionDuration: 80ms;
 	}
 
 	&[data-placement*='top'] {
-		top: -($arrowSizeRotated / 2) !important;
+		top: (-$arrowSizeRotated / 2 + $arrowOffset) !important;
 	}
 
 	&[data-placement*='right'] {
-		left: ($arrowSizeRotated / 2) !important;
+		left: ($arrowSizeRotated / 2 - $arrowOffset) !important;
 	}
 
 	&[data-placement*='bottom'] {
-		top: ($arrowSizeRotated / 2) !important;
+		top: ($arrowSizeRotated / 2 - $arrowOffset) !important;
 	}
 
 	&[data-placement*='left'] {
-		left: -($arrowSizeRotated / 2) !important;
+		left: (-$arrowSizeRotated / 2 + $arrowOffset) !important;
 	}
 }
 

--- a/src/components/Tooltip/Tooltip.scss
+++ b/src/components/Tooltip/Tooltip.scss
@@ -1,0 +1,2 @@
+@import '../../styles/_partials/index';
+

--- a/src/components/Tooltip/Tooltip.scss
+++ b/src/components/Tooltip/Tooltip.scss
@@ -103,31 +103,59 @@ $transitionDuration: 80ms;
 		(100% + $extraShadowArea) (100% + $extraShadowArea) // bottom-right (bottom after rotate)
 	);
 
-	&[data-placement*='top'] {
+	&[data-placement^='top'] {
 		bottom: $borderThickness; // overlay border
 		left: calc(50% - #{$arrowSizeRotated / 2});
 		transform-origin: 0 100%;
 		transform: rotate(45deg);
 	}
 
-	&[data-placement*='right'] {
+	&[data-placement^='right'] {
 		left: -$arrowSize / 2 + $borderThickness;
 		top: calc(50% - #{$arrowSizeRotated / 2});
 		transform-origin: 49% 57%;
 		transform: rotate(135deg);
 	}
 
-	&[data-placement*='bottom'] {
+	&[data-placement^='bottom'] {
 		top: -$arrowSize / 2 + $borderThickness;
 		left: calc(50% - #{$arrowSizeRotated / 2});
 		transform-origin: 60% 46%;
 		transform: rotate(225deg);
+
+		&[data-placement$='start'] {
+			left: 13px;
+		}
+
+		&[data-placement$='end'] {
+			left: calc(100% - #{$arrowSizeRotated} - 13px);
+		}
 	}
 
-	&[data-placement*='left'] {
+	&[data-placement^='left'] {
 		right: -$arrowSize / 2 + $borderThickness;
 		top: calc(50% - #{$arrowSizeRotated/ 2});
 		transform-origin: 70% 63%;
 		transform: rotate(-45deg);
+	}
+
+	&[data-placement^='top'][data-placement$='start'],
+	&[data-placement^='bottom'][data-placement$='start'] {
+		left: 13px;
+	}
+
+	&[data-placement^='top'][data-placement$='end'],
+	&[data-placement^='bottom'][data-placement$='end'] {
+		left: calc(100% - #{$arrowSizeRotated} - 13px);
+	}
+
+	&[data-placement^='right'][data-placement$='start'],
+	&[data-placement^='left'][data-placement$='start'] {
+		top: 13px;
+	}
+
+	&[data-placement^='right'][data-placement$='end'],
+	&[data-placement^='left'][data-placement$='end'] {
+		top: calc(100% - #{$arrowSizeRotated} - 13px);
 	}
 }

--- a/src/components/Tooltip/Tooltip.scss
+++ b/src/components/Tooltip/Tooltip.scss
@@ -1,2 +1,17 @@
 @import '../../styles/_partials/index';
 
+.Tooltip_Content {
+	&:hover + .Tooltip_Popper {
+		visibility: visible;
+	}
+}
+
+.Tooltip_Popper {
+	visibility: hidden; // this sets visibility through CSS first, JS second and  allows for use of Chrome Dev Tools :hov
+	background: white;
+	border: 1px solid gray;
+
+	&.Tooltip_Popper__ForceHover {
+		visibility: visible;
+	}
+}

--- a/src/components/Tooltip/Tooltip.scss
+++ b/src/components/Tooltip/Tooltip.scss
@@ -75,8 +75,9 @@ $transitionDuration: 80ms;
 }
 
 .Tooltip_Popper_Content {
-	padding: 10px 30px;
+	padding: 20px;
 	font-weight: 300;
+	text-align: center;
 	@include theme-color-graydark50-else-gray25;
 	@include theme-input-background-color;
 	@include theme-input-border;

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -72,9 +72,10 @@ export class Tooltip extends React.Component<IProps, IState> {
 								{
 									[styles.Tooltip_Popper__ForceHover]: this.props.forceHover,
 									[styles.Tooltip_Popper__TransitionLeaving]: this.state.isLeavingTransition,
-								}
+								},
+								this.props.className,
 							)}
-							style={style}
+							style={{...style, ...(this.props.style || {})}}
 							data-placement={placement}
 						>
 							<div
@@ -96,7 +97,6 @@ export class Tooltip extends React.Component<IProps, IState> {
 										'Tooltip_Popper_Arrow',
 									)}
 									ref={arrowProps.ref}
-									// style={arrowProps.style}
 									data-placement={placement}
 								/>
 							</div>

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -10,11 +10,31 @@ interface IProps extends IReactComponentProps {
 	position?: 'top' | 'top-start' | 'top-end' | 'right' | 'right-start' | 'right-end' | 'bottom' | 'bottom-start' | 'bottom-end' | 'left' | 'left-start' | 'left-end';
 }
 
-export class Tooltip extends React.Component<IProps> {
+interface IState {
+	isLeavingTransition: boolean;
+}
+
+export class Tooltip extends React.Component<IProps, IState> {
 
 	static defaultProps: Partial<IProps> = {
 		forceHover: false,
 		position: 'top',
+	};
+
+	constructor (props: IReactComponentProps) {
+		super(props);
+
+		this.state = {
+			isLeavingTransition: false,
+		};
+	}
+
+	protected _onMouseLeavePopperInner = () => {
+		this.setState({ isLeavingTransition: true });
+	};
+
+	protected _onTransitionEndPopperInner = () => {
+		this.setState({ isLeavingTransition: false });
 	};
 
 	render () {
@@ -36,6 +56,7 @@ export class Tooltip extends React.Component<IProps> {
 										styles.Tooltip_Content,
 										'Tooltip_Content',
 									),
+									onMouseLeave: this._onMouseLeavePopperInner,
 								}
 							);
 						});
@@ -50,6 +71,7 @@ export class Tooltip extends React.Component<IProps> {
 								'Tooltip_Popper',
 								{
 									[styles.Tooltip_Popper__ForceHover]: this.props.forceHover,
+									[styles.Tooltip_Popper__TransitionLeaving]: this.state.isLeavingTransition,
 								}
 							)}
 							style={style}
@@ -58,6 +80,7 @@ export class Tooltip extends React.Component<IProps> {
 							<div
 								className={styles.Tooltip_Popper_Inner}
 								data-placement={placement}
+								onTransitionEnd={this._onTransitionEndPopperInner}
 							>
 								<div
 									className={classnames(

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -3,16 +3,18 @@ import IReactComponentProps from '../../common/structures/IReactComponentProps';
 import classnames from 'classnames';
 import * as styles from './Tooltip.scss';
 import { Manager, Reference, Popper } from 'react-popper';
-import { ResizeObserverComponent } from './ResizeObserverComponent';
 
 interface IProps extends IReactComponentProps {
 	content?: React.ReactElement;
+	forceHover?: boolean;
+	position?: 'auto' | 'auto-start' | 'auto-end' | 'top' | 'top-start' | 'top-end' | 'right' | 'right-start' | 'right-end' | 'bottom' | 'bottom-start' | 'bottom-end' | 'left' | 'left-start' | 'left-end';
 }
 
 export class Tooltip extends React.Component<IProps> {
 
 	static defaultProps: Partial<IProps> = {
-
+		forceHover: false,
+		position: 'auto',
 	};
 
 	render () {
@@ -23,18 +25,36 @@ export class Tooltip extends React.Component<IProps> {
 						if(!this.props.content) {
 							return null;
 						}
-						return (
-							<ResizeObserverComponent>
-								{React.cloneElement(this.props.content, {ref})}
-							</ResizeObserverComponent>
-						)
+						return React.cloneElement(
+							this.props.content,
+							{
+								ref,
+								className: classnames(
+									this.props.content.props.className,
+									styles.Tooltip_Content,
+								),
+							}
+						);
 					}}
 				</Reference>
-				<Popper placement="bottom">
+				<Popper placement={this.props.position}>
 					{({ ref, style, placement, arrowProps }) => (
-						<div ref={ref} style={style} data-placement={placement}>
+						<div
+							ref={ref}
+							className={classnames(
+								styles.Tooltip_Popper,
+								{
+									[styles.Tooltip_Popper__ForceHover]: this.props.forceHover,
+								}
+							)}
+							style={style}
+							data-placement={placement}
+						>
 							{this.props.children}
-							<div ref={arrowProps.ref} style={arrowProps.style} />
+							<div
+								ref={arrowProps.ref}
+								style={arrowProps.style}
+							/>
 						</div>
 					)}
 				</Popper>

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -55,8 +55,10 @@ export class Tooltip extends React.Component<IProps> {
 						>
 							{this.props.content}
 							<div
+								className={styles.Tooltip_Arrow}
 								ref={arrowProps.ref}
 								style={arrowProps.style}
+								data-placement={placement}
 							/>
 						</div>
 					)}

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -8,9 +8,11 @@ interface IProps extends IReactComponentProps {
 	content?: React.ReactElement;
 	forceHover?: boolean;
 	position?: 'top' | 'top-start' | 'top-end' | 'right' | 'right-start' | 'right-end' | 'bottom' | 'bottom-start' | 'bottom-end' | 'left' | 'left-start' | 'left-end';
+	useJsHover?: boolean;
 }
 
 interface IState {
+	isHover: boolean;
 	isLeavingTransition: boolean;
 }
 
@@ -19,22 +21,35 @@ export class Tooltip extends React.Component<IProps, IState> {
 	static defaultProps: Partial<IProps> = {
 		forceHover: false,
 		position: 'top',
+		useJsHover: false,
 	};
 
 	constructor (props: IReactComponentProps) {
 		super(props);
 
 		this.state = {
+			isHover: false,
 			isLeavingTransition: false,
 		};
 	}
 
-	protected _onMouseLeavePopperInner = () => {
-		this.setState({ isLeavingTransition: true });
+	protected _onMouseEnterContentReference = () => {
+		this.setState({
+			isHover: true,
+		});
+	};
+
+	protected _onMouseLeaveContentReference = () => {
+		this.setState({
+			isLeavingTransition: true,
+			isHover: false,
+		});
 	};
 
 	protected _onTransitionEndPopperInner = () => {
-		this.setState({ isLeavingTransition: false });
+		this.setState({
+			isLeavingTransition: false,
+		});
 	};
 
 	render () {
@@ -56,53 +71,56 @@ export class Tooltip extends React.Component<IProps, IState> {
 										styles.Tooltip_Content,
 										'Tooltip_Content',
 									),
-									onMouseLeave: this._onMouseLeavePopperInner,
+									onMouseEnter: this._onMouseEnterContentReference,
+									onMouseLeave: this._onMouseLeaveContentReference,
 								}
 							);
 						});
 					}}
 				</Reference>
-				<Popper placement={this.props.position}>
-					{({ ref, style, placement, arrowProps }) => (
-						<div
-							ref={ref}
-							className={classnames(
-								styles.Tooltip_Popper,
-								'Tooltip_Popper',
-								{
-									[styles.Tooltip_Popper__ForceHover]: this.props.forceHover,
-									[styles.Tooltip_Popper__TransitionLeaving]: this.state.isLeavingTransition,
-								},
-								this.props.className,
-							)}
-							style={{...style, ...(this.props.style || {})}}
-							data-placement={placement}
-						>
+				{(this.props.forceHover || !this.props.useJsHover || this.state.isHover) && (
+					<Popper placement={this.props.position}>
+						{({ ref, style, placement, arrowProps }) => (
 							<div
-								className={styles.Tooltip_Popper_Inner}
+								ref={ref}
+								className={classnames(
+									styles.Tooltip_Popper,
+									'Tooltip_Popper',
+									{
+										[styles.Tooltip_Popper__ForceHover]: this.props.forceHover,
+										[styles.Tooltip_Popper__TransitionLeaving]: this.state.isLeavingTransition,
+									},
+									this.props.className,
+								)}
+								style={{...style, ...(this.props.style || {})}}
 								data-placement={placement}
-								onTransitionEnd={this._onTransitionEndPopperInner}
 							>
 								<div
-									className={classnames(
-										styles.Tooltip_Popper_Content,
-										'Tooltip_Popper_Content',
-									)}
-								>
-									{this.props.content}
-								</div>
-								<div
-									className={classnames(
-										styles.Tooltip_Popper_Arrow,
-										'Tooltip_Popper_Arrow',
-									)}
-									ref={arrowProps.ref}
+									className={styles.Tooltip_Popper_Inner}
 									data-placement={placement}
-								/>
+									onTransitionEnd={this._onTransitionEndPopperInner}
+								>
+									<div
+										className={classnames(
+											styles.Tooltip_Popper_Content,
+											'Tooltip_Popper_Content',
+										)}
+									>
+										{this.props.content}
+									</div>
+									<div
+										className={classnames(
+											styles.Tooltip_Popper_Arrow,
+											'Tooltip_Popper_Arrow',
+										)}
+										ref={arrowProps.ref}
+										data-placement={placement}
+									/>
+								</div>
 							</div>
-						</div>
-					)}
-				</Popper>
+						)}
+					</Popper>
+				)}
 			</Manager>
 		);
 	}

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -7,7 +7,7 @@ import { Manager, Reference, Popper } from 'react-popper';
 interface IProps extends IReactComponentProps {
 	content?: React.ReactElement;
 	forceHover?: boolean;
-	position?: 'top' | 'right' | 'bottom' | 'left';
+	position?: 'top' | 'top-start' | 'top-end' | 'right' | 'right-start' | 'right-end' | 'bottom' | 'bottom-start' | 'bottom-end' | 'left' | 'left-start' | 'left-end';
 }
 
 interface IState {

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -7,7 +7,7 @@ import { Manager, Reference, Popper } from 'react-popper';
 interface IProps extends IReactComponentProps {
 	content?: React.ReactElement;
 	forceHover?: boolean;
-	position?: 'top' | 'top-start' | 'top-end' | 'right' | 'right-start' | 'right-end' | 'bottom' | 'bottom-start' | 'bottom-end' | 'left' | 'left-start' | 'left-end';
+	position?: 'top' | 'right' | 'bottom' | 'left';
 }
 
 interface IState {

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -22,19 +22,22 @@ export class Tooltip extends React.Component<IProps> {
 			<Manager>
 				<Reference>
 					{({ ref }) => {
-						if(!this.props.content) {
+						if(!this.props.children) {
 							return null;
 						}
-						return React.cloneElement(
-							this.props.content,
-							{
-								ref,
-								className: classnames(
-									this.props.content.props.className,
-									styles.Tooltip_Content,
-								),
-							}
-						);
+
+						return React.Children.map(this.props.children as React.ReactElement, (child: React.ReactElement) => {
+							return React.cloneElement(
+								child,
+								{
+									ref,
+									className: classnames(
+										child.props.className,
+										styles.Tooltip_Content,
+									),
+								}
+							);
+						});
 					}}
 				</Reference>
 				<Popper placement={this.props.position}>
@@ -50,7 +53,7 @@ export class Tooltip extends React.Component<IProps> {
 							style={style}
 							data-placement={placement}
 						>
-							{this.props.children}
+							{this.props.content}
 							<div
 								ref={arrowProps.ref}
 								style={arrowProps.style}

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -13,7 +13,7 @@ interface IProps extends IReactComponentProps {
 export class Tooltip extends React.Component<IProps> {
 
 	static defaultProps: Partial<IProps> = {
-		forceHover: true,
+		forceHover: false,
 		position: 'top',
 	};
 
@@ -34,6 +34,7 @@ export class Tooltip extends React.Component<IProps> {
 									className: classnames(
 										child.props.className,
 										styles.Tooltip_Content,
+										'Tooltip_Content',
 									),
 								}
 							);
@@ -46,6 +47,7 @@ export class Tooltip extends React.Component<IProps> {
 							ref={ref}
 							className={classnames(
 								styles.Tooltip_Popper,
+								'Tooltip_Popper',
 								{
 									[styles.Tooltip_Popper__ForceHover]: this.props.forceHover,
 								}
@@ -53,13 +55,28 @@ export class Tooltip extends React.Component<IProps> {
 							style={style}
 							data-placement={placement}
 						>
-							{this.props.content}
 							<div
-								className={styles.Tooltip_Arrow}
-								ref={arrowProps.ref}
-								style={arrowProps.style}
+								className={styles.Tooltip_Popper_Inner}
 								data-placement={placement}
-							/>
+							>
+								<div
+									className={classnames(
+										styles.Tooltip_Popper_Content,
+										'Tooltip_Popper_Content',
+									)}
+								>
+									{this.props.content}
+								</div>
+								<div
+									className={classnames(
+										styles.Tooltip_Popper_Arrow,
+										'Tooltip_Popper_Arrow',
+									)}
+									ref={arrowProps.ref}
+									// style={arrowProps.style}
+									data-placement={placement}
+								/>
+							</div>
 						</div>
 					)}
 				</Popper>

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -1,0 +1,45 @@
+import * as React from 'react';
+import IReactComponentProps from '../../common/structures/IReactComponentProps';
+import classnames from 'classnames';
+import * as styles from './Tooltip.scss';
+import { Manager, Reference, Popper } from 'react-popper';
+import { ResizeObserverComponent } from './ResizeObserverComponent';
+
+interface IProps extends IReactComponentProps {
+	content?: React.ReactElement;
+}
+
+export class Tooltip extends React.Component<IProps> {
+
+	static defaultProps: Partial<IProps> = {
+
+	};
+
+	render () {
+		return (
+			<Manager>
+				<Reference>
+					{({ ref }) => {
+						if(!this.props.content) {
+							return null;
+						}
+						return (
+							<ResizeObserverComponent>
+								{React.cloneElement(this.props.content, {ref})}
+							</ResizeObserverComponent>
+						)
+					}}
+				</Reference>
+				<Popper placement="bottom">
+					{({ ref, style, placement, arrowProps }) => (
+						<div ref={ref} style={style} data-placement={placement}>
+							{this.props.children}
+							<div ref={arrowProps.ref} style={arrowProps.style} />
+						</div>
+					)}
+				</Popper>
+			</Manager>
+		);
+	}
+
+}

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -7,14 +7,14 @@ import { Manager, Reference, Popper } from 'react-popper';
 interface IProps extends IReactComponentProps {
 	content?: React.ReactElement;
 	forceHover?: boolean;
-	position?: 'auto' | 'auto-start' | 'auto-end' | 'top' | 'top-start' | 'top-end' | 'right' | 'right-start' | 'right-end' | 'bottom' | 'bottom-start' | 'bottom-end' | 'left' | 'left-start' | 'left-end';
+	position?: 'top' | 'top-start' | 'top-end' | 'right' | 'right-start' | 'right-end' | 'bottom' | 'bottom-start' | 'bottom-end' | 'left' | 'left-start' | 'left-end';
 }
 
 export class Tooltip extends React.Component<IProps> {
 
 	static defaultProps: Partial<IProps> = {
-		forceHover: false,
-		position: 'auto',
+		forceHover: true,
+		position: 'top',
 	};
 
 	render () {

--- a/src/components/Tooltip/index.ts
+++ b/src/components/Tooltip/index.ts
@@ -1,0 +1,1 @@
+export {Tooltip} from './Tooltip';

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,6 +50,7 @@ export {TableList as TableList, TableListRow as TableListRow} from './components
 export {default as TableListRepeater} from './components/TableListRepeater';
 export {default as TabNav} from './components/TabNav';
 export {TertiaryNav as TertiaryNav, TertiaryNavItem as TertiaryNavItem} from './components/TertiaryNav';
+export {Tooltip} from './components/Tooltip';
 export {default as Truncate} from './components/Truncate';
 export {VerticalNav as VerticalNav, VerticalNavItem as VerticalNavItem} from './components/VerticalNav';
 export {WorkspaceSwitcher} from './components/VerticalNav/components/WorkspaceSwitcher';

--- a/src/styles/_partials/_functions.scss
+++ b/src/styles/_partials/_functions.scss
@@ -61,3 +61,7 @@
 	}
 	@return $cos;
 }
+
+@function calculateRotatedSquaresLength($originalLength, $degrees) {
+	@return $originalLength * abs(cos(rad($degrees))) + $originalLength * abs(sin(rad($degrees)));
+}

--- a/src/styles/_partials/_functions.scss
+++ b/src/styles/_partials/_functions.scss
@@ -1,3 +1,63 @@
 @function deprecated($selector, $sinceLocalVersion: '', $sinceComponentsVersion: '', $notes: '') {
 	@return $selector
 }
+
+// Math functions
+
+@function pow ($number, $exp) {
+	$value: 1;
+	@if $exp > 0 {
+		@for $i from 1 through $exp {
+			$value: $value * $number;
+		}
+	} @else if $exp < 0 {
+		@for $i from 1 through -$exp {
+			$value: $value / $number;
+		}
+	}
+	@return $value;
+}
+
+@function fact ($number) {
+	$value: 1;
+	@if $number > 0 {
+		@for $i from 1 through $number {
+			$value: $value * $i;
+		}
+	}
+	@return $value;
+}
+
+@function pi () {
+	@return 3.14159265359;
+}
+
+@function rad ($angle) {
+	$unit: unit($angle);
+	$unitless: $angle / ($angle * 0 + 1);
+	// If the angle has 'deg' as unit, convert to radians.
+	@if $unit == deg {
+		$unitless: $unitless / 180 * pi();
+	}
+	@return $unitless;
+}
+
+@function sin ($angle) {
+	$sin: 0;
+	$angle: rad($angle);
+	// Iterate a bunch of times.
+	@for $i from 0 through 10 {
+		$sin: $sin + pow(-1, $i) * pow($angle, (2 * $i + 1)) / fact(2 * $i + 1);
+	}
+	@return $sin;
+}
+
+@function cos ($angle) {
+	$cos: 0;
+	$angle: rad($angle);
+	// Iterate a bunch of times.
+	@for $i from 0 through 10 {
+		$cos: $cos + pow(-1, $i) * pow($angle, 2 * $i) / fact(2 * $i);
+	}
+	@return $cos;
+}

--- a/src/styles/buttons.scss
+++ b/src/styles/buttons.scss
@@ -15,7 +15,7 @@
 		@include tracking(40);
 		font-weight: 700;
 		border: 0;
-		transition: transform .1s ease 0s, padding .1s ease 0s, background-color .1s ease 0s, color .1s ease 0s;
+		transition: transform .1s ease 0s, background-color .1s ease 0s, color .1s ease 0s;
 		text-decoration: none;
 		align-self: center;
 		color: $gray25;

--- a/yarn.lock
+++ b/yarn.lock
@@ -30,6 +30,13 @@
   dependencies:
     regenerator-runtime "^0.12.0"
 
+"@babel/runtime@^7.1.2":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.4.4.tgz#dc2e34982eb236803aa27a07fea6857af1b9171d"
+  integrity sha512-w0+uT71b6Yi7i5SE0co4NioIpSYS6lLiXvCzWzGSKvpK5vdQtCbICHMj+gbAKAOtxiV6HsVh/MBdaF9EQ6faSg==
+  dependencies:
+    regenerator-runtime "^0.13.2"
+
 "@fimbul/bifrost@^0.17.0":
   version "0.17.0"
   resolved "https://registry.yarnpkg.com/@fimbul/bifrost/-/bifrost-0.17.0.tgz#f0383ba7e40992e3193dc87e2ddfde2ad62a9cf4"
@@ -663,6 +670,11 @@ arrify@^1.0.0, arrify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
   integrity sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=
+
+asap@~2.0.3:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
+  integrity sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=
 
 asn1.js@^4.0.0:
   version "4.10.1"
@@ -1788,6 +1800,11 @@ copy-webpack-plugin@^4.5.4:
     p-limit "^1.0.0"
     serialize-javascript "^1.4.0"
 
+core-js@^1.0.0:
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
+  integrity sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=
+
 core-js@^2.4.0, core-js@^2.5.0:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.2.tgz#267988d7268323b349e20b4588211655f0e83944"
@@ -1838,6 +1855,14 @@ create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
     ripemd160 "^2.0.0"
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
+
+create-react-context@<=0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/create-react-context/-/create-react-context-0.2.2.tgz#9836542f9aaa22868cd7d4a6f82667df38019dca"
+  integrity sha512-KkpaLARMhsTsgp0d2NA/R94F/eDLbhXERdIq3LvX2biCAXcDvHYoOqHfWCHf1+OLj+HKBotLG3KqaOOf+C1C+A==
+  dependencies:
+    fbjs "^0.8.0"
+    gud "^1.0.0"
 
 cross-spawn@6.0.5, cross-spawn@^6.0.0, cross-spawn@^6.0.5:
   version "6.0.5"
@@ -2466,6 +2491,13 @@ encodeurl@~1.0.2:
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.2.tgz#ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59"
   integrity sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=
 
+encoding@^0.1.11:
+  version "0.1.12"
+  resolved "https://registry.yarnpkg.com/encoding/-/encoding-0.1.12.tgz#538b66f3ee62cd1ab51ec323829d1f9480c74beb"
+  integrity sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=
+  dependencies:
+    iconv-lite "~0.4.13"
+
 end-of-stream@^1.0.0, end-of-stream@^1.1.0:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.1.tgz#ed29634d19baba463b6ce6b80a37213eab71ec43"
@@ -2978,6 +3010,19 @@ fb-watchman@^2.0.0:
   integrity sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=
   dependencies:
     bser "^2.0.0"
+
+fbjs@^0.8.0:
+  version "0.8.17"
+  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.17.tgz#c4d598ead6949112653d6588b01a5cdcd9f90fdd"
+  integrity sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=
+  dependencies:
+    core-js "^1.0.0"
+    isomorphic-fetch "^2.1.1"
+    loose-envify "^1.0.0"
+    object-assign "^4.1.0"
+    promise "^7.1.1"
+    setimmediate "^1.0.5"
+    ua-parser-js "^0.7.18"
 
 figgy-pudding@^3.5.1:
   version "3.5.1"
@@ -3546,6 +3591,11 @@ growly@^1.3.0:
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
   integrity sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=
 
+gud@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/gud/-/gud-1.0.0.tgz#a489581b17e6a70beca9abe3ae57de7a499852c0"
+  integrity sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw==
+
 gzip-size@5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/gzip-size/-/gzip-size-5.0.0.tgz#a55ecd99222f4c48fd8c01c625ce3b349d0a0e80"
@@ -3837,7 +3887,7 @@ iconv-lite@0.4.23:
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
-iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@^0.4.4:
+iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@^0.4.4, iconv-lite@~0.4.13:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
@@ -4350,7 +4400,7 @@ is-root@2.0.0:
   resolved "https://registry.yarnpkg.com/is-root/-/is-root-2.0.0.tgz#838d1e82318144e5a6f77819d90207645acc7019"
   integrity sha512-F/pJIk8QD6OX5DNhRB7hWamLsUilmkDGho48KbgZ6xg/lmAZXHxzXQ91jzB3yRSw5kdQGGGc4yz8HYhTYIMWPg==
 
-is-stream@^1.1.0:
+is-stream@^1.0.1, is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
   integrity sha1-EtSj3U5o4Lec6428hBc66A2RykQ=
@@ -4428,6 +4478,14 @@ isobject@^3.0.0, isobject@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
   integrity sha1-TkMekrEalzFjaqH5yNHMvP2reN8=
+
+isomorphic-fetch@^2.1.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz#611ae1acf14f5e81f729507472819fe9733558a9"
+  integrity sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=
+  dependencies:
+    node-fetch "^1.0.1"
+    whatwg-fetch ">=0.10.0"
 
 isstream@~0.1.2:
   version "0.1.2"
@@ -5862,6 +5920,14 @@ node-dir@^0.1.10:
   dependencies:
     minimatch "^3.0.2"
 
+node-fetch@^1.0.1:
+  version "1.7.3"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.3.tgz#980f6f72d85211a5347c6b2bc18c5b84c3eb47ef"
+  integrity sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==
+  dependencies:
+    encoding "^0.1.11"
+    is-stream "^1.0.1"
+
 node-forge@0.7.5:
   version "0.7.5"
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.7.5.tgz#6c152c345ce11c52f465c2abd957e8639cd674df"
@@ -6596,6 +6662,11 @@ pn@^1.1.0:
   resolved "https://registry.yarnpkg.com/pn/-/pn-1.1.0.tgz#e2f4cef0e219f463c179ab37463e4e1ecdccbafb"
   integrity sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==
 
+popper.js@^1.14.4:
+  version "1.15.0"
+  resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.15.0.tgz#5560b99bbad7647e9faa475c6b8056621f5a4ff2"
+  integrity sha512-w010cY1oCUmI+9KwwlWki+r5jxKfTFDVoadl7MSrIujHU5MJ5OR6HTDj6Xo8aoR/QsA56x8jKjA59qGH4ELtrA==
+
 portfinder@^1.0.9:
   version "1.0.20"
   resolved "https://registry.yarnpkg.com/portfinder/-/portfinder-1.0.20.tgz#bea68632e54b2e13ab7b0c4775e9b41bf270e44a"
@@ -6785,6 +6856,13 @@ promise-inflight@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/promise-inflight/-/promise-inflight-1.0.1.tgz#98472870bf228132fcbdd868129bad12c3c029e3"
   integrity sha1-mEcocL8igTL8vdhoEputEsPAKeM=
+
+promise@^7.1.1:
+  version "7.3.1"
+  resolved "https://registry.yarnpkg.com/promise/-/promise-7.3.1.tgz#064b72602b18f90f29192b8b1bc418ffd1ebd3bf"
+  integrity sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==
+  dependencies:
+    asap "~2.0.3"
 
 prompts@^0.1.9:
   version "0.1.14"
@@ -7133,6 +7211,18 @@ react-modal@^3.5.1:
     react-lifecycles-compat "^3.0.0"
     warning "^3.0.0"
 
+react-popper@^1.3.3:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/react-popper/-/react-popper-1.3.3.tgz#2c6cef7515a991256b4f0536cd4bdcb58a7b6af6"
+  integrity sha512-ynMZBPkXONPc5K4P5yFWgZx5JGAUIP3pGGLNs58cfAPgK67olx7fmLp+AdpZ0+GoQ+ieFDa/z4cdV6u7sioH6w==
+  dependencies:
+    "@babel/runtime" "^7.1.2"
+    create-react-context "<=0.2.2"
+    popper.js "^1.14.4"
+    prop-types "^15.6.1"
+    typed-styles "^0.0.7"
+    warning "^4.0.2"
+
 react-resize-observer@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/react-resize-observer/-/react-resize-observer-1.1.1.tgz#641dfa2e0f4bd2549a8ab4bbbaf43b68f3dcaf76"
@@ -7396,6 +7486,11 @@ regenerator-runtime@^0.12.0:
   version "0.12.1"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz#fa1a71544764c036f8c49b13a08b2594c9f8a0de"
   integrity sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg==
+
+regenerator-runtime@^0.13.2:
+  version "0.13.2"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz#32e59c9a6fb9b1a4aff09b4930ca2d4477343447"
+  integrity sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA==
 
 regex-cache@^0.4.2:
   version "0.4.4"
@@ -7935,7 +8030,7 @@ set-value@^2.0.0:
     is-plain-object "^2.0.3"
     split-string "^3.0.1"
 
-setimmediate@^1.0.4:
+setimmediate@^1.0.4, setimmediate@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
   integrity sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=
@@ -8929,6 +9024,11 @@ type-is@~1.6.16:
     media-typer "0.3.0"
     mime-types "~2.1.18"
 
+typed-styles@^0.0.7:
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/typed-styles/-/typed-styles-0.0.7.tgz#93392a008794c4595119ff62dde6809dbc40a3d9"
+  integrity sha512-pzP0PWoZUhsECYjABgCGQlRGL1n7tOHsgwYv3oIiEpJwGhFTuty/YNeduxQYzXXa3Ge5BdT6sHYIQYpl4uJ+5Q==
+
 typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
@@ -8938,6 +9038,11 @@ typescript@^3.2.2:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.2.2.tgz#fe8101c46aa123f8353523ebdcf5730c2ae493e5"
   integrity sha512-VCj5UiSyHBjwfYacmDuc/NOk4QQixbE+Wn7MFJuS0nRuPQbof132Pw4u53dm264O8LPc2MVsc7RJNml5szurkg==
+
+ua-parser-js@^0.7.18:
+  version "0.7.19"
+  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.19.tgz#94151be4c0a7fb1d001af7022fdaca4642659e4b"
+  integrity sha512-T3PVJ6uz8i0HzPxOF9SWzWAlfN/DavlpQqepn22xgve/5QecC+XMCAtmUNnY7C9StehaV6exjUCI801lOI7QlQ==
 
 uglify-js@^3.1.4:
   version "3.4.9"
@@ -9261,6 +9366,13 @@ warning@^4.0.1:
   dependencies:
     loose-envify "^1.0.0"
 
+warning@^4.0.2:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/warning/-/warning-4.0.3.tgz#16e9e077eb8a86d6af7d64aa1e05fd85b4678ca3"
+  integrity sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==
+  dependencies:
+    loose-envify "^1.0.0"
+
 watch@~0.18.0:
   version "0.18.0"
   resolved "https://registry.yarnpkg.com/watch/-/watch-0.18.0.tgz#28095476c6df7c90c963138990c0a5423eb4b986"
@@ -9439,6 +9551,11 @@ whatwg-encoding@^1.0.1, whatwg-encoding@^1.0.3:
   integrity sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==
   dependencies:
     iconv-lite "0.4.24"
+
+whatwg-fetch@>=0.10.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz#fc804e458cc460009b1a2b966bc8817d2578aefb"
+  integrity sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q==
 
 whatwg-mimetype@^2.1.0, whatwg-mimetype@^2.2.0:
   version "2.3.0"


### PR DESCRIPTION
**Audience:** Engineers | Third Party Developers

**Summary:** A new Tooltip component needs to be created to solve for two major problems that the existing FlyTooltip doesn't solve for:

1. don't wrap tooltip content in additional elements
2. when a tooltip runs out of screen real estate, it should reposition itself

One final objective with the new Tooltip component is to exclude any styles related to other components. Since scoped styles have been introduced, this has been increasingly important. As such, when replacing Flytooltip for Tooltip, several of those previously baked-in styles will have to be re-introduced using other patterns.

The underlying library chosen to make this happen is `popper.js` due to its features, flexibility, and popularity. In addition, popper is simply a positioning component and therefore that allows us the flexibility to create the tooltip api and features we specifically need.

**Technical:**
- `react-popper` library is used
- CSS `:hover` is used to show the tooltip instead of JavaScript to allow for easier debugging within Chrome Dev Tools
- many of the styles from FlyTooltip have been repurposed but a lot of changes had to be made for the new element structure of the component
- new math sass functions added: pow, fact, pi, rad, sin, cos
- in addition to position options such as top, right, bottom and left, there are modifiers to this that allow for start and end (e.g. top-start, left-end)

**Limitations:** Currently, items that don't render their full size initially will likely result in their tooltip being positioned incorrectly. To overcome this, the `useJsHover` prop can be enabled. This delays the tooltip creation until after hover via JavaScript.

**Future Considerations:** It might be worth taking many of the base styles and logic introduced within `Tooltip` and moving it to `Popup` eventually.

**Screenshots:** 
![image](https://user-images.githubusercontent.com/41925404/58483665-4fdaf200-8126-11e9-93ff-a33af0111aa3.png)
