### PR TITLE
refactor(LOC-1162): change Text size prop value from `m` to `default`

### DIFF
--- a/src/components/text/Text/Text.tsx
+++ b/src/components/text/Text/Text.tsx
@@ -11,7 +11,7 @@ import {
 
 export enum TextPropSize {
 	caption = 'caption',
-	m = 'm',
+	default = 'default',
 }
 
 interface IProps extends ITextCommonProps {
@@ -28,7 +28,7 @@ export const Text = (props: IProps) => {
 				'Text',
 				className,
 			)}
-			color={size === TextPropSize.m ? TextBasePropColor.graydark_gray15_text : TextBasePropColor.gray_gray75_title}
+			color={size === TextPropSize.default ? TextBasePropColor.graydark_gray15_text : TextBasePropColor.gray_gray75_title}
 			fontSize={TextBasePropFontSize.s}
 			fontWeight={TextBasePropFontWeight.normal}
 			{...privateOptions}
@@ -38,6 +38,6 @@ export const Text = (props: IProps) => {
 };
 
 Text.defaultProps = {
-	size: 'm',
+	size: 'default',
 	tag: 'span',
 } as Partial<IProps>;


### PR DESCRIPTION
**Audience:** Add-on Developers

**Summary:** Change default `size` prop option from `m` to `default` since there are no other t-shirt sizes for this component.

**Screenshots:** 
![image](https://user-images.githubusercontent.com/41925404/64179691-359d6800-ce29-11e9-9caf-dd6a0f49575a.png)
