### PR TITLE
refactor(LOC-1213): remove individual component index.ts files and reference them directly

### DIFF
--- a/src/components/alerts/Banner/index.ts
+++ b/src/components/alerts/Banner/index.ts
@@ -1,1 +1,0 @@
-export {default} from './Banner';

--- a/src/components/alerts/BannerCarousel/README.md
+++ b/src/components/alerts/BannerCarousel/README.md
@@ -1,7 +1,7 @@
 BannerCarousel example:
 
 ```js
-import Banner from '../Banner';
+import Banner from '../Banner/Banner';
 
 <BannerCarousel>
     <Banner variant="neutral" icon="warning" buttonText="Click Me!"

--- a/src/components/alerts/BannerCarousel/index.ts
+++ b/src/components/alerts/BannerCarousel/index.ts
@@ -1,1 +1,0 @@
-export {default} from './BannerCarousel';

--- a/src/components/alerts/FlyLargeConfirm/index.ts
+++ b/src/components/alerts/FlyLargeConfirm/index.ts
@@ -1,1 +1,0 @@
-export {default} from './FlyLargeConfirm';

--- a/src/components/buttons/Close/index.ts
+++ b/src/components/buttons/Close/index.ts
@@ -1,1 +1,0 @@
-export {default} from './Close';

--- a/src/components/buttons/_private/ButtonBase/ButtonBase.tsx
+++ b/src/components/buttons/_private/ButtonBase/ButtonBase.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import classnames from 'classnames';
 import * as styles from './ButtonBase.scss';
 import ILocalContainerProps from '../../../../common/structures/ILocalContainerProps';
-import { Container } from '../../../modules/Container';
+import { Container } from '../../../modules/Container/Container';
 
 export enum ButtonPropColor {
 	default = 'default',

--- a/src/components/inputs/BrowseInput/index.ts
+++ b/src/components/inputs/BrowseInput/index.ts
@@ -1,1 +1,0 @@
-export {default} from './BrowseInput';

--- a/src/components/inputs/Checkbox/index.ts
+++ b/src/components/inputs/Checkbox/index.ts
@@ -1,1 +1,0 @@
-export {default} from './Checkbox';

--- a/src/components/inputs/FlyDropdown/index.ts
+++ b/src/components/inputs/FlyDropdown/index.ts
@@ -1,1 +1,0 @@
-export {default} from './FlyDropdown';

--- a/src/components/inputs/FlySelect/README.md
+++ b/src/components/inputs/FlySelect/README.md
@@ -48,7 +48,7 @@ Constrained Width:
 
 Using an Avatar within a form FlySelect:
 ```js
-import Avatar from '../../media/Avatar';
+import Avatar from '../../media/Avatar/Avatar';
 
 <div>
 	<div className="FormRow">

--- a/src/components/inputs/FlySelect/index.ts
+++ b/src/components/inputs/FlySelect/index.ts
@@ -1,1 +1,0 @@
-export {default} from './FlySelect';

--- a/src/components/inputs/InputPasswordToggle/index.ts
+++ b/src/components/inputs/InputPasswordToggle/index.ts
@@ -1,1 +1,0 @@
-export {default} from './InputPasswordToggle';

--- a/src/components/inputs/InputSearch/index.ts
+++ b/src/components/inputs/InputSearch/index.ts
@@ -1,1 +1,0 @@
-export {default} from './InputSearch';

--- a/src/components/inputs/RadioBlock/README.md
+++ b/src/components/inputs/RadioBlock/README.md
@@ -68,7 +68,7 @@ Medium size RadioBlock:
 Disable the 2nd item and show a tooltip on hover:
 
 ```js
-import { Tooltip } from '../../overlays/Tooltip';
+import { Tooltip } from '../../overlays/Tooltip/Tooltip';
 
 <RadioBlock heightSize="m" onChange={() => console.log('onChange')} default={'test1'} options={{
     'test1': {

--- a/src/components/inputs/RadioBlock/index.ts
+++ b/src/components/inputs/RadioBlock/index.ts
@@ -1,1 +1,0 @@
-export {default} from './RadioBlock';

--- a/src/components/inputs/Switch/index.ts
+++ b/src/components/inputs/Switch/index.ts
@@ -1,1 +1,0 @@
-export {default} from './Switch';

--- a/src/components/layout/AdvancedToggle/AdvancedToggle.test.tsx
+++ b/src/components/layout/AdvancedToggle/AdvancedToggle.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
-import AdvancedToggle from './index';
+import AdvancedToggle from './AdvancedToggle';
 
 it('renders without crashing', () => {
 	shallow(<AdvancedToggle />);

--- a/src/components/layout/AdvancedToggle/index.ts
+++ b/src/components/layout/AdvancedToggle/index.ts
@@ -1,1 +1,0 @@
-export {default} from './AdvancedToggle';

--- a/src/components/layout/Divider/index.ts
+++ b/src/components/layout/Divider/index.ts
@@ -1,1 +1,0 @@
-export {default} from './Divider';

--- a/src/components/loaders/BigLoader/BigLoader.tsx
+++ b/src/components/loaders/BigLoader/BigLoader.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import IReactComponentProps from '../../../common/structures/IReactComponentProps';
 import classnames from 'classnames';
 import * as styles from './BigLoader.sass';
-import LoadingIndicator from '../LoadingIndicator/index';
+import LoadingIndicator from '../LoadingIndicator/LoadingIndicator';
 
 interface IProps extends IReactComponentProps {
 

--- a/src/components/loaders/BigLoader/index.ts
+++ b/src/components/loaders/BigLoader/index.ts
@@ -1,1 +1,0 @@
-export {default} from './BigLoader';

--- a/src/components/loaders/DownloaderItem/DownloaderItem.tsx
+++ b/src/components/loaders/DownloaderItem/DownloaderItem.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import IReactComponentProps from '../../../common/structures/IReactComponentProps';
-import ProgressBar from '../ProgressBar/index';
+import ProgressBar from '../ProgressBar/ProgressBar';
 import { TextButton } from '../../buttons/TextButton/TextButton';
 
 const { ipcRenderer } = require('electron');

--- a/src/components/loaders/DownloaderItem/index.ts
+++ b/src/components/loaders/DownloaderItem/index.ts
@@ -1,1 +1,0 @@
-export {default} from './DownloaderItem';

--- a/src/components/loaders/InstallerStepStatus/index.ts
+++ b/src/components/loaders/InstallerStepStatus/index.ts
@@ -1,1 +1,0 @@
-export {default} from './InstallerStepStatus';

--- a/src/components/loaders/LoadingIndicator/index.ts
+++ b/src/components/loaders/LoadingIndicator/index.ts
@@ -1,1 +1,0 @@
-export {default} from './LoadingIndicator';

--- a/src/components/loaders/ProgressBar/index.ts
+++ b/src/components/loaders/ProgressBar/index.ts
@@ -1,1 +1,0 @@
-export {default} from './ProgressBar';

--- a/src/components/loaders/Spinner/index.ts
+++ b/src/components/loaders/Spinner/index.ts
@@ -1,1 +1,0 @@
-export {default} from './Spinner';

--- a/src/components/media/Avatar/Avatar.tsx
+++ b/src/components/media/Avatar/Avatar.tsx
@@ -2,8 +2,8 @@ import * as React from 'react';
 import IReactComponentProps from '../../../common/structures/IReactComponentProps';
 import * as styles from './Avatar.sass';
 import classnames from 'classnames';
-import ImageCircle from '../ImageCircle/index';
-import ClippedContent from '../../modules/ClippedContent/index';
+import ImageCircle from '../ImageCircle/ImageCircle';
+import ClippedContent from '../../modules/ClippedContent/ClippedContent';
 
 interface IProps extends IReactComponentProps {
 

--- a/src/components/media/Avatar/index.ts
+++ b/src/components/media/Avatar/index.ts
@@ -1,1 +1,0 @@
-export {default} from './Avatar';

--- a/src/components/media/ImageCircle/ImageCircle.tsx
+++ b/src/components/media/ImageCircle/ImageCircle.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import classnames from 'classnames';
 import * as styles from './ImageCircle.sass';
 import IReactComponentProps from '../../../common/structures/IReactComponentProps';
-import ClippedContent from '../../modules/ClippedContent/index';
+import ClippedContent from '../../modules/ClippedContent/ClippedContent';
 
 interface IProps extends IReactComponentProps {
 

--- a/src/components/media/ImageCircle/index.ts
+++ b/src/components/media/ImageCircle/index.ts
@@ -1,1 +1,0 @@
-export {default} from './ImageCircle';

--- a/src/components/menus/Drawer/index.ts
+++ b/src/components/menus/Drawer/index.ts
@@ -1,1 +1,0 @@
-export {default} from './Drawer';

--- a/src/components/menus/Stepper/README.md
+++ b/src/components/menus/Stepper/README.md
@@ -1,5 +1,5 @@
 ```js
-import { Step } from './index';
+import { Step } from './Stepper';
 
 <Stepper>
     <Step number={1} done={false} active={true}>Setup Site</Step>

--- a/src/components/menus/Stepper/index.ts
+++ b/src/components/menus/Stepper/index.ts
@@ -1,1 +1,0 @@
-export { Stepper, Step } from './Stepper';

--- a/src/components/menus/TabNav/index.ts
+++ b/src/components/menus/TabNav/index.ts
@@ -1,1 +1,0 @@
-export {default} from './TabNav';

--- a/src/components/menus/TertiaryNav/index.ts
+++ b/src/components/menus/TertiaryNav/index.ts
@@ -1,1 +1,0 @@
-export {TertiaryNav, TertiaryNavItem} from './TertiaryNav';

--- a/src/components/modules/Card/index.ts
+++ b/src/components/modules/Card/index.ts
@@ -1,1 +1,0 @@
-export {default} from './Card';

--- a/src/components/modules/ClippedContent/index.ts
+++ b/src/components/modules/ClippedContent/index.ts
@@ -1,1 +1,0 @@
-export {default} from './ClippedContent';

--- a/src/components/modules/Container/README.md
+++ b/src/components/modules/Container/README.md
@@ -17,7 +17,7 @@ There's a powerful margin system built into Container that allows for:
 The following example shows how to use Container to add margin around an element in shorthand vertical / horizontal form:
 
 ```js
-import Card from '../Card';
+import Card from '../Card/Card';
 
 <Container margin="m s xl">
 	<Card>
@@ -29,7 +29,7 @@ import Card from '../Card';
 It's equally as easy to add individual margin props.
 
 ```js
-import Card from '../Card';
+import Card from '../Card/Card';
 
 <Container marginLeft="xl">
 	<Card>
@@ -41,7 +41,7 @@ import Card from '../Card';
 These margin props can also handle simple plus / minus arithmatic for both shorthand and individual margin properties.
 
 ```js
-import Card from '../Card';
+import Card from '../Card/Card';
 
 <Container margin="xl+xl -s xl-15 m">
 	<Card>

--- a/src/components/modules/Container/index.ts
+++ b/src/components/modules/Container/index.ts
@@ -1,1 +1,0 @@
-export { Container } from './Container';

--- a/src/components/modules/DragBar/index.ts
+++ b/src/components/modules/DragBar/index.ts
@@ -1,1 +1,0 @@
-export {default} from './DragBar';

--- a/src/components/modules/EmptyArea/index.ts
+++ b/src/components/modules/EmptyArea/index.ts
@@ -1,1 +1,0 @@
-export {EmptyArea} from './EmptyArea';

--- a/src/components/modules/InnerPaneSidebar/index.ts
+++ b/src/components/modules/InnerPaneSidebar/index.ts
@@ -1,7 +1,0 @@
-export {
-	InnerPaneSidebar,
-	InnerPaneSidebarHeader,
-	InnerPaneSidebarAddNew,
-	InnerPaneSidebarContent,
-	InnerPaneSidebarContentItem,
-} from './InnerPaneSidebar';

--- a/src/components/modules/Markdown/index.ts
+++ b/src/components/modules/Markdown/index.ts
@@ -1,1 +1,0 @@
-export {default} from './Markdown';

--- a/src/components/modules/SiteInfoInnerPane/README.md
+++ b/src/components/modules/SiteInfoInnerPane/README.md
@@ -27,9 +27,9 @@ With `<InnerPaneSidebar />`:
 
 ```js
 import { TableList, TableListRow } from '../../tables/TableList/TableList';
-import { EmptyArea } from '../EmptyArea';
+import { EmptyArea } from '../EmptyArea/EmptyArea';
 import { Button } from '../../buttons/Button/Button';
-import { InnerPaneSidebar, InnerPaneSidebarHeader, InnerPaneSidebarContent } from '../InnerPaneSidebar';
+import { InnerPaneSidebar, InnerPaneSidebarHeader, InnerPaneSidebarContent } from '../InnerPaneSidebar/InnerPaneSidebar';
 
 <SiteInfoInnerPane>
     <TableList>

--- a/src/components/modules/SiteInfoInnerPane/index.ts
+++ b/src/components/modules/SiteInfoInnerPane/index.ts
@@ -1,1 +1,0 @@
-export {default} from './SiteInfoInnerPane';

--- a/src/components/modules/TitleBar/TitleBar.tsx
+++ b/src/components/modules/TitleBar/TitleBar.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import ILocalContainerProps from '../../../common/structures/ILocalContainerProps';
 import * as styles from './TitleBar.scss';
 import classnames from 'classnames';
-import { Container } from '../Container';
+import { Container } from '../Container/Container';
 
 interface IProps extends ILocalContainerProps {
 	title?: string;

--- a/src/components/modules/TitleBar/index.ts
+++ b/src/components/modules/TitleBar/index.ts
@@ -1,1 +1,0 @@
-export { TitleBar } from './TitleBar';

--- a/src/components/modules/VerticalNav/README.md
+++ b/src/components/modules/VerticalNav/README.md
@@ -83,7 +83,7 @@ import { WorkspaceSwitcher } from '../../modules/VerticalNav/components/Workspac
 _Note the lack of top padding._
 
 ```js
-import FlyTooltip from '../../overlays/FlyTooltip';
+import FlyTooltip from '../../overlays/FlyTooltip/FlyTooltip';
 
 <div className="__OsWindows" style={{ height: '300px' }}>
     <VerticalNav location={{ pathname: '' }}>

--- a/src/components/modules/VerticalNav/components/WorkspaceSwitcher.tsx
+++ b/src/components/modules/VerticalNav/components/WorkspaceSwitcher.tsx
@@ -5,7 +5,7 @@ import * as stylesVerticalNav from '../VerticalNav.scss';
 import Popup from '../../../overlays/Popup/Popup';
 import Divider from '../../../layout/Divider/Divider';
 import AddSVG from '../../../../svg/add';
-import Avatar from '../../../media/Avatar';
+import Avatar from '../../../media/Avatar/Avatar';
 import IReactComponentProps from '../../../../common/structures/IReactComponentProps';
 import { VerticalNavItem } from '../VerticalNav';
 import CloseSmallSVG from '../../../../svg/close--small';

--- a/src/components/modules/VerticalNav/index.ts
+++ b/src/components/modules/VerticalNav/index.ts
@@ -1,2 +1,0 @@
-export { VerticalNav, VerticalNavItem } from './VerticalNav';
-export { WorkspaceSwitcher } from './components/WorkspaceSwitcher';

--- a/src/components/modules/VirtualList/examples/VirtualListExample.tsx
+++ b/src/components/modules/VirtualList/examples/VirtualListExample.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import * as styles from './VirtualListExample.scss';
 import { VirtualList } from '../VirtualList';
-import Divider from '../../../layout/Divider/index';
-import Checkbox from '../../../inputs/Checkbox/index';
+import Divider from '../../../layout/Divider/Divider';
+import Checkbox from '../../../inputs/Checkbox/Checkbox';
 import IReactComponentProps from '../../../../common/structures/IReactComponentProps';
 
 import { IVirtualListHelperCalculations } from '../helpers/VirtualListHelper';

--- a/src/components/modules/VirtualList/index.ts
+++ b/src/components/modules/VirtualList/index.ts
@@ -1,1 +1,0 @@
-export { VirtualList } from './VirtualList';

--- a/src/components/modules/VirtualTable/VirtualTable.tsx
+++ b/src/components/modules/VirtualTable/VirtualTable.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { VirtualList } from '../VirtualList';
+import { VirtualList } from '../VirtualList/VirtualList';
 import IReactComponentProps from '../../../common/structures/IReactComponentProps';
 import { VirtualTableRow } from './components/VirtualTableRow';
 import classnames from 'classnames';

--- a/src/components/modules/VirtualTable/examples/VirtualTableExample.tsx
+++ b/src/components/modules/VirtualTable/examples/VirtualTableExample.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
 import * as styles from './VirtualTableExample.scss';
 import IReactComponentProps from '../../../../common/structures/IReactComponentProps';
-import Checkbox from '../../../inputs/Checkbox/index';
-import FlySelect from '../../../inputs/FlySelect/index';
-import Divider from '../../../layout/Divider/index';
+import Checkbox from '../../../inputs/Checkbox/Checkbox';
+import FlySelect from '../../../inputs/FlySelect/FlySelect';
+import Divider from '../../../layout/Divider/Divider';
 import { IVirtualTableCellRendererDataArgs, VirtualTable } from '../VirtualTable';
 
 interface IDataObject {

--- a/src/components/modules/VirtualTable/index.ts
+++ b/src/components/modules/VirtualTable/index.ts
@@ -1,1 +1,0 @@
-export { VirtualTable } from './VirtualTable';

--- a/src/components/modules/WindowsToolbar/index.ts
+++ b/src/components/modules/WindowsToolbar/index.ts
@@ -1,1 +1,0 @@
-export {default} from './WindowsToolbar';

--- a/src/components/overlays/FlyModal/FlyModal.tsx
+++ b/src/components/overlays/FlyModal/FlyModal.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import classnames from 'classnames';
 import * as styles from './FlyModal.sass';
-import Close from '../../buttons/Close/index';
 import IReactComponentProps from '../../../common/structures/IReactComponentProps';
+import Close from '../../buttons/Close/Close';
 
 const ReactModal = require('react-modal');
 

--- a/src/components/overlays/FlyModal/index.ts
+++ b/src/components/overlays/FlyModal/index.ts
@@ -1,1 +1,0 @@
-export {default} from './FlyModal';

--- a/src/components/overlays/FlyTooltip/index.ts
+++ b/src/components/overlays/FlyTooltip/index.ts
@@ -1,1 +1,0 @@
-export {default} from './FlyTooltip';

--- a/src/components/overlays/Popup/index.ts
+++ b/src/components/overlays/Popup/index.ts
@@ -1,1 +1,0 @@
-export {default} from './Popup';

--- a/src/components/overlays/Tooltip/index.ts
+++ b/src/components/overlays/Tooltip/index.ts
@@ -1,1 +1,0 @@
-export {Tooltip} from './Tooltip';

--- a/src/components/tables/TableList/index.ts
+++ b/src/components/tables/TableList/index.ts
@@ -1,1 +1,0 @@
-export { TableList, TableListRow } from './TableList';

--- a/src/components/tables/TableListRepeater/TableListRepeater.tsx
+++ b/src/components/tables/TableListRepeater/TableListRepeater.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import IReactComponentProps from '../../../common/structures/IReactComponentProps';
 import classnames from 'classnames';
-import { TableList } from '../TableList/index';
+import { TableList } from '../TableList/TableList';
 import CloseSmallSVG from '../../../svg/close--small';
 import AddSVG from '../../../svg/add';
 import isEqual = require('lodash.isequal');

--- a/src/components/tables/TableListRepeater/index.ts
+++ b/src/components/tables/TableListRepeater/index.ts
@@ -1,1 +1,0 @@
-export {default} from './TableListRepeater';

--- a/src/components/text/List/index.ts
+++ b/src/components/text/List/index.ts
@@ -1,1 +1,0 @@
-export {default} from './List';

--- a/src/components/text/Truncate/index.ts
+++ b/src/components/text/Truncate/index.ts
@@ -1,1 +1,0 @@
-export {default} from './Truncate';

--- a/src/components/text/_private/TextBase/TextBase.tsx
+++ b/src/components/text/_private/TextBase/TextBase.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import classnames from 'classnames';
 import * as styles from './TextBase.scss';
 import ILocalContainerProps from '../../../../common/structures/ILocalContainerProps';
-import { Container } from '../../../modules/Container';
+import { Container } from '../../../modules/Container/Container';
 
 export enum TextBasePropColor {
 	gray_gray75_title = 'gray_gray75_title',

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,75 +2,75 @@ import addStyles from './add-styles';
 addStyles();
 
 // Alerts
-export {default as Banner} from './components/alerts/Banner';
-export {default as BannerCarousel} from './components/alerts/BannerCarousel';
-export {default as FlyLargeConfirm} from './components/alerts/FlyLargeConfirm';
+export {default as Banner} from './components/alerts/Banner/Banner';
+export {default as BannerCarousel} from './components/alerts/BannerCarousel/BannerCarousel';
+export {default as FlyLargeConfirm} from './components/alerts/FlyLargeConfirm/FlyLargeConfirm';
 // Buttons
 export {ButtonBase} from './components/buttons/_private/ButtonBase/ButtonBase';
 export {Button} from './components/buttons/Button/Button';
-export {default as Close} from './components/buttons/Close';
+export {default as Close} from './components/buttons/Close/Close';
 export {PrimaryButton} from './components/buttons/PrimaryButton/PrimaryButton';
 export {TextButton} from './components/buttons/TextButton/TextButton';
 // Inputs
-export {default as BrowseInput} from './components/inputs/BrowseInput';
-export {default as Checkbox} from './components/inputs/Checkbox';
-export {default as FlyDropdown} from './components/inputs/FlyDropdown';
-export {default as FlySelect} from './components/inputs/FlySelect';
-export {default as InputPasswordToggle} from './components/inputs/InputPasswordToggle';
-export {default as InputSearch} from './components/inputs/InputSearch';
-export {default as RadioBlock} from './components/inputs/RadioBlock';
-export {default as Switch} from './components/inputs/Switch';
+export {default as BrowseInput} from './components/inputs/BrowseInput/BrowseInput';
+export {default as Checkbox} from './components/inputs/Checkbox/Checkbox';
+export {default as FlyDropdown} from './components/inputs/FlyDropdown/FlyDropdown';
+export {default as FlySelect} from './components/inputs/FlySelect/FlySelect';
+export {default as InputPasswordToggle} from './components/inputs/InputPasswordToggle/InputPasswordToggle';
+export {default as InputSearch} from './components/inputs/InputSearch/InputSearch';
+export {default as RadioBlock} from './components/inputs/RadioBlock/RadioBlock';
+export {default as Switch} from './components/inputs/Switch/Switch';
 // Layout
-export {default as AdvancedToggle} from './components/layout/AdvancedToggle';
-export {default as Divider} from './components/layout/Divider';
+export {default as AdvancedToggle} from './components/layout/AdvancedToggle/AdvancedToggle';
+export {default as Divider} from './components/layout/Divider/Divider';
 // Loaders
-export {default as BigLoader} from './components/loaders/BigLoader';
-export {default as DownloaderItem} from './components/loaders/DownloaderItem';
-export {default as InstallerStepStatus} from './components/loaders/InstallerStepStatus';
-export {default as LoadingIndicator} from './components/loaders/LoadingIndicator';
-export {default as ProgressBar} from './components/loaders/ProgressBar';
-export {default as Spinner} from './components/loaders/Spinner';
+export {default as BigLoader} from './components/loaders/BigLoader/BigLoader';
+export {default as DownloaderItem} from './components/loaders/DownloaderItem/DownloaderItem';
+export {default as InstallerStepStatus} from './components/loaders/InstallerStepStatus/InstallerStepStatus';
+export {default as LoadingIndicator} from './components/loaders/LoadingIndicator/LoadingIndicator';
+export {default as ProgressBar} from './components/loaders/ProgressBar/ProgressBar';
+export {default as Spinner} from './components/loaders/Spinner/Spinner';
 // Media
-export {default as Avatar} from './components/media/Avatar';
-export {default as ImageCircle} from './components/media/ImageCircle';
+export {default as Avatar} from './components/media/Avatar/Avatar';
+export {default as ImageCircle} from './components/media/ImageCircle/ImageCircle';
 // Menus
-export {default as Drawer} from './components/menus/Drawer';
-export {Stepper as Stepper, Step as Step} from './components/menus/Stepper';
-export {default as TabNav} from './components/menus/TabNav';
-export {TertiaryNav as TertiaryNav, TertiaryNavItem as TertiaryNavItem} from './components/menus/TertiaryNav';
+export {default as Drawer} from './components/menus/Drawer/Drawer';
+export {Stepper as Stepper, Step as Step} from './components/menus/Stepper/Stepper';
+export {default as TabNav} from './components/menus/TabNav/TabNav';
+export {TertiaryNav as TertiaryNav, TertiaryNavItem as TertiaryNavItem} from './components/menus/TertiaryNav/TertiaryNav';
 // Modules
 export {default as Animation} from './components/modules/Animation/Animation';
-export {default as Card} from './components/modules/Card';
-export {default as ClippedContent} from './components/modules/ClippedContent';
-export {Container} from './components/modules/Container';
-export {default as DragBar} from './components/modules/DragBar';
-export {EmptyArea as EmptyArea} from './components/modules/EmptyArea';
+export {default as Card} from './components/modules/Card/Card';
+export {default as ClippedContent} from './components/modules/ClippedContent/ClippedContent';
+export {Container} from './components/modules/Container/Container';
+export {default as DragBar} from './components/modules/DragBar/DragBar';
+export {EmptyArea as EmptyArea} from './components/modules/EmptyArea/EmptyArea';
 export {
 	InnerPaneSidebar as InnerPaneSidebar,
 	InnerPaneSidebarHeader as InnerPaneSidebarHeader,
 	InnerPaneSidebarAddNew as InnerPaneSidebarAddNew,
 	InnerPaneSidebarContent as InnerPaneSidebarContent,
 	InnerPaneSidebarContentItem as InnerPaneSidebarContentItem,
-} from './components/modules/InnerPaneSidebar';
-export {default as Markdown} from './components/modules/Markdown';
-export {default as SiteInfoInnerPane} from './components/modules/SiteInfoInnerPane';
-export {TitleBar} from './components/modules/Titlebar';
-export {VerticalNav as VerticalNav, VerticalNavItem as VerticalNavItem} from './components/modules/VerticalNav';
+} from './components/modules/InnerPaneSidebar/InnerPaneSidebar';
+export {default as Markdown} from './components/modules/Markdown/Markdown';
+export {default as SiteInfoInnerPane} from './components/modules/SiteInfoInnerPane/SiteInfoInnerPane';
+export {TitleBar} from './components/modules/Titlebar/TitleBar';
+export {VerticalNav as VerticalNav, VerticalNavItem as VerticalNavItem} from './components/modules/VerticalNav/VerticalNav';
 export {WorkspaceSwitcher} from './components/modules/VerticalNav/components/WorkspaceSwitcher';
-export {VirtualList} from './components/modules/VirtualList';
-export {VirtualTable} from './components/modules/VirtualTable';
-export {default as WindowsToolbar} from './components/modules/WindowsToolbar';
+export {VirtualList} from './components/modules/VirtualList/VirtualList';
+export {VirtualTable} from './components/modules/VirtualTable/VirtualTable';
+export {default as WindowsToolbar} from './components/modules/WindowsToolbar/WindowsToolbar';
 // Overlays
-export {default as FlyModal} from './components/overlays/FlyModal';
-export {default as FlyTooltip} from './components/overlays/FlyTooltip';
-export {default as Popup} from './components/overlays/Popup';
-export {Tooltip} from './components/overlays/Tooltip';
+export {default as FlyModal} from './components/overlays/FlyModal/FlyModal';
+export {default as FlyTooltip} from './components/overlays/FlyTooltip/FlyTooltip';
+export {default as Popup} from './components/overlays/Popup/Popup';
+export {Tooltip} from './components/overlays/Tooltip/Tooltip';
 // Tables
-export {TableList as TableList, TableListRow as TableListRow} from './components/tables/TableList';
-export {default as TableListRepeater} from './components/tables/TableListRepeater';
+export {TableList as TableList, TableListRow as TableListRow} from './components/tables/TableList/TableList';
+export {default as TableListRepeater} from './components/tables/TableListRepeater/TableListRepeater';
 // Text
-export {default as List} from './components/text/List';
+export {default as List} from './components/text/List/List';
 export {Text} from './components/text/Text/Text';
 export {TextBase} from './components/text/_private/TextBase/TextBase';
 export {Title} from './components/text/Title/Title';
-export {default as Truncate} from './components/text/Truncate';
+export {default as Truncate} from './components/text/Truncate/Truncate';


### PR DESCRIPTION
**Audience:** Engineers | Add-on Developers

**User Story:** As an Engineer and Add-on Developer I want fewer imports/exports per component so that it’s easier to setup components, use components (by having fewer imports), and more directly utilize “go to declaration” when drilling down into a component’s internals [LOC-1213](https://getflywheel.atlassian.net/browse/LOC-1213)

**Technical:** Previously, the main `index.ts` file was referencing each component's individual `index.ts` file which was then referencing the actual components. This removes the middle-man since no immediate benefit has been identified. The biggest change this results in is that internal components can no longer reference other components via either of these syntaxes:
```
import ClippedContent from '../../modules/ClippedContent/index';
// or
import ClippedContent from '../../modules/ClippedContent';
```
But instead uses the following:
```
import ClippedContent from '../../modules/ClippedContent/ClippedContent';
```