### PR TITLE
fix: remove filter to fix slow WorkspaceSwitcher animation

### DIFF
--- a/src/components/FlyTooltip/FlyTooltip.scss
+++ b/src/components/FlyTooltip/FlyTooltip.scss
@@ -45,7 +45,6 @@
 	}
 
 	&::before {
-		box-shadow: 0 0 20px 0 rgba($gray-dark, .15);
 		top: auto;
 		right: 10px;
 		bottom: -6px;

--- a/src/components/Popup/Popup.sass
+++ b/src/components/Popup/Popup.sass
@@ -2,6 +2,7 @@
 
 .Popup
 	$transiton-duration: 80ms
+	$transiton-delay: 80ms
 	$ease-in: cubic-bezier(.2,.3,.25,.9)
 
 	position: relative
@@ -22,7 +23,8 @@
 		right: 0
 		bottom: 0
 		left: 0
-		transition: transform $transiton-duration $ease-in $transiton-duration
+		transition: transform $transiton-duration $ease-in $transiton-delay
+		will-change: transform
 
 		@include selectors_ifHostHasModifier('.Popup__PositionTop')
 			transform: scale(0) translateY(0%) translateZ(0)
@@ -66,7 +68,7 @@
 		line-height: normal
 		@include theme-background-white-else-graydark50
 		border-radius: $border-radius
-		filter: drop-shadow(0 0 7px rgba($gray-dark, .16)) // use a filter instead of box-shadow so the effect is applied to the pseudo element as well
+		box-shadow: 0 0 20px 0 rgba(0, 0, 0, 0.14)
 
 		@include selectors_setAsDefaults()
 			padding: 0
@@ -121,7 +123,8 @@
 			background: $green-dark50
 
 	.Popup_BubbleContent
-		transition: opacity $transiton-duration $ease-in $transiton-duration
+		transition: opacity $transiton-duration $ease-in $transiton-delay
+		will-change: opacity
 		@include selectors_setAsDefaults()
 			opacity: 0
 		@include selectors_ifHostHasModifier('.Popup__Open')

--- a/src/components/Tooltip/Tooltip.scss
+++ b/src/components/Tooltip/Tooltip.scss
@@ -49,6 +49,7 @@ $transitionDuration: 100ms;
 
 .Tooltip_Popper_Inner {
 	transition: transform $transitionDuration $transitionEaseIn, transform-origin $transitionDuration $transitionEaseIn;
+	will-change: transform;
 
 	@at-root .Tooltip_Popper:not(.Tooltip_Popper__DoPreventTransitionOut) & {
 		transform: scale(0) translateX(0%) translateY(0%) translateZ(0);


### PR DESCRIPTION
**Audience:** Users | Engineers

**Summary:** The WorkspaceSwitcher animation performance was poor on first reveal and sometimes subsequent calls to show and/or hide. This fix removes the filter effect as it was identified as the culprit.

**Technical:** `filter: drop-shadow...` was not playing nice with `transition` so it was replaced with `box-shadow`. Several style instances of transition and box shadow were changed in conjunction with this change. In addition, `will-change` has been added as a performance measure to Popup and Tooltip.