### PR TITLE
fix(LOC-1271): paragraph needs font weight to be 300 by default

### DIFF
--- a/src/styles/text.scss
+++ b/src/styles/text.scss
@@ -25,6 +25,7 @@
 	}
 
 	p {
+		font-weight: 300;
 		line-height: 1.5;
 
 		a {


### PR DESCRIPTION
**Audience:** Users | Engineers | Add-on Developers

**Summary:** The default paragraph `font-weight` is falling back to `500` and needs to explicitly be set to `300` to get the intended style.

**Screenshots**

Before:
![image](https://user-images.githubusercontent.com/41925404/66584606-10e49080-eb4b-11e9-9ac1-7d94c19fd5b6.png)

After (intended):
![image](https://user-images.githubusercontent.com/41925404/66584632-1f32ac80-eb4b-11e9-835c-c17440b032dc.png)
