### PR TITLE
style(LOC-777): add hover states to workspace switcher and adjust clip-path of avatars

### DIFF
--- a/src/components/ClippedContent/ClippedContent.sass
+++ b/src/components/ClippedContent/ClippedContent.sass
@@ -3,7 +3,7 @@
 .ClippedContent
 	display: flex
 	flex-direction: column
-	clip-path: inset(0 round 4px)
+	clip-path: inset(-1px 0 round 4px)
 
 	&.ClippedContent__AlignX
 		justify-content: center

--- a/src/components/VerticalNav/components/WorkspaceSwitcher.scss
+++ b/src/components/VerticalNav/components/WorkspaceSwitcher.scss
@@ -91,6 +91,11 @@
 			}
 		}
 
+		&:hover::after {
+			margin: -4px;
+			border-width: 4px;
+		}
+
 		&.WorkspaceSwitcher_PopupGridItem__Team::after {
 			border-radius: 50%;
 		}
@@ -98,9 +103,14 @@
 
 	.WorkspaceSwitcher_PopupGridItem.WorkspaceSwitcher_PopupGridItem__Active {
 		&::after {
-			margin: -2px;
+			margin: -4px;
 			border: 4px solid $green;
 			border-radius: 8px;
+		}
+
+		&:hover::after {
+			margin: -2px;
+			border-width: 2px;
 		}
 
 		&.WorkspaceSwitcher_PopupGridItem__Team::after {
@@ -121,6 +131,14 @@
 			width: 12px;
 			stroke: $gray75;
 			stroke-width: 2px;
+		}
+
+		&:hover {
+			background-color: $gray75;
+
+			svg {
+				stroke: $white;
+			}
 		}
 	}
 

--- a/src/components/VerticalNav/components/WorkspaceSwitcher.scss
+++ b/src/components/VerticalNav/components/WorkspaceSwitcher.scss
@@ -131,6 +131,10 @@
 			width: 12px;
 			stroke: $gray75;
 			stroke-width: 2px;
+
+			path {
+				fill: $gray75;
+			}
 		}
 
 		&:hover {
@@ -138,6 +142,10 @@
 
 			svg {
 				stroke: $white;
+
+				path {
+					fill: $white;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
**Audience:** Users | Engineers | Third-Party Developers

**Summary:** The workspace switcher is missing several hover states. This PR adds those styles while also adjusting the clip-path of avatars (via ImageCircle) to address alleged rounding issue that results in an unexpected y-start of the clip path.

**Screenshots:**

Before clip-path fix:
![image](https://user-images.githubusercontent.com/41925404/60292166-260e1a00-98e2-11e9-889e-08d90bdcc017.png)

After clip-path fix:
![image](https://user-images.githubusercontent.com/41925404/60292199-3625f980-98e2-11e9-8c57-e8f2a45c0595.png)

Inactive item (base vs hover):
![image](https://user-images.githubusercontent.com/41925404/60292318-72595a00-98e2-11e9-8aa9-052d53e3260b.png)

Active item (base vs hover):
![image](https://user-images.githubusercontent.com/41925404/60292602-13e0ab80-98e3-11e9-847c-34e363b21037.png)

Add button (base vs hover):
![image](https://user-images.githubusercontent.com/41925404/60292703-5d30fb00-98e3-11e9-93bf-a6b9eed1cee7.png)

