### PR TITLE
fix(LOC-972): use untildify instead of format-home-path to support Lightning

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
 	"license": "MIT",
 	"dependencies": {
 		"@getflywheel/memoize-one-ts": "^0.0.2",
+		"@types/untildify": "^3.0.0",
 		"classnames": "^2.2.6",
 		"highlight.js": "^9.13.1",
 		"lodash.isequal": "^4.5.0",
@@ -18,6 +19,7 @@
 		"react-resize-observer": "^1.1.1",
 		"react-router-dom": "^4.3.1",
 		"react-truncate-markup": "^3.0.0",
+		"untildify": "^4.0.0",
 		"url-parse": "^1.4.4"
 	},
 	"typescript": {

--- a/src/components/BrowseInput/BrowseInput.tsx
+++ b/src/components/BrowseInput/BrowseInput.tsx
@@ -3,18 +3,16 @@ import classnames from 'classnames';
 import * as styles from './BrowseInput.sass';
 import IReactComponentProps from '../../common/structures/IReactComponentProps';
 import Handler from '../../common/structures/Handler';
+import untildify = require('untildify');
 
 let remote: any;
 let dialog: any;
-let formatHomePath: any;
 
 try {
 	remote = require('electron').remote;
 	dialog = remote.dialog;
-	formatHomePath = remote.require('./helpers/format-home-path').default;
-}
-catch (e) {
-	console.warn(`Electron wasn't detected and BrowseInput won't function normally.`);
+} catch (e) {
+	console.warn(`Electron wasn't detected so BrowseInput won't function normally.`);
 }
 
 interface IProps extends IReactComponentProps {
@@ -56,7 +54,7 @@ export default class BrowseInput extends React.Component<IProps, IState> {
 
 	browseFolder () {
 		dialog.showOpenDialog(remote.getCurrentWindow(), {
-			'defaultPath': formatHomePath(this.state.value || this.props.defaultPath),
+			'defaultPath': untildify(this.state.value! || this.props.defaultPath!),
 			'properties': this.props.dialogProperties,
 			'title': this.props.dialogTitle,
 		}, (paths: any[]) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -563,6 +563,11 @@
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
   integrity sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==
 
+"@types/untildify@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@types/untildify/-/untildify-3.0.0.tgz#cd3e6624e46ccf292d3823fb48fa90dda0deaec0"
+  integrity sha512-FTktI3Y1h+gP9GTjTvXBP5v8xpH4RU6uS9POoBcGy4XkS2Np6LNtnP1eiNNth4S7P+qw2c/rugkwBasSHFzJEg==
+
 "@types/url-parse@^1.4.2":
   version "1.4.2"
   resolved "https://registry.yarnpkg.com/@types/url-parse/-/url-parse-1.4.2.tgz#e18928ac9a11b693266d0f37720c2a9611d8c85b"
@@ -9324,6 +9329,11 @@ unset-value@^1.0.0:
   dependencies:
     has-value "^0.3.1"
     isobject "^3.0.0"
+
+untildify@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/untildify/-/untildify-4.0.0.tgz#2bc947b953652487e4600949fb091e3ae8cd919b"
+  integrity sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==
 
 upath@^1.0.5:
   version "1.1.0"


### PR DESCRIPTION
**Summary:** Use `untildify` instead of the `format-home-path` helper in Local. 

**Context:** `format-home-path` is in a different location in Lightning, thus breaking existing requires like the one this PR resolves. Going forward, `local-components` should _not_ require anything directly from Local.