### PR TITLE
fix(LOC-277): persist tooltip visibility when switching from reference to popper on hover

### DIFF
--- a/src/components/Tooltip/Tooltip.scss
+++ b/src/components/Tooltip/Tooltip.scss
@@ -4,37 +4,31 @@ $arrowSize: 15px;
 $arrowOffset: 14px;
 $arrowSizeRotated: calculateRotatedSquaresLength($arrowSize, 45deg);
 $transitionEaseIn: cubic-bezier(.2,.3,.25,.9);
-$transitionDuration: 80ms;
+$transitionDuration: 100ms;
 
 @mixin tooltipBoxShadow {
 	box-shadow: 0 0 5px 0 rgba(0, 0, 0, 0.14);
 }
 
-@mixin showTooltip {
-	visibility: visible;
-
-	& > .Tooltip_Popper_Inner {
-		transform: scale(1.0) translateX(0%) translateY(0%) translateZ(0);
-		transform-origin: 50% 50%;
-	}
-}
-
 .Tooltip_Content {
-	&:hover + .Tooltip_Popper {
-		@include showTooltip;
+	&:hover + .Tooltip_Popper,
+	& + .Tooltip_Popper.Tooltip_Popper__DoPreventTransitionOut,
+	& + .Tooltip_Popper.Tooltip_Popper__ForceHover {
+		visibility: visible;
+
+		& > .Tooltip_Popper_Inner {
+			transform: scale(1.0) translateX(0%) translateY(0%) translateZ(0);
+			transform-origin: 50% 50%;
+		}
+	}
+
+	& + .Tooltip_Popper.Tooltip_Popper__IsTransitionLeaving {
+		visibility: visible;
 	}
 }
 
 .Tooltip_Popper {
 	visibility: hidden;
-
-	&.Tooltip_Popper__TransitionLeaving {
-		visibility: visible; // stay visible while transitioning out
-	}
-
-	&.Tooltip_Popper__ForceHover {
-		@include showTooltip;
-	}
 
 	&[data-placement*='top'] {
 		top: (-$arrowSizeRotated / 2 + $arrowOffset) !important;
@@ -54,8 +48,11 @@ $transitionDuration: 80ms;
 }
 
 .Tooltip_Popper_Inner {
-	transform: scale(0) translateX(0%) translateY(0%) translateZ(0);
-	transition: transform $transitionDuration $transitionEaseIn 80ms, transform-origin 1800ms $transitionEaseIn 80ms;
+	transition: transform $transitionDuration $transitionEaseIn, transform-origin $transitionDuration $transitionEaseIn;
+
+	@at-root .Tooltip_Popper:not(.Tooltip_Popper__DoPreventTransitionOut) & {
+		transform: scale(0) translateX(0%) translateY(0%) translateZ(0);
+	}
 
 	&[data-placement*='top'] {
 		transform-origin: 50% 100%;
@@ -96,7 +93,6 @@ $transitionDuration: 80ms;
 	border-radius: 0 0 4px 0;
 	@include tooltipBoxShadow;
 	pointer-events: none;
-	//transition: all 0.05s cubic-bezier(0.2, 0.3, 0.25, 0.9) 0s;
 	// pre-rotate poly used to clip the content
 	clip-path: polygon(
 		(0% - $extraShadowArea) (100% + $extraShadowArea), // bottom-left (left after rotate)

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -5,15 +5,20 @@ import * as styles from './Tooltip.scss';
 import { Manager, Reference, Popper } from 'react-popper';
 
 interface IProps extends IReactComponentProps {
+	/** the content that should show the tooltip upon the user's mouse entering it **/
 	content?: React.ReactElement;
-	delayHide?: number;
+	/** whether to force the tooltip to show and ignore mouse events **/
 	forceHover?: boolean;
+	/** the number of milliseconds to delay hiding the tooltip after the user's mouse leaves this component **/
+	hideDelay?: number;
+	/** the position/placement of the tooltip relative to the content **/
 	position?: 'top' | 'top-start' | 'top-end' | 'right' | 'right-start' | 'right-end' | 'bottom' | 'bottom-start' | 'bottom-end' | 'left' | 'left-start' | 'left-end';
+	/** whether to use just JavaScript to show and hide the tooltip **/
 	useJsHover?: boolean;
 }
 
 interface IState {
-	/** this will prevent CSS-driven fading out of the tooltip if the JS-driven events determine it shouldn't fire (e.g. force hover, delayed exit, still hovering over popper element) **/
+	/** whether to prevent CSS-driven fading out of the tooltip if the JS-driven events determine it shouldn't fire (e.g. force hover, delayed exit, still hovering over popper element) **/
 	doPreventTransitionOut: boolean;
 	isMouseOverPopper: boolean;
 	isMouseOverReference: boolean;
@@ -23,7 +28,7 @@ interface IState {
 export class Tooltip extends React.Component<IProps, IState> {
 
 	static defaultProps: Partial<IProps> = {
-		delayHide: 500,
+		hideDelay: 500,
 		forceHover: false,
 		position: 'top',
 		useJsHover: false,
@@ -65,7 +70,7 @@ export class Tooltip extends React.Component<IProps, IState> {
 				doPreventTransitionOut: this.state.isMouseOverReference,
 				isTransitionLeaving: !this.state.isMouseOverReference,
 			});
-		}, this.props.delayHide);
+		}, this.props.hideDelay);
 	};
 
 	protected _onMouseEnterReference = () => {
@@ -95,7 +100,7 @@ export class Tooltip extends React.Component<IProps, IState> {
 				doPreventTransitionOut: this.state.isMouseOverPopper,
 				isTransitionLeaving: !this.state.isMouseOverPopper,
 			});
-		}, this.props.delayHide);
+		}, this.props.hideDelay);
 	};
 
 	protected _onTransitionEndPopperInner = () => {


### PR DESCRIPTION
**Audience:** Engineers | Third Party Developers

**Summary:** The tooltip needs to continue showing even after the mouse leaves the content reference and enters the actual tooltip. Furthermore, the tooltip shouldn't hide when moving back and forth between the two elements. 

**Technical:** A delay needed to be added to allow for the switching between the reference and tooltip/popper elements. From an interaction standpoint, a delay is a positive enhancement anyways so that delay has been increased to a 'natural feeling' number.

**Screenshots:**
Slowed down interactions of intricate hover state sequences (1/10th normal speed):
http://flywheel.link/98d0d351d075