### PR TITLE
fix(LOC-1158): add Button intents back in with expected 'fill' form

### DIFF
--- a/src/components/buttons/Button/Button.tsx
+++ b/src/components/buttons/Button/Button.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import classnames from 'classnames';
 import {
 	ButtonBase,
 	ButtonPropColor,
@@ -6,14 +7,21 @@ import {
 	ButtonPropPadding, IButtonBaseProps,
 	IButtonCommonProps,
 } from '../ButtonBase/ButtonBase';
-import classnames from 'classnames';
+
+export enum ButtonPropIntent {
+	alert = 'alert',
+	default = 'default',
+	destructive = 'destructive',
+	success = 'success',
+}
 
 interface IProps extends IButtonCommonProps {
+	intent?: ButtonPropIntent | keyof typeof ButtonPropIntent;
 	privateOptions?: IButtonBaseProps;
 }
 
 export const Button = (props: IProps) => {
-	const {className, privateOptions, ...otherProps} = props;
+	const {className, intent, privateOptions, ...otherProps} = props;
 
 	return (
 		<ButtonBase
@@ -21,8 +29,8 @@ export const Button = (props: IProps) => {
 				className,
 				'Button',
 			)}
-			color={ButtonPropColor.gray}
-			form={ButtonPropForm.outline}
+			color={setIntentColor(props, ButtonPropColor.gray)}
+			form={setForm(props, ButtonPropForm.outline)}
 			padding={ButtonPropPadding.m}
 			{...privateOptions}
 			{...otherProps}
@@ -30,7 +38,32 @@ export const Button = (props: IProps) => {
 	);
 };
 
+function setIntentColor (props: IProps, defaultValue: ButtonPropColor): ButtonPropColor {
+	switch (props.intent) {
+		case ButtonPropIntent.alert:
+			return ButtonPropColor.orange;
+		case ButtonPropIntent.destructive:
+			return ButtonPropColor.red;
+		case ButtonPropIntent.success:
+			return ButtonPropColor.green;
+	}
+
+	return defaultValue;
+}
+
+function setForm (props: IProps, defaultValue: ButtonPropForm): ButtonPropForm {
+	switch (props.intent) {
+		case ButtonPropIntent.alert:
+		case ButtonPropIntent.destructive:
+		case ButtonPropIntent.success:
+			return ButtonPropForm.fill;
+	}
+
+	return defaultValue;
+}
+
 Button.defaultProps = {
 	disabled: ButtonBase.defaultProps.disabled,
+	intent: ButtonPropIntent.default,
 	tag: ButtonBase.defaultProps.tag,
 } as Partial<IProps>;

--- a/src/components/buttons/Button/examples/ButtonExample.tsx
+++ b/src/components/buttons/Button/examples/ButtonExample.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import IReactComponentProps from '../../../../common/structures/IReactComponentProps';
 import { ComponentExampleBase } from '../../../../common/helpers/ComponentExampleBase';
-import { Button } from '../Button';
+import { Button, ButtonPropIntent } from '../Button';
 
 export class ButtonExample extends ComponentExampleBase {
 
@@ -15,6 +15,11 @@ export class ButtonExample extends ComponentExampleBase {
 					defaultValue: 'Secondary Button',
 					propName: 'content (children)',
 					type: 'html',
+				},
+				{
+					options: ButtonPropIntent,
+					propName: 'intent',
+					type: 'enum',
 				},
 				{
 					propName: 'tag',


### PR DESCRIPTION
**Audience:** Engineers | Add-on Developers

**Summary:** Intents need to be reintroduced within the `Button` component with intended `fill` form and subsequent styles.