### PR TITLE
improvement(LOC-277): add container wrapper to RadioBlock to allow for easy implementation of Tooltip component

### DIFF
--- a/src/components/RadioBlock/README.md
+++ b/src/components/RadioBlock/README.md
@@ -65,7 +65,7 @@ Medium size RadioBlock:
 }} />
 ```
 
-Tooltip for the second, disabled option:
+Disable the 2nd item and show a tooltip on hover:
 
 ```js
 <RadioBlock heightSize="m" onChange={() => console.log('onChange')} default={'test1'} options={{
@@ -73,9 +73,13 @@ Tooltip for the second, disabled option:
         label: 'Test 1',
     },
     'test2': {
-    	disabled: true,
         label: 'Test 2',
-        tooltipContent: <p>Hey, this is why this is disabled. It all started when you clicked...</p>,
+    	disabled: true,
+        container: {
+			element: (
+				<Tooltip content={<div>Hey, this option's disabled.<br /><a>Here's why</a></div>} />
+			)
+		}
     },
 }} />
 ```

--- a/src/components/RadioBlock/RadioBlock.sass
+++ b/src/components/RadioBlock/RadioBlock.sass
@@ -1,5 +1,9 @@
 @import '../../styles/_partials/index'
 
+$zIndexOptionNormal: 1
+$zIndexOptionSelected: $zIndexOptionNormal + 3
+$zIndexOptionTooltip: $zIndexOptionSelected + 3
+
 .RadioBlock
 	display: flex
 	flex-wrap: wrap
@@ -10,12 +14,16 @@
 		flex-direction: column
 	&.RadioBlock__Readonly
 
+	// if child is not a radioblock option then the assumption is that it's a popup, tooltip or some other element that needs to appear above the options
+	> *:not(.RadioBlock_Option)
+		z-index: $zIndexOptionTooltip
+
 .RadioBlock_Option_TooltipWrapper
 	flex: 1
 
 .RadioBlock_Option
 	position: relative
-	z-index: 1
+	z-index: $zIndexOptionNormal
 	@include theme-background-white-else-graydark
 	text-align: center
 	font-size: 18px
@@ -34,7 +42,7 @@
 		z-index: 4
 
 		.RadioBLock_Label
-			z-index: 2
+			z-index: $zIndexOptionNormal + 1
 			border-color: $green
 
 			@include selectors_ifHostHasModifier('.RadioBlock_Option__Warn')
@@ -44,7 +52,7 @@
 				opacity: 1
 				top: -4px
 				left: -4px
-				z-index: 2
+				z-index: $zIndexOptionNormal + 1
 				border-radius: 4px
 				width: calc(100% + 4px)
 				height: calc(100% + 4px)
@@ -113,7 +121,7 @@
 
 		*
 			position: relative
-			z-index: 2
+			z-index: $zIndexOptionNormal + 1
 
 	.RadioBLock_Label_Text
 		pointer-events: none
@@ -131,7 +139,7 @@
 			position: absolute
 			top: 6.4px
 			right: 9.6px
-			z-index: 9
+			z-index: $zIndexOptionSelected + 1
 			width: 10px
 			height: 14px
 			color: $white

--- a/src/components/RadioBlock/RadioBlock.tsx
+++ b/src/components/RadioBlock/RadioBlock.tsx
@@ -64,35 +64,38 @@ class RadioBlock extends React.Component<IProps, IState> {
 
 	render () {
 		return (
-			<div
-				className={classnames(
-					styles.RadioBlock,
-					this.props.className,
+			// wrap in optional container
+			<Container {...this.props.container}>
+				<div
+					className={classnames(
+						styles.RadioBlock,
+						this.props.className,
+						{
+							[styles.RadioBlock__DirectionVert]: this.props.direction === 'vert',
+							[styles.RadioBlock__Readonly]: this.props.readonly === true,
+						},
+					)}
+				>
 					{
-						[styles.RadioBlock__DirectionVert]: this.props.direction === 'vert',
-						[styles.RadioBlock__Readonly]: this.props.readonly === true,
-					},
-				)}
-			>
-				{
-					Object.keys(this.props.options).map((optionValue: string, i: number) => (
-						<RadioBlockItem
-							onClick={this.onClick}
-							className={this.props.options[optionValue].className}
-							container={this.props.options[optionValue].container}
-							disabled={this.props.disabled || this.props.options[optionValue].disabled}
-							warn={this.props.warn || this.props.options[optionValue].warn}
-							heightSize={this.props.heightSize}
-							label={this.props.options[optionValue].label}
-							value={optionValue}
-							key={i}
-							readonly={this.props.readonly || this.props.options[optionValue].readonly}
-							svg={this.props.options[optionValue].svg}
-							selected={this.state.value === optionValue}
-						/>
-					))
-				}
-			</div>
+						Object.keys(this.props.options).map((optionValue: string, i: number) => (
+							<RadioBlockItem
+								onClick={this.onClick}
+								className={this.props.options[optionValue].className}
+								container={this.props.options[optionValue].container}
+								disabled={this.props.disabled || this.props.options[optionValue].disabled}
+								warn={this.props.warn || this.props.options[optionValue].warn}
+								heightSize={this.props.heightSize}
+								label={this.props.options[optionValue].label}
+								value={optionValue}
+								key={i}
+								readonly={this.props.readonly || this.props.options[optionValue].readonly}
+								svg={this.props.options[optionValue].svg}
+								selected={this.state.value === optionValue}
+							/>
+						))
+					}
+				</div>
+			</Container>
 		);
 	}
 

--- a/src/components/RadioBlock/RadioBlock.tsx
+++ b/src/components/RadioBlock/RadioBlock.tsx
@@ -1,14 +1,14 @@
 import * as React from 'react';
-import IReactComponentProps from '../../common/structures/IReactComponentProps';
 import classnames from 'classnames';
 import CheckmarkSVG from '../../svg/checkmark--big';
 import ExclamationSVG from '../../svg/exclamation';
 import * as styles from './RadioBlock.sass';
 import Header from '../Header/Header';
-import FlyTooltip from '../FlyTooltip/FlyTooltip';
 import Handler from '../../common/structures/Handler';
+import { Container } from '../Container/Container';
+import ILocalContainerProps from '../../common/structures/ILocalContainerProps';
 
-interface IProps extends IReactComponentProps {
+interface IProps extends ILocalContainerProps {
 	default: string | null;
 	direction: 'horiz' | 'vert';
 	disabled?: boolean;
@@ -79,6 +79,7 @@ class RadioBlock extends React.Component<IProps, IState> {
 						<RadioBlockItem
 							onClick={this.onClick}
 							className={this.props.options[optionValue].className}
+							container={this.props.options[optionValue].container}
 							disabled={this.props.disabled || this.props.options[optionValue].disabled}
 							warn={this.props.warn || this.props.options[optionValue].warn}
 							heightSize={this.props.heightSize}
@@ -88,7 +89,6 @@ class RadioBlock extends React.Component<IProps, IState> {
 							readonly={this.props.readonly || this.props.options[optionValue].readonly}
 							svg={this.props.options[optionValue].svg}
 							selected={this.state.value === optionValue}
-							tooltipContent={this.props.options[optionValue].tooltipContent}
 						/>
 					))
 				}
@@ -98,8 +98,7 @@ class RadioBlock extends React.Component<IProps, IState> {
 
 }
 
-interface IRadioBlockItemProps extends IReactComponentProps {
-
+interface IRadioBlockItemProps extends ILocalContainerProps {
 	disabled?: boolean;
 	warn?: boolean;
 	heightSize?: 'm' | 'l';
@@ -108,9 +107,7 @@ interface IRadioBlockItemProps extends IReactComponentProps {
 	readonly?: boolean;
 	selected?: boolean;
 	svg?: any;
-	tooltipContent?: React.ReactNode;
 	value?: string | null;
-
 }
 
 class RadioBlockItem extends React.Component<IRadioBlockItemProps> {
@@ -136,24 +133,6 @@ class RadioBlockItem extends React.Component<IRadioBlockItemProps> {
 		}
 	}
 
-	renderOptionalTooltipAndContent (content: React.ReactNode) {
-		if (this.props.tooltipContent) {
-			return (
-				<FlyTooltip
-					content={this.props.tooltipContent}
-					position="center"
-					hoverIntent={true}
-					className={styles.RadioBlock_Option_TooltipWrapper}
-					width="max-content"
-				>
-					{content}
-				</FlyTooltip>
-			);
-		}
-
-		return content;
-	}
-
 	render () {
 		const svg = this.props.warn ?
 			<ExclamationSVG />
@@ -164,35 +143,38 @@ class RadioBlockItem extends React.Component<IRadioBlockItemProps> {
 				<CheckmarkSVG />
 		;
 
-		return this.renderOptionalTooltipAndContent((
-			<div
-				onClick={this.onClick}
-				className={classnames(
-					styles.RadioBlock_Option,
-					this.props.className,
-					{
-						[styles.RadioBlock_Option__Disabled]: this.props.disabled,
-						[styles.RadioBlock_Option__Warn]: this.props.warn,
-						[styles.RadioBlock_Option__HeightSizeMedium]: this.props.heightSize === 'm',
-						[styles.RadioBlock_Option__Readonly]: this.props.readonly,
-						[styles.RadioBlock_Option__Selected]: this.props.selected,
-					},
-				)}
-			>
-				<label className={styles.RadioBLock_Label}>
-					<Header
-						className={styles.RadioBLock_Label_Text}
-						fontSize={this.props.heightSize === 'l' ? 's' : 'xs'}
-						fontWeight="500"
-					>
-						{this.props.label}
-					</Header>
-					<div className={styles.RadioBLock_Arrow}>
-						{svg}
-					</div>
-				</label>
-			</div>
-		));
+		return (
+			// wrap in optional container
+			<Container {...this.props.container}>
+				<div
+					onClick={this.onClick}
+					className={classnames(
+						styles.RadioBlock_Option,
+						this.props.className,
+						{
+							[styles.RadioBlock_Option__Disabled]: this.props.disabled,
+							[styles.RadioBlock_Option__Warn]: this.props.warn,
+							[styles.RadioBlock_Option__HeightSizeMedium]: this.props.heightSize === 'm',
+							[styles.RadioBlock_Option__Readonly]: this.props.readonly,
+							[styles.RadioBlock_Option__Selected]: this.props.selected,
+						},
+					)}
+				>
+					<label className={styles.RadioBLock_Label}>
+						<Header
+							className={styles.RadioBLock_Label_Text}
+							fontSize={this.props.heightSize === 'l' ? 's' : 'xs'}
+							fontWeight="500"
+						>
+							{this.props.label}
+						</Header>
+						<div className={styles.RadioBLock_Arrow}>
+							{svg}
+						</div>
+					</label>
+				</div>
+			</Container>
+		);
 	}
 
 }


### PR DESCRIPTION
**Audience:** Engineers | Third Party Developers

**Summary:** RadioBlock needs to support the newest Tooltip component. Rather than simply swapping out the internal dependency of FlyTooltip within RadioBlock, `local-components` Container component was introduced. This not only allows RadioBlock to leverage Container's built-in features (e.g. margin), but also allows any component or element to be a wrapper container for RadioBlock and RadioBlockOption thus eliminating a hard-coded dependency on a component like FlyTooltip.

RadioBlock also uses a number of z-indexes to display various graphics and selected states. To make this more maintainable and flexible, SASS variables have been added and a style has been added that assumes that any sibling to a RadioBlockOption is likely there as a popup and will appear above the rest of RadioBlock.

**Breaking Changes:** RadioBlock's API has changed to more generically support `container` rather than supporting a specific tooltip implementation via the `tooltipContent` prop.

**Screenshots:**
Example showing the new `container` prop leveraging the new Tooltip component: 
![image](https://user-images.githubusercontent.com/41925404/58507053-73b62c00-8156-11e9-8f58-9458acc688fd.png)

