### PR TITLE
fix(LOC-1155): update content styles and update examples

### DIFF
--- a/src/components/TitleBar/README.md
+++ b/src/components/TitleBar/README.md
@@ -8,7 +8,13 @@ For more information on the `TitleBar` component and its use, please check out o
 
 ```js
 <TitleBar title="Add-on with title">
-    and right-aligned content
+    optional right content
 </TitleBar>
 ```
 
+```js
+<TitleBar title="Add-on with title">
+    <span>optional right content</span>
+    <a href="#">Action link</a>
+</TitleBar>
+```

--- a/src/components/TitleBar/TitleBar.scss
+++ b/src/components/TitleBar/TitleBar.scss
@@ -14,4 +14,13 @@
 .TitleBar_Content {
 	margin-left: 20px;
 	text-align: right;
+	font-weight: $font-weight-300-light;
+
+	> * {
+		margin-right: 10px;
+	}
+
+	> *:last-child {
+		margin-right: 0;
+	}
 }

--- a/src/components/TitleBar/TitleBar.tsx
+++ b/src/components/TitleBar/TitleBar.tsx
@@ -16,7 +16,9 @@ export const TitleBar = (props: IProps) => (
 				'TitleBar',
 			)}
 		>
-			{props.title}
+			<div>
+				{props.title}
+			</div>
 			{ props.children && (
 				<div className={styles.TitleBar_Content}>
 					{props.children}


### PR DESCRIPTION
**Audience:** Engineers | Add-on Developers

**Summary:** The right-content font-weight styles are wrong, there's no spacing added to children, and an additional example with text and a link is needed.

**Screenshot:**

![image](https://user-images.githubusercontent.com/41925404/63525936-24b53400-c4c4-11e9-81dd-670221865d75.png)