### PR TITLE
feat(LOC-1155): create TitleBar component

### DIFF
--- a/src/components/Container/Container.tsx
+++ b/src/components/Container/Container.tsx
@@ -59,7 +59,7 @@ export const Container = (props: IContainerProps) => {
 							...props.style,
 							...element.props.style,
 							...ContainerMarginHelper.getContainerMarginStyle(props),
-						}
+						},
 					},
 				)
 	);

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import classnames from 'classnames';
 import * as styles from './Header.sass';
 import Handler from '../../common/structures/Handler';
-import { Container } from '../Container/Container';
+import { Container } from '../Container';
 import ILocalContainerProps from '../../common/structures/ILocalContainerProps';
 
 interface IProps extends ILocalContainerProps {

--- a/src/components/TitleBar/README.md
+++ b/src/components/TitleBar/README.md
@@ -1,9 +1,14 @@
-The `TitleBar` component is used to create context around its functionality and is particularly useful for Add-ons located within inside of existing views, such as the table view, are naturally more likely to communicate their presence by default.
+The `TitleBar` component is used to create context around its functionality and is particularly useful for Add-ons located within inside of existing views.
 
 For more information on the `TitleBar` component and its use, please check out our [design system](https://build.localbyflywheel.com/project/designing-your-add-on/creating-your-layout#the-title-bar).
 
 ```js
-<TitleBar>
-	My Fantastic Add-on
+<TitleBar title="Add-on Title" />
+```
+
+```js
+<TitleBar title="Add-on with title">
+    and right-aligned content
 </TitleBar>
 ```
+

--- a/src/components/TitleBar/README.md
+++ b/src/components/TitleBar/README.md
@@ -1,0 +1,9 @@
+The `TitleBar` component is used to create context around its functionality and is particularly useful for Add-ons located within inside of existing views, such as the table view, are naturally more likely to communicate their presence by default.
+
+For more information on the `TitleBar` component and its use, please check out our [design system](https://build.localbyflywheel.com/project/designing-your-add-on/creating-your-layout#the-title-bar).
+
+```js
+<TitleBar>
+	My Fantastic Add-on
+</TitleBar>
+```

--- a/src/components/TitleBar/TitleBar.scss
+++ b/src/components/TitleBar/TitleBar.scss
@@ -1,0 +1,9 @@
+@import '../../styles/_partials/index';
+
+.TitleBar {
+	flex: 1; // fill width if within flexbox display (the assumption is that they would only be placing this component within a vertical flex direction)
+	width: 100%;
+	padding: 15px 30px;
+	font-weight: $font-weight-700-bold;
+	@include theme-background-gray15-else-graydark50;
+}

--- a/src/components/TitleBar/TitleBar.scss
+++ b/src/components/TitleBar/TitleBar.scss
@@ -1,9 +1,17 @@
 @import '../../styles/_partials/index';
 
 .TitleBar {
+	display: flex;
+	flex-direction: row;
+	justify-content: space-between;
 	flex: 1; // fill width if within flexbox display (the assumption is that they would only be placing this component within a vertical flex direction)
 	width: 100%;
-	padding: 15px 30px;
+	padding: 15px 20px 15px 30px;
 	font-weight: $font-weight-700-bold;
 	@include theme-background-gray15-else-graydark50;
+}
+
+.TitleBar_Content {
+	margin-left: 20px;
+	text-align: right;
 }

--- a/src/components/TitleBar/TitleBar.tsx
+++ b/src/components/TitleBar/TitleBar.tsx
@@ -1,0 +1,20 @@
+import * as React from 'react';
+import ILocalContainerProps from '../../common/structures/ILocalContainerProps';
+import * as styles from './TitleBar.scss';
+import classnames from 'classnames';
+import { Container } from '../Container';
+
+interface IProps extends ILocalContainerProps {}
+
+export const TitleBar = (props: IProps) => (
+	<Container>
+		<div
+			className={classnames(
+				styles.TitleBar,
+				'TitleBar',
+			)}
+		>
+			{props.children}
+		</div>
+	</Container>
+);

--- a/src/components/TitleBar/TitleBar.tsx
+++ b/src/components/TitleBar/TitleBar.tsx
@@ -4,7 +4,9 @@ import * as styles from './TitleBar.scss';
 import classnames from 'classnames';
 import { Container } from '../Container';
 
-interface IProps extends ILocalContainerProps {}
+interface IProps extends ILocalContainerProps {
+	title?: string;
+}
 
 export const TitleBar = (props: IProps) => (
 	<Container>
@@ -14,7 +16,12 @@ export const TitleBar = (props: IProps) => (
 				'TitleBar',
 			)}
 		>
-			{props.children}
+			{props.title}
+			{ props.children && (
+				<div className={styles.TitleBar_Content}>
+					{props.children}
+				</div>
+			)}
 		</div>
 	</Container>
 );

--- a/src/components/TitleBar/index.ts
+++ b/src/components/TitleBar/index.ts
@@ -1,0 +1,1 @@
+export { TitleBar } from './TitleBar';

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,6 +50,7 @@ export {TableList as TableList, TableListRow as TableListRow} from './components
 export {default as TableListRepeater} from './components/TableListRepeater';
 export {default as TabNav} from './components/TabNav';
 export {TertiaryNav as TertiaryNav, TertiaryNavItem as TertiaryNavItem} from './components/TertiaryNav';
+export {TitleBar} from './components/Titlebar';
 export {Tooltip} from './components/Tooltip';
 export {default as Truncate} from './components/Truncate';
 export {VerticalNav as VerticalNav, VerticalNavItem as VerticalNavItem} from './components/VerticalNav';


### PR DESCRIPTION
**Audience:** Third-party developers | Engineers

**Summary:** This adds an out-of-the-box TitleBar component for Add-on developers to easily implement while not having to worry about styles like font-sizes, font-weights, and dark mode text and background colors. The Local app also has several instances that could be refactored to use this component.

**Technical:** `TitleBar` takes a `title` prop as well as children content that will be right-aligned (if provided).

**Out of Scope:** In dark mode, several instances where this component is used have a border above it that's slightly lighter and creates a beveled look. This is not intentional and while a `margin-top: -1px` fix could resolve the issue, it's far from ideal to bake that into the base style of the component and thus has not been implemented.

**Screenshots:**
![image](https://user-images.githubusercontent.com/41925404/63357640-5a74e400-c32f-11e9-9d73-303ad6cb42a1.png)

![image](https://user-images.githubusercontent.com/41925404/63357576-44ffba00-c32f-11e9-94a9-c7258f517db7.png)

note: the font-weight below is not representative of how it will look in the app
![image](https://user-images.githubusercontent.com/41925404/63361863-88115b80-c336-11e9-96ae-28f2d79d3780.png)
