### PR TITLE
fix(LOC-1302): add support to explicitly set theme mode on section with ancestor selector

### DIFF
--- a/src/styles/_partials/_theme.scss
+++ b/src/styles/_partials/_theme.scss
@@ -5,22 +5,37 @@
 //
 
 @mixin if-theme-light {
+	// apply as default (no .Theme__Light selector required)
 	@content;
 
-	@each $selector in selector-parse(&) { // must loop over each selector for the css rule to be applied correctly
+	// loop over each selector for the css rule to correctly apply each style
+	@each $selector in selector-parse(&) {
+		// support explicitly setting section theme color for selector pattern: html .Theme__Dark div .Theme__Light div .my-custom-selector
 		@at-root :global(.Theme__Dark) :global(.Theme__Light) #{$selector} {
+			@content;
+		}
+
+		// support explicitly setting section theme color for selector pattern: html .Theme__Dark div .my-custom-selector div .Theme__Light div (e.g .Theme__Dark body .Theme__Light)
+		@at-root :global(.Theme__Dark) #{$selector} :global(.Theme__Light) {
 			@content;
 		}
 	}
 }
 
 @mixin if-theme-dark {
-	@each $selector in selector-parse(&) { // must loop over each selector for the css rule to be applied correctly
+	// loop over each selector for the css rule to correctly apply each style
+	@each $selector in selector-parse(&) {
 		@at-root :global(.Theme__Dark) #{$selector} {
 			@content;
 		}
 
+		// support explicitly setting section theme color for selector pattern: html .Theme__Light div .Theme__Dark div .my-custom-selector
 		@at-root :global(.Theme__Light) :global(.Theme__Dark) #{$selector} {
+			@content;
+		}
+
+		// support explicitly setting section theme color for selector pattern: html .Theme__Light div .my-custom-selector div .Theme__Dark div (e.g .Theme__Light body .Theme__Dark)
+		@at-root :global(.Theme__Light) #{$selector} :global(.Theme__Dark) {
 			@content;
 		}
 	}


### PR DESCRIPTION
**Audience:** Users | Engineers

**Summary:** There's a bug where elements that explicitly set a theme mode such as `.Theme__Light` to ensure that theme colors are always applied the same regardless of the current global theme doesn't work if the selector applying the color (e.g. body) is an ancestor of the element setting the new theme mode (e.g. html.Theme__Dark body .Theme__Light).

**Screenshot:**

The bug:
![image](https://user-images.githubusercontent.com/41925404/66072749-4241d880-e51b-11e9-89f7-6a2e802dd4c0.png)


The fix:
<img width="1112" alt="Screen Shot 2019-10-02 at 1 43 49 PM" src="https://user-images.githubusercontent.com/41925404/66072493-bf208280-e51a-11e9-8712-14c7c6fc3018.png">
