### PR TITLE
fix(LOC-1158): remove Button intent styles `alert` and `success`

### DIFF
--- a/src/components/buttons/Button/Button.tsx
+++ b/src/components/buttons/Button/Button.tsx
@@ -9,10 +9,8 @@ import {
 } from '../ButtonBase/ButtonBase';
 
 export enum ButtonPropIntent {
-	alert = 'alert',
 	default = 'default',
 	destructive = 'destructive',
-	success = 'success',
 }
 
 interface IProps extends IButtonCommonProps {
@@ -40,12 +38,8 @@ export const Button = (props: IProps) => {
 
 function setIntentColor (props: IProps, defaultValue: ButtonPropColor): ButtonPropColor {
 	switch (props.intent) {
-		case ButtonPropIntent.alert:
-			return ButtonPropColor.orange;
 		case ButtonPropIntent.destructive:
 			return ButtonPropColor.red;
-		case ButtonPropIntent.success:
-			return ButtonPropColor.green;
 	}
 
 	return defaultValue;
@@ -53,9 +47,7 @@ function setIntentColor (props: IProps, defaultValue: ButtonPropColor): ButtonPr
 
 function setForm (props: IProps, defaultValue: ButtonPropForm): ButtonPropForm {
 	switch (props.intent) {
-		case ButtonPropIntent.alert:
 		case ButtonPropIntent.destructive:
-		case ButtonPropIntent.success:
 			return ButtonPropForm.fill;
 	}
 


### PR DESCRIPTION
**Audience:** Engineers | Add-on Developers

**Summary:** Buttons styles for `alert` and `success` only exist for reversed/ghost appearance and that's not currently supported so those need to be removed.

**Screenshot:** 
![image](https://user-images.githubusercontent.com/41925404/64180966-4949ce00-ce2b-11e9-90e9-c8cdd1ecff97.png)
