### PR TITLE
improvement(LOC-1254): type FlySelect and cleanup errors

### DIFF
--- a/src/common/structures/Generics.ts
+++ b/src/common/structures/Generics.ts
@@ -1,0 +1,1 @@
+export type FunctionGeneric = (...params: any[]) => any;

--- a/src/components/alerts/Banner/Banner.tsx
+++ b/src/components/alerts/Banner/Banner.tsx
@@ -6,6 +6,7 @@ import WarningSVG from '../../../svg/warning';
 import CloseSVG from '../../../svg/close--small';
 import { ButtonPropColor, ButtonPropForm } from '../../buttons/_private/ButtonBase/ButtonBase';
 import { TextButton, TextButtonPropSize } from '../../buttons/TextButton/TextButton';
+import { FunctionGeneric } from '../../../common/structures/Generics';
 
 interface IProps extends IReactComponentProps {
 

--- a/src/components/buttons/Close/Close.tsx
+++ b/src/components/buttons/Close/Close.tsx
@@ -3,6 +3,7 @@ import IReactComponentProps from '../../../common/structures/IReactComponentProp
 import classnames from 'classnames';
 import CloseBigSVG from '../../../svg/close--big';
 import * as styles from './Close.scss';
+import { FunctionGeneric } from '../../../common/structures/Generics';
 
 interface IProps extends IReactComponentProps {
 	position?: 'absolute' | 'static',

--- a/src/components/buttons/_private/ButtonBase/ButtonBase.tsx
+++ b/src/components/buttons/_private/ButtonBase/ButtonBase.tsx
@@ -3,6 +3,7 @@ import classnames from 'classnames';
 import * as styles from './ButtonBase.scss';
 import ILocalContainerProps from '../../../../common/structures/ILocalContainerProps';
 import { Container } from '../../../modules/Container/Container';
+import { FunctionGeneric } from '../../../../common/structures/Generics';
 
 export enum ButtonPropColor {
 	default = 'default',

--- a/src/components/inputs/BrowseInput/BrowseInput.tsx
+++ b/src/components/inputs/BrowseInput/BrowseInput.tsx
@@ -4,6 +4,7 @@ import * as styles from './BrowseInput.sass';
 import IReactComponentProps from '../../../common/structures/IReactComponentProps';
 import { TextButton, TextButtonPropSize } from '../../buttons/TextButton/TextButton';
 import untildify = require('untildify');
+import { FunctionGeneric } from '../../../common/structures/Generics';
 
 let remote: any;
 let dialog: any;

--- a/src/components/inputs/Checkbox/Checkbox.tsx
+++ b/src/components/inputs/Checkbox/Checkbox.tsx
@@ -4,6 +4,7 @@ import IReactComponentProps from '../../../common/structures/IReactComponentProp
 import * as styles from './Checkbox.sass';
 import CheckmarkSVG from '../../../svg/checkmark--sm';
 import CheckMixedSVG from '../../../svg/checkmark--mixed';
+import { FunctionGeneric } from '../../../common/structures/Generics';
 
 interface IProps extends IReactComponentProps {
 	checked?: boolean | 'mixed';

--- a/src/components/inputs/FlyDropdown/FlyDropdown.tsx
+++ b/src/components/inputs/FlyDropdown/FlyDropdown.tsx
@@ -3,6 +3,7 @@ import classnames from 'classnames';
 import * as styles from './FlyDropdown.sass';
 import CaretSVG from '../../../svg/caret';
 import IReactComponentProps from '../../../common/structures/IReactComponentProps';
+import { FunctionGeneric } from '../../../common/structures/Generics';
 
 interface IItems {
 	color: 'red' | 'none';

--- a/src/components/inputs/FlySelect/FlySelect.tsx
+++ b/src/components/inputs/FlySelect/FlySelect.tsx
@@ -5,6 +5,7 @@ import DownloadSmallSVG from '../../../svg/download--small';
 import ArrowRightSVG from '../../../svg/arrow--right';
 import IReactComponentProps from '../../../common/structures/IReactComponentProps';
 import * as styles from './FlySelect.scss';
+import { FunctionGeneric } from '../../../common/structures/Generics';
 
 export interface FlySelectOption {
 	disabled?: boolean
@@ -159,7 +160,7 @@ export default class FlySelect extends React.Component<IProps, IState> {
 
 	calculateOptionsPosition () {
 		if (!this.state.open) {
-			return;
+			return undefined;
 		}
 
 		const optionsBounding = this.__containerRef.current.getBoundingClientRect();
@@ -276,7 +277,7 @@ export default class FlySelect extends React.Component<IProps, IState> {
 		const disabled = typeof optionsFormatted[optionValue as string] === 'object' ? optionsFormatted[optionValue as string].disabled : false;
 
 		if (option.optionGroup !== group) {
-			return;
+			return null;
 		}
 
 		return (
@@ -298,7 +299,7 @@ export default class FlySelect extends React.Component<IProps, IState> {
 
 	renderOptionGroups () {
 		if (!this.props.optionGroups) {
-			return;
+			return null;
 		}
 
 		const output: any[] = [];

--- a/src/components/inputs/InputSearch/InputSearch.tsx
+++ b/src/components/inputs/InputSearch/InputSearch.tsx
@@ -4,6 +4,7 @@ import classnames from 'classnames';
 import * as styles from './InputSearch.sass';
 import SearchSVG from '../../../svg/search';
 import ObjectUtils from '../../../utils/object-utils';
+import { FunctionGeneric } from '../../../common/structures/Generics';
 
 const excludeProps = {
 	className: true,

--- a/src/components/inputs/RadioBlock/RadioBlock.tsx
+++ b/src/components/inputs/RadioBlock/RadioBlock.tsx
@@ -6,6 +6,7 @@ import * as styles from './RadioBlock.sass';
 import { Container } from '../../modules/Container/Container';
 import ILocalContainerProps from '../../../common/structures/ILocalContainerProps';
 import { Title, TitlePropSize } from '../../text/Title/Title';
+import { FunctionGeneric } from '../../../common/structures/Generics';
 
 interface IProps extends ILocalContainerProps {
 	default: string | null;

--- a/src/components/inputs/Switch/Switch.tsx
+++ b/src/components/inputs/Switch/Switch.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import IReactComponentProps from '../../../common/structures/IReactComponentProps';
 import classnames from 'classnames';
 import * as styles from './Switch.sass';
+import { FunctionGeneric } from '../../../common/structures/Generics';
 
 interface IProps extends IReactComponentProps {
 

--- a/src/components/loaders/DownloaderItem/DownloaderItem.tsx
+++ b/src/components/loaders/DownloaderItem/DownloaderItem.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import IReactComponentProps from '../../../common/structures/IReactComponentProps';
 import ProgressBar from '../ProgressBar/ProgressBar';
 import { TextButton } from '../../buttons/TextButton/TextButton';
+import { FunctionGeneric } from '../../../common/structures/Generics';
 
 const { ipcRenderer } = require('electron');
 

--- a/src/components/media/ImageCircle/ImageCircle.tsx
+++ b/src/components/media/ImageCircle/ImageCircle.tsx
@@ -3,6 +3,7 @@ import classnames from 'classnames';
 import * as styles from './ImageCircle.sass';
 import IReactComponentProps from '../../../common/structures/IReactComponentProps';
 import ClippedContent from '../../modules/ClippedContent/ClippedContent';
+import { FunctionGeneric } from '../../../common/structures/Generics';
 
 interface IProps extends IReactComponentProps {
 

--- a/src/components/menus/TertiaryNav/TertiaryNav.tsx
+++ b/src/components/menus/TertiaryNav/TertiaryNav.tsx
@@ -4,6 +4,7 @@ import { Switch, Route, NavLink, RouteComponentProps } from 'react-router-dom';
 import { withRouter } from 'react-router';
 import * as styles from './TertiaryNav.sass';
 import IReactComponentProps from '../../../common/structures/IReactComponentProps';
+import { FunctionGeneric } from '../../../common/structures/Generics';
 
 interface ITertiaryNavProps extends IReactComponentProps {
 

--- a/src/components/modules/Card/Card.tsx
+++ b/src/components/modules/Card/Card.tsx
@@ -4,6 +4,7 @@ import classnames from 'classnames';
 import * as styles from './Card.sass';
 import Truncate from '../../text/Truncate/Truncate';
 import { Title } from '../../text/Title/Title';
+import { FunctionGeneric } from '../../../common/structures/Generics';
 
 interface IProps extends IReactComponentProps {
 

--- a/src/components/modules/VerticalNav/components/WorkspaceSwitcher.tsx
+++ b/src/components/modules/VerticalNav/components/WorkspaceSwitcher.tsx
@@ -11,6 +11,7 @@ import { VerticalNavItem } from '../VerticalNav';
 import CloseSmallSVG from '../../../../svg/close--small';
 import WarningSVG from '../../../../svg/warning';
 import { TextButton } from '../../../buttons/TextButton/TextButton';
+import { FunctionGeneric } from '../../../../common/structures/Generics';
 
 interface IWorkspaceSwitcherProps extends IReactComponentProps {
 	className?: string;

--- a/src/components/modules/WindowsToolbar/WindowsToolbar.tsx
+++ b/src/components/modules/WindowsToolbar/WindowsToolbar.tsx
@@ -7,6 +7,7 @@ import WindowsMinimize from '../../../svg/windows_minimize';
 import WindowsMaximize from '../../../svg/windows_maximize';
 import WindowsClose from '../../../svg/windows_close';
 import WindowsBack from '../../../svg/windows_back';
+import { FunctionGeneric } from '../../../common/structures/Generics';
 
 interface IProps extends IReactComponentProps {
 

--- a/src/components/tables/TableListRepeater/TableListRepeater.tsx
+++ b/src/components/tables/TableListRepeater/TableListRepeater.tsx
@@ -8,6 +8,7 @@ import isEqual = require('lodash.isequal');
 import * as styles from '../TableList/TableList.sass';
 import { PrimaryButton } from '../../buttons/PrimaryButton/PrimaryButton';
 import { Button } from '../../buttons/Button/Button';
+import { FunctionGeneric } from '../../../common/structures/Generics';
 
 interface IProps extends IReactComponentProps {
 

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -13,5 +13,3 @@ declare module 'highlight.js/lib/languages/*';
 declare module 'react-truncate-markup/lib';
 declare module 'svgo';
 declare module 'mock-require';
-
-type FunctionGeneric = (...params: any[]) => any;


### PR DESCRIPTION
## Audience

Local Engineers | Add-on Developers

## Summary

Add typings for FlySelect so setting props like `optionGroups` are easier to use and safe-guarded. Also export `FunctionGeneric` rather than using `global.d.ts` to overcome build issues within `flywheel-local`. 

## Reference

- **NOJIRA**
- [LOC-1254](https://getflywheel.atlassian.net/browse/LOC-1254)
