### PR TITLE
Clean up some documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,11 @@ In additional to a quickly growing set of React components, we also having SVGs,
 
 ## Digging deeper
 
-The `local-compoennts` library can be broken down into 3 main parts:
+The `local-components` library can be broken down into 3 main parts:
 
-1. components
-2. styles
-3. svg
+1. [Components](#components)
+2. [Styles](#styles)
+3. [SVGs](#svgs)
 
 ### Components
 
@@ -60,3 +60,7 @@ If you'd like to learn more about scoped styles, please check out CSS Modules [h
 ### SVGs
 
 Coming soon!
+
+## License
+
+[MIT](LICENSE)


### PR DESCRIPTION
While skimming through the README, I noticed a spelling mistake that should be cleaned up!

In addition, I figured it wouldn't hurt to add some header links and a link to the `LICENSE` file to match the other `local-*` repos.