### PR TITLE
refactor(LOC-1220): remove global styles for sites that are no longer needed

### DIFF
--- a/src/components/alerts/Banner/Banner.sass
+++ b/src/components/alerts/Banner/Banner.sass
@@ -73,8 +73,6 @@
 
 	.CTA
 		right: 10px
-		padding-top: 5px
-		padding-bottom: 5px
 
 	.Dismiss
 		display: inline-block

--- a/src/styles/containers/Flywheel.scss
+++ b/src/styles/containers/Flywheel.scss
@@ -19,15 +19,6 @@
 		overflow-y: auto;
 		flex-direction: column;
 		flex: 1;
-
-		.Title {
-			@include tracking(20);
-			text-transform: uppercase;
-			@include theme-color-gray-else-gray15;
-			font-size: 14px;
-			font-weight: 700;
-			margin-top: 0;
-		}
 	}
 
 	.FlywheelConnect {


### PR DESCRIPTION
**Audience:** Users | Engineers

**Summary:** Remove global styles that are colliding with the new `Title` component being used within `flywheel-local`. Also tweaking the `Banner` button top and bottom padding.