### PR TITLE
improvement(LOC-1222): add innerRef support for button components

### DIFF
--- a/src/common/structures/IReactComponentProps.ts
+++ b/src/common/structures/IReactComponentProps.ts
@@ -1,12 +1,11 @@
 import * as React from 'react';
 
 export default interface IReactComponentProps {
-
 	children?: React.ReactNode;
 	className?: string;
 	key?: string | number;
+	innerRef?: (element: HTMLElement) => void | string;
 	onClick?: any;
 	style?: object;
 	ref?: any;
-
 }

--- a/src/components/buttons/_private/ButtonBase/ButtonBase.tsx
+++ b/src/components/buttons/_private/ButtonBase/ButtonBase.tsx
@@ -65,7 +65,7 @@ export class ButtonBase extends React.Component<IButtonBaseProps> {
 	};
 
 	render () {
-		const {children, color, container, className, disabled, fontSize, form, onClick, padding, tag, ...otherProps} = this.props;
+		const {children, color, container, className, disabled, fontSize, form, innerRef, onClick, padding, tag, ...otherProps} = this.props;
 		const Tag: any = tag;
 
 		return (
@@ -94,6 +94,7 @@ export class ButtonBase extends React.Component<IButtonBaseProps> {
 					)}
 					disabled={disabled}
 					onClick={onClick}
+					ref={innerRef}
 					{...otherProps}
 				>
 					{children}


### PR DESCRIPTION
**Audience:** Engineers | Add-on Developers

**Summary:** Buttons need to support refs. This allows refs to be set by using `innerRef`.

**Out of Scope:** Wrapping each button component in `React.forwardRef`.