### PR TITLE
fix(LOC-1162): correct text sizes, colors, and add captions for Text component

### DIFF
--- a/src/common/helpers/ComponentExampleBase.tsx
+++ b/src/common/helpers/ComponentExampleBase.tsx
@@ -206,7 +206,7 @@ export class ComponentExampleBase extends React.Component<IReactComponentProps, 
 							key={item.propName}
 							className={styles.ComponentExample_Config_PropBlock}
 						>
-							<Title size={TitlePropSize.s} privateOptions={{fontWeight: TextBasePropFontWeight.bold}}>
+							<Title size={TitlePropSize.s} privateOptions={{fontWeight: TextBasePropFontWeight.heavy}}>
 								{item.propName}
 							</Title>
 							<div>

--- a/src/components/text/Text/Text.tsx
+++ b/src/components/text/Text/Text.tsx
@@ -9,12 +9,18 @@ import {
 	TextBasePropFontWeight,
 } from '../_private/TextBase/TextBase';
 
+export enum TextPropSize {
+	caption = 'caption',
+	m = 'm',
+}
+
 interface IProps extends ITextCommonProps {
 	privateOptions?: ITextBaseProps;
+	size?: TextPropSize | keyof typeof TextPropSize;
 }
 
 export const Text = (props: IProps) => {
-	const {className, privateOptions, ...otherProps} = props;
+	const {className, privateOptions, size, ...otherProps} = props;
 
 	return (
 		<TextBase
@@ -22,9 +28,9 @@ export const Text = (props: IProps) => {
 				'Text',
 				className,
 			)}
-			color={TextBasePropColor.gray_gray15_text}
-			fontSize={TextBasePropFontSize.m}
-			fontWeight={TextBasePropFontWeight.light}
+			color={size === TextPropSize.m ? TextBasePropColor.graydark_gray15_text : TextBasePropColor.gray_gray75_title}
+			fontSize={TextBasePropFontSize.s}
+			fontWeight={TextBasePropFontWeight.medium}
 			{...privateOptions}
 			{...otherProps}
 		/>
@@ -32,5 +38,6 @@ export const Text = (props: IProps) => {
 };
 
 Text.defaultProps = {
+	size: 'm',
 	tag: 'span',
 } as Partial<IProps>;

--- a/src/components/text/Text/Text.tsx
+++ b/src/components/text/Text/Text.tsx
@@ -30,7 +30,7 @@ export const Text = (props: IProps) => {
 			)}
 			color={size === TextPropSize.m ? TextBasePropColor.graydark_gray15_text : TextBasePropColor.gray_gray75_title}
 			fontSize={TextBasePropFontSize.s}
-			fontWeight={TextBasePropFontWeight.medium}
+			fontWeight={TextBasePropFontWeight.normal}
 			{...privateOptions}
 			{...otherProps}
 		/>

--- a/src/components/text/Text/examples/TextExample.tsx
+++ b/src/components/text/Text/examples/TextExample.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import IReactComponentProps from '../../../../common/structures/IReactComponentProps';
 import { ComponentExampleBase } from '../../../../common/helpers/ComponentExampleBase';
+import { TextPropSize } from '../Text';
 
 export class TextExample extends ComponentExampleBase {
 
@@ -14,6 +15,11 @@ export class TextExample extends ComponentExampleBase {
 					defaultValue: 'This is text.',
 					propName: 'content (children)',
 					type: 'html',
+				},
+				{
+					options: TextPropSize,
+					propName: 'size',
+					type: 'enum',
 				},
 				{
 					propName: 'tag',

--- a/src/components/text/Title/Title.tsx
+++ b/src/components/text/Title/Title.tsx
@@ -10,11 +10,11 @@ import {
 } from '../_private/TextBase/TextBase';
 
 export enum TitlePropSize {
+	caption = 'caption',
 	s = 's',
 	m = 'm',
 	l = 'l',
 	xl = 'xl',
-	caption = 'caption',
 }
 
 interface IProps extends ITextCommonProps {
@@ -31,8 +31,8 @@ export const Title = (props: IProps) => {
 				'Title',
 				className,
 			)}
-			color={setColorProp(size, TextBasePropColor.graydark_white_caption)}
-			fontSize={setSizeProp(size, TextBasePropFontSize.m)}
+			color={setColorProp(props, TextBasePropColor.graydark_white_caption)}
+			fontSize={setSizeProp(props, TextBasePropFontSize.m)}
 			fontWeight={TextBasePropFontWeight.medium}
 			{...privateOptions}
 			{...otherProps}
@@ -45,12 +45,12 @@ Title.defaultProps = {
 	tag: 'div',
 } as Partial<IProps>;
 
-function setSizeProp (size: TitlePropSize | keyof typeof TitlePropSize | undefined, defaultValue: TextBasePropFontSize): TextBasePropFontSize {
-	switch (size) {
+function setSizeProp (props: IProps, defaultValue: TextBasePropFontSize): TextBasePropFontSize {
+	switch (props.size) {
 		case TitlePropSize.s:
+		case TitlePropSize.caption:
 			return TextBasePropFontSize.s;
 		case TitlePropSize.m:
-		case TitlePropSize.caption:
 			return TextBasePropFontSize.m;
 		case TitlePropSize.l:
 			return TextBasePropFontSize.l;
@@ -61,8 +61,8 @@ function setSizeProp (size: TitlePropSize | keyof typeof TitlePropSize | undefin
 	return defaultValue;
 }
 
-function setColorProp (size: TitlePropSize | keyof typeof TitlePropSize | undefined, defaultColor: TextBasePropColor): TextBasePropColor {
-	switch (size) {
+function setColorProp (props: IProps, defaultColor: TextBasePropColor): TextBasePropColor {
+	switch (props.size) {
 		case TitlePropSize.caption:
 			return TextBasePropColor.gray_gray75_title;
 	}

--- a/src/components/text/Title/Title.tsx
+++ b/src/components/text/Title/Title.tsx
@@ -33,7 +33,7 @@ export const Title = (props: IProps) => {
 			)}
 			color={setColorProp(props, TextBasePropColor.graydark_white_caption)}
 			fontSize={setSizeProp(props, TextBasePropFontSize.m)}
-			fontWeight={TextBasePropFontWeight.medium}
+			fontWeight={TextBasePropFontWeight.bold}
 			{...privateOptions}
 			{...otherProps}
 		/>

--- a/src/components/text/_private/TextBase/TextBase.scss
+++ b/src/components/text/_private/TextBase/TextBase.scss
@@ -11,12 +11,12 @@
 	// css variable-based styles
 	color: var(--TextBase_TextColor);
 
-	&.TextBase__Color_Gray_Gray15 {
-		@include setThemeVar('--TextBase_TextColor', $gray, $gray15);
-	}
-
 	&.TextBase__Color_Gray_Gray75 {
 		@include setThemeVar('--TextBase_TextColor', $gray, $gray75);
+	}
+
+	&.TextBase__Color_GrayDark_Gray15 {
+		@include setThemeVar('--TextBase_TextColor', $gray-dark, $gray15);
 	}
 
 	&.TextBase__Color_GrayDark_White {
@@ -39,23 +39,15 @@
 		font-size: 4.2rem;
 	}
 
-	&.TextBase__FontWeight_300Light {
+	&.TextBase__FontWeight_300 {
 		font-weight: $font-weight-300-light;
 	}
 
-	&.TextBase__FontWeight_400Normal {
-		font-weight: $font-weight-400-normal;
-	}
-
-	&.TextBase__FontWeight_500Medium {
+	&.TextBase__FontWeight_500 {
 		font-weight: $font-weight-500-medium;
 	}
 
-	&.TextBase__FontWeight_700Bold {
+	&.TextBase__FontWeight_700 {
 		font-weight: $font-weight-700-bold;
-	}
-
-	&.TextBase__FontWeight_900Heavy {
-		font-weight: $font-weight-900-heavy;
 	}
 }

--- a/src/components/text/_private/TextBase/TextBase.tsx
+++ b/src/components/text/_private/TextBase/TextBase.tsx
@@ -5,8 +5,8 @@ import ILocalContainerProps from '../../../../common/structures/ILocalContainerP
 import { Container } from '../../../Container';
 
 export enum TextBasePropColor {
-	gray_gray15_text = 'gray_gray15_text',
 	gray_gray75_title = 'gray_gray75_title',
+	graydark_gray15_text = 'graydark_gray15_text',
 	graydark_white_caption = 'graydark_white_caption',
 }
 export enum TextBasePropFontSize {
@@ -17,11 +17,9 @@ export enum TextBasePropFontSize {
 }
 
 export enum TextBasePropFontWeight {
-	light = 'light',
 	normal = 'normal',
 	medium = 'medium',
 	bold = 'bold',
-	heavy = 'heavy',
 }
 
 export interface ITextCommonProps extends ILocalContainerProps {
@@ -43,7 +41,7 @@ export class TextBase extends React.Component<ITextBaseProps> {
 	static defaultProps: Partial<ITextBaseProps> = {
 		color: TextBasePropColor.graydark_white_caption,
 		fontSize: TextBasePropFontSize.s,
-		fontWeight: TextBasePropFontWeight.light,
+		fontWeight: TextBasePropFontWeight.medium,
 		tag: 'span',
 	};
 
@@ -59,18 +57,16 @@ export class TextBase extends React.Component<ITextBaseProps> {
 						'TextBase',
 						className,
 						{
-							[styles.TextBase__Color_Gray_Gray15]: color === TextBasePropColor.gray_gray15_text,
 							[styles.TextBase__Color_Gray_Gray75]: color === TextBasePropColor.gray_gray75_title,
+							[styles.TextBase__Color_GrayDark_Gray15]: color === TextBasePropColor.graydark_gray15_text,
 							[styles.TextBase__Color_GrayDark_White]: color === TextBasePropColor.graydark_white_caption,
 							[styles.TextBase__FontSize_Small]: fontSize === TextBasePropFontSize.s,
 							[styles.TextBase__FontSize_Medium]: fontSize === TextBasePropFontSize.m,
 							[styles.TextBase__FontSize_Large]: fontSize === TextBasePropFontSize.l,
 							[styles.TextBase__FontSize_XLarge]: fontSize === TextBasePropFontSize.xl,
-							[styles.TextBase__FontWeight_300Light]: fontWeight === TextBasePropFontWeight.light,
-							[styles.TextBase__FontWeight_400Normal]: fontWeight === TextBasePropFontWeight.normal,
-							[styles.TextBase__FontWeight_500Medium]: fontWeight === TextBasePropFontWeight.medium,
-							[styles.TextBase__FontWeight_700Bold]: fontWeight === TextBasePropFontWeight.bold,
-							[styles.TextBase__FontWeight_900Heavy]: fontWeight === TextBasePropFontWeight.heavy,
+							[styles.TextBase__FontWeight_300]: fontWeight === TextBasePropFontWeight.normal,
+							[styles.TextBase__FontWeight_500]: fontWeight === TextBasePropFontWeight.medium,
+							[styles.TextBase__FontWeight_700]: fontWeight === TextBasePropFontWeight.bold,
 						},
 					)}
 					{...otherProps}

--- a/src/components/text/_private/TextBase/TextBase.tsx
+++ b/src/components/text/_private/TextBase/TextBase.tsx
@@ -18,8 +18,8 @@ export enum TextBasePropFontSize {
 
 export enum TextBasePropFontWeight {
 	normal = 'normal',
-	medium = 'medium',
 	bold = 'bold',
+	heavy = 'heavy',
 }
 
 export interface ITextCommonProps extends ILocalContainerProps {
@@ -41,7 +41,7 @@ export class TextBase extends React.Component<ITextBaseProps> {
 	static defaultProps: Partial<ITextBaseProps> = {
 		color: TextBasePropColor.graydark_white_caption,
 		fontSize: TextBasePropFontSize.s,
-		fontWeight: TextBasePropFontWeight.medium,
+		fontWeight: TextBasePropFontWeight.normal,
 		tag: 'span',
 	};
 
@@ -65,8 +65,8 @@ export class TextBase extends React.Component<ITextBaseProps> {
 							[styles.TextBase__FontSize_Large]: fontSize === TextBasePropFontSize.l,
 							[styles.TextBase__FontSize_XLarge]: fontSize === TextBasePropFontSize.xl,
 							[styles.TextBase__FontWeight_300]: fontWeight === TextBasePropFontWeight.normal,
-							[styles.TextBase__FontWeight_500]: fontWeight === TextBasePropFontWeight.medium,
-							[styles.TextBase__FontWeight_700]: fontWeight === TextBasePropFontWeight.bold,
+							[styles.TextBase__FontWeight_500]: fontWeight === TextBasePropFontWeight.bold,
+							[styles.TextBase__FontWeight_700]: fontWeight === TextBasePropFontWeight.heavy,
 						},
 					)}
 					{...otherProps}


### PR DESCRIPTION
**Audience:** Engineers | Add-on Developers

**Summary:** There were some discrepancies between the design and implementation for sizes and colors in addition to Text captions not being exposed publicly. This PR corrects those. 