### PR TITLE
improvement(LOC-898): upgrade to Pro in WorkspaceSwitcher

### DIFF
--- a/src/components/VerticalNav/README.md
+++ b/src/components/VerticalNav/README.md
@@ -10,6 +10,7 @@ const { WorkspaceSwitcher } = require('./components/WorkspaceSwitcher');
 	    	infoBannerUrl="#"
     		onClickAccount={() => console.log('onClickAccount')}
     		onClickAddTeam={() => console.log('onClickAddTeam')}
+    		onClickUpgradeToPro={() => console.log('onClickUpgradeToPro')}
     		onClickLogout={() => console.log('onClickLogout')}
     		onClickWorkspace={(workspace) => console.log('onClickWorkspace: ', workspace)}
 			routeTo="/main/users"
@@ -19,22 +20,26 @@ const { WorkspaceSwitcher } = require('./components/WorkspaceSwitcher');
 				{
 					id: 1,
 					isActive: true,
+					isPro: false,
 					isTeam: false,
 					src: "https://get.pxhere.com/photo/avatar-people-person-business-user-man-character-set-icon-portrait-profile-pictograph-hairstyle-jacket-suit-sunglasses-handsome-head-face-design-concept-symbol-smile-formal-elements-eyewear-vision-care-gentleman-male-shoulder-outerwear-necktie-businessperson-facial-hair-glasses-clip-art-human-behavior-white-collar-worker-neck-1447673.jpg"
 				},
 				{
 					id: 2,
+					isPro: false,
 					isTeam: true,
 					src: "https://upload.wikimedia.org/wikipedia/commons/1/10/Y_Combinator_Logo.png"
 				},
 				{
 					id: 3,
+					isPro: false,
 					isTeam: true,
 					isOwner: true,
 					src: "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSSRpQpaGpT1tDSZFY5KCxnC91NG3FYR56Fg3sjoQFaJfupST6Wbg"
 				},
 				{
 					id: 4,
+					isPro: false,
 					isTeam: true,
 					src: "https://upload.wikimedia.org/wikipedia/commons/d/dd/Windscreen_defrost.png"
 				},

--- a/src/components/VerticalNav/components/WorkspaceSwitcher.scss
+++ b/src/components/VerticalNav/components/WorkspaceSwitcher.scss
@@ -124,7 +124,7 @@
 		}
 	}
 
-	.WorkspaceSwitcher_PopupFooter {
+	.WorkspaceSwitcher_Section {
 		white-space: nowrap;
 		padding: 15px 20px 15px 20px;
 	}
@@ -135,7 +135,7 @@
 		margin: 0 auto;
 
 		& + button {
-			margin-top: 10px;
+			margin-top: 15px;
 		}
 	}
 

--- a/src/components/VerticalNav/components/WorkspaceSwitcher.tsx
+++ b/src/components/VerticalNav/components/WorkspaceSwitcher.tsx
@@ -21,6 +21,7 @@ interface IWorkspaceSwitcherProps extends IReactComponentProps {
 	onCloseInfoBanner?: Handler;
 	onClickManageTeam: Handler;
 	onClickLogout: Handler;
+	onClickUpgradeToPro: Handler;
 	onClickWorkspace: Handler;
 	onClickWorkspaceNav: Handler;
 	routeTo: string;
@@ -92,6 +93,7 @@ export class WorkspaceSwitcher extends React.Component<IWorkspaceSwitcherProps, 
 
 	render () {
 		const hasTeams = this.props.workspaces && !!this.props.workspaces.filter(workspaceItem => workspaceItem.isTeam).length;
+		const hasPro = this.props.workspaces && !!this.props.workspaces.filter(workspaceItem => workspaceItem.isPro).length;
 
 		return (
 			<VerticalNavItem
@@ -128,61 +130,75 @@ export class WorkspaceSwitcher extends React.Component<IWorkspaceSwitcherProps, 
 								</div>
 							)}
 						>
-							{ hasTeams &&
+							{ this.props.showInfoBanner && !this.state.isInfoBannerClosed &&
+								<div
+									className={styles.WorkspaceSwitcher_Popup_InfoContainer}
+									onClick={this.onCloseInfoBannerContainer}
+								>
+									<WarningSVG className={styles.WorkspaceSwitcher_Popup_WarningSvg}/>
+									<a href={this.props.infoBannerUrl} className={styles.WorkspaceSwitcher_Popup_Text}>What’s this?</a>
+									<span onClick={this.onCloseInfoBanner}>
+										<CloseSmallSVG className={styles.WorkspaceSwitcher_Popup_CloseSvg} />
+									</span>
+								</div>
+							}
+							<div
+								className={classnames(
+									styles.WorkspaceSwitcher_PopupGrid,
+									{
+										[styles.WorkspaceSwitcher_PopupGrid__WithTopPadding]: !this.props.showInfoBanner || this.state.isInfoBannerClosed,
+									},
+								)}
+							>
+								{this.props.workspaces.map((workspaceItem) => {
+									return (
+										<div key={workspaceItem.id} onClick={() => this.onSelect(workspaceItem)}>
+											<Avatar
+												className={classnames(
+													styles.WorkspaceSwitcher_PopupGridItem,
+													styles.WorkspaceSwitcher_Avatar,
+													{
+														[styles.WorkspaceSwitcher_PopupGridItem__Active]: workspaceItem.id === this.state.activeWorkspaceItem.id,
+														[styles.WorkspaceSwitcher_PopupGridItem__Team]: !workspaceItem.isTeam,
+													},
+												)}
+												color={workspaceItem.color}
+												initials={workspaceItem.initials}
+												placeholderSrc={workspaceItem.srcCache}
+												size="s"
+												type={workspaceItem.isTeam ? 'team' : 'user'}
+												src={workspaceItem.src}
+											/>
+										</div>
+									);
+								})}
+								<div
+									className={styles.WorkspaceSwitcher_PopupGridItemAdd}
+									onClick={this.props.onClickAddTeam}
+								>
+									<AddSVG />
+								</div>
+							</div>
+							<Divider />
+							{ !hasPro && !hasTeams &&
 								<>
-									{ this.props.showInfoBanner && !this.state.isInfoBannerClosed &&
-										<div
-											className={styles.WorkspaceSwitcher_Popup_InfoContainer}
-											onClick={this.onCloseInfoBannerContainer}
+									<div className={styles.WorkspaceSwitcher_Section}>
+										<Button
+											className="__Green"
+											onClick={this.props.onClickUpgradeToPro}
 										>
-											<WarningSVG className={styles.WorkspaceSwitcher_Popup_WarningSvg}/>
-											<a href={this.props.infoBannerUrl} className={styles.WorkspaceSwitcher_Popup_Text}>What’s this?</a>
-											<span onClick={this.onCloseInfoBanner}>
-												<CloseSmallSVG className={styles.WorkspaceSwitcher_Popup_CloseSvg} />
-											</span>
-										</div>
-									}
-									<div
-										className={classnames(
-											styles.WorkspaceSwitcher_PopupGrid,
-											{
-												[styles.WorkspaceSwitcher_PopupGrid__WithTopPadding]: !this.props.showInfoBanner || this.state.isInfoBannerClosed,
-											},
-										)}
-									>
-										{this.props.workspaces.map((workspaceItem) => {
-											return (
-												<div key={workspaceItem.id} onClick={() => this.onSelect(workspaceItem)}>
-													<Avatar
-														className={classnames(
-															styles.WorkspaceSwitcher_PopupGridItem,
-															styles.WorkspaceSwitcher_Avatar,
-															{
-																[styles.WorkspaceSwitcher_PopupGridItem__Active]: workspaceItem.id === this.state.activeWorkspaceItem.id,
-																[styles.WorkspaceSwitcher_PopupGridItem__Team]: !workspaceItem.isTeam,
-															},
-														)}
-														color={workspaceItem.color}
-														initials={workspaceItem.initials}
-														placeholderSrc={workspaceItem.srcCache}
-														size="s"
-														type={workspaceItem.isTeam ? 'team' : 'user'}
-														src={workspaceItem.src}
-													/>
-												</div>
-											);
-										})}
-										<div
-											className={styles.WorkspaceSwitcher_PopupGridItemAdd}
-											onClick={this.props.onClickAddTeam}
-										>
-											<AddSVG />
-										</div>
+											UPGRADE TO PRO
+										</Button>
 									</div>
 									<Divider />
 								</>
 							}
-							<div className={styles.WorkspaceSwitcher_PopupFooter}>
+							<div
+								className={classnames(
+									styles.WorkspaceSwitcher_PopupFooter,
+									styles.WorkspaceSwitcher_Section,
+								)}
+							>
 								<Button
 									className="__Green"
 									onClick={() => (
@@ -195,14 +211,6 @@ export class WorkspaceSwitcher extends React.Component<IWorkspaceSwitcherProps, 
 								>
 									{this.state.activeWorkspaceItem.isOwner ? 'Manage Team' : 'My Account'}
 								</Button>
-								{ !hasTeams &&
-									<Button
-										className="__Green"
-										onClick={this.props.onClickAddTeam}
-									>
-										Add a Team
-									</Button>
-								}
 								<Button
 									className="__Green"
 									onClick={this.props.onClickLogout}


### PR DESCRIPTION
**Audience:** Users | Engineers

**Summary:** Setup WorkspaceSwitcher to support upgrade to pro option.

**Technical:**
- Remove existing teams option
- Add 'isPro' prop
- Check for any paid seat and only show upgrade option if none exists

**Out of Scope**:
- the design calls for the workspace avatars to be centered horizontally but that's not being accounted for in this story

**Screenshots:**

Workspace Switcher with 'Upgrade To Pro' item
<img src="https://user-images.githubusercontent.com/41925404/59693130-0113fb80-91ac-11e9-856f-7a3fa1f17478.png" width="300">