### PR TITLE
fix(LOC-732, LOC-752): fix incorrect and missing component styles 

### DIFF
--- a/src/components/Checkbox/Checkbox.sass
+++ b/src/components/Checkbox/Checkbox.sass
@@ -30,7 +30,7 @@ $checkboxSize: 16px
 		flex-shrink: 0
 		width: $checkboxSize
 		height: $checkboxSize
-		background: $white
+		@include theme-background-white-else-graydarkalt
 		@include theme-input-border
 		@include selectors_ifHostHasModifier('.Checkbox__Disabled')
 			@include theme-background-gray5-else-gray-dark50

--- a/src/styles/_partials/_theme.scss
+++ b/src/styles/_partials/_theme.scss
@@ -83,6 +83,10 @@
 	@include __theme-background($white, $gray25);
 }
 
+@mixin theme-background-white-else-graydarkalt {
+	@include __theme-background($white, $gray-dark-alt);
+}
+
 @mixin theme-background-white-else-graydark50 {
 	@include __theme-background($white, $gray-dark50);
 }

--- a/src/styles/_partials/_variables.scss
+++ b/src/styles/_partials/_variables.scss
@@ -65,7 +65,7 @@ $system-font: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, 
 // Reusable Color Patterns
 
 $theme-border-light: $gray15;
-$theme-border-dark: $gray-dark50;
+$theme-border-dark: $gray;
 $theme-input-border-box-shadow-dark: $gray;
 
 $font-size-header-xs: 1.4rem;

--- a/src/styles/containers/Flywheel.scss
+++ b/src/styles/containers/Flywheel.scss
@@ -126,9 +126,6 @@
 			height: 88px;
 			margin: 0 26px 0 0;
 			cursor: pointer;
-			@include if-theme-dark() {
-				filter: brightness(0.34);
-			}
 		}
 
 		button {


### PR DESCRIPTION
**Audience:** Users | Engineers | Third Party Developers

**Summary:** Add dark mode variant for Checkbox, adjust FlySite image filter style, and change non-input border styles to match their intended gray value to fix the workspace switcher divider issue for dark mode.

**Screenshots:**
without dark mode variant:
![image](https://user-images.githubusercontent.com/41925404/58657690-721a6e80-82e4-11e9-9600-43f957f2e8ac.png)

with dark mode variant (improvement):
![image](https://user-images.githubusercontent.com/41925404/58657620-4b5c3800-82e4-11e9-839a-7199ae3e7e06.png)

with dark mode disabled (improvement):
![image](https://user-images.githubusercontent.com/41925404/58663055-32a64f00-82f1-11e9-9460-25daaf7b3cad.png)

before FlySite image:
![image](https://user-images.githubusercontent.com/41925404/58659069-a04d7d80-82e7-11e9-984a-1566d8e77c6f.png)

after FlySite image (with fix):
![image](https://user-images.githubusercontent.com/41925404/58659128-ca9f3b00-82e7-11e9-9fa6-635792e6ec7e.png)

before divider: 
![image](https://user-images.githubusercontent.com/41925404/58661464-a0e91280-82ed-11e9-8bb5-c59130121f70.png)

after divider (with border fix):
![image](https://user-images.githubusercontent.com/41925404/58662011-d5110300-82ee-11e9-80c3-53eac077c757.png)
