### PR TITLE
fix(LOC-1273): fix outline button story and tweak browse input margin

### DIFF
--- a/src/components/buttons/_private/ButtonBase/ButtonBase.scss
+++ b/src/components/buttons/_private/ButtonBase/ButtonBase.scss
@@ -6,6 +6,7 @@ $disabled-background-light-alt-soft: $gray5;
 $disabled-background-dark: $gray;
 $disabled-background-dark-alt-hard: $gray-dark50;
 $disabled-text-light: $gray75;
+$disabled-text-light-alt-soft: $gray25;
 $disabled-text-dark: $gray-dark50;
 
 .ButtonBase {
@@ -123,15 +124,15 @@ $disabled-text-dark: $gray-dark50;
 
 	&:hover {
 		@include setThemeVar('--Button_TextColor_Hover', var(--Button_IfFill__TextColor_Hover));
-		@include setThemeVar('--Button_Background', var(--Button_IfFill__Background_Hover), transparent);
-		@include setThemeVar('--Button_BorderColor', var(--Button_IfFill__Background_Hover), var(--Button_IfFill__TextColor_Hover));
+		@include setThemeVar('--Button_Background', var(--Button_IfFill__Background), transparent);
+		@include setThemeVar('--Button_BorderColor', transparent, var(--Button_IfFill__TextColor_Hover));
 		@include setThemeVar('--Button_SvgPathFillColor', var(--Button_IfFill__TextColor));
 	}
 
 	&[disabled] {
 		@include setThemeVar('--Button_Background', $disabled-background-light-alt-soft, $disabled-background-dark-alt-hard);
 		@include setThemeVar('--Button_BorderColor', $disabled-background-light, $disabled-background-dark);
-		@include setThemeVar('--Button_TextColor', $disabled-text-light, $disabled-background-dark);
+		@include setThemeVar('--Button_TextColor', $disabled-text-light-alt-soft, $disabled-background-dark);
 	}
 }
 

--- a/src/components/inputs/BrowseInput/BrowseInput.sass
+++ b/src/components/inputs/BrowseInput/BrowseInput.sass
@@ -9,7 +9,6 @@
 		white-space: nowrap
 		overflow: hidden
 		text-overflow: ellipsis
-		padding-right: 20px
 
 		&.BrowseInput_Placeholder
 			color: $gray25

--- a/src/components/inputs/BrowseInput/BrowseInput.tsx
+++ b/src/components/inputs/BrowseInput/BrowseInput.tsx
@@ -93,7 +93,7 @@ export default class BrowseInput extends React.Component<IProps, IState> {
 				<TextButton
 					size={TextButtonPropSize.tiny}
 					style={{
-						marginLeft: '20px',
+						marginLeft: '10px',
 						padding: 0,
 					}}
 					onClick={this.browseFolder}


### PR DESCRIPTION
**Audience:** Users | Engineers | Add-on Developers

**Summary:** Fix inconsistent outline button styles for hover and disabled and tweak BrowseInput button margin.

**Screenshots:** 
Disabled outline button state:
![image](https://user-images.githubusercontent.com/41925404/65618468-ef4cac00-df83-11e9-967a-cfdf12a79073.png)

Hover outline button state:
![image](https://user-images.githubusercontent.com/41925404/65618487-f673ba00-df83-11e9-9989-73bc63b81807.png)

BrowseInput button margin-left tweak:
![image](https://user-images.githubusercontent.com/41925404/65618517-07243000-df84-11e9-97e9-e3616c9e0f1d.png)
