### PR TITLE
improvement(LOC-1405): add striped row option to FlySelect and add example

### DIFF
--- a/src/components/inputs/FlySelect/FlySelect.tsx
+++ b/src/components/inputs/FlySelect/FlySelect.tsx
@@ -41,6 +41,7 @@ interface IProps extends IReactComponentProps {
 	optionGroups?: FlySelectOptionGroups;
 	placeholder?: string;
 	readonly?: boolean;
+	striped?: boolean;
 	value?: string;
 }
 
@@ -288,6 +289,7 @@ export default class FlySelect extends React.Component<IProps, IState> {
 					'FlySelect_Option',
 					{
 						'__Disabled': disabled,
+						'FlySelect_Option__Striped': this.props.striped,
 					},
 				)}
 				onClick={(e) => this.selectOption(e, optionValue)}
@@ -317,22 +319,25 @@ export default class FlySelect extends React.Component<IProps, IState> {
 			}
 
 			output.push(
-				<div
-					key={optionGroupID}
-					className="FlySelect_OptionGroup"
-				>
-					<span>{optionGroup.label}</span>
-					{
-						optionGroup.linkText
-							?
-							<a onClick={optionGroup.linkOnClick}>
-								{optionGroup.linkText}
-								<ArrowRightSVG/>
-							</a>
-							:
-							null
-					}
-				</div>,
+				<>
+					<div
+						key={optionGroupID}
+						className="FlySelect_OptionGroup"
+					>
+						<span>{optionGroup.label}</span>
+						{
+							optionGroup.linkText
+								?
+								<a onClick={optionGroup.linkOnClick}>
+									{optionGroup.linkText}
+									<ArrowRightSVG/>
+								</a>
+								:
+								null
+						}
+					</div>
+					<span /> {/* note: this is here to ensure that the expected alternating row color order is maintained */}
+				</>,
 			);
 
 			output.push(optionNodes);

--- a/src/components/inputs/FlySelect/README.md
+++ b/src/components/inputs/FlySelect/README.md
@@ -46,6 +46,49 @@ Constrained Width:
 </div>
 ```
 
+Option groups with striped rows:
+```js
+<div style={{width: '150px'}}>
+    <FlySelect 
+        optionGroups={{
+            active: {
+                label: 'Active Items',
+            },
+            inactive: {
+                label: 'Inactive Items',
+            },
+        }}
+        options={{
+            'a': {
+                label: 'Item A',
+            	optionGroup: 'active',
+            },
+            'b': {
+                disabled: true,
+                label: 'Item B',
+                optionGroup: 'inactive',
+                secondaryText: '(deactivated)',
+            },
+            'c': {
+                label: 'Item C',
+            	optionGroup: 'active',
+            },
+            'd': {
+                label: 'Item D',
+            	optionGroup: 'active',
+            },
+            'e': {
+                label: 'Item E',
+            	optionGroup: 'active',
+            },
+        }}
+        onChange={() => console.log('onChange')} 
+        placeholder="Select Something!" 
+        striped={true}
+    />
+</div>
+```
+
 Using an Avatar within a form FlySelect:
 ```js
 import Avatar from '../../media/Avatar/Avatar';

--- a/src/styles/forms.scss
+++ b/src/styles/forms.scss
@@ -129,34 +129,12 @@
 			}
 		}
 
-		.FlySelect_Option {
-			height: 30px;
-			padding: 0 10px;
-
-			.FlySelect__SecondaryText {
-				margin-right: 0;
-			}
-
-			&:hover {
-				color: $white;
-				background: $green-dark50;
-
-				span {
-					color: $white;
-				}
-
-				svg path {
-					fill: $white;
-				}
-			}
-		}
-
 		.FlySelect_OptionGroup {
-			@include theme-background-gray5-else-graydarkalt;
 			height: 37px;
 			line-height: 37px;
 			text-align: left;
 			@include theme-color-gray-else-gray25;
+			@include theme-background-gray15-else-graydark50;
 			text-transform: uppercase;
 			@include tracking(5);
 			font-weight: 700;
@@ -186,6 +164,32 @@
 						@include theme-fill-gray-else-white;
 					}
 				}
+			}
+		}
+
+		.FlySelect_Option {
+			height: 30px;
+			padding: 0 10px;
+
+			.FlySelect__SecondaryText {
+				margin-right: 0;
+			}
+
+			&:hover {
+				color: $white;
+				background: $green-dark50;
+
+				span {
+					color: $white;
+				}
+
+				svg path {
+					fill: $white;
+				}
+			}
+
+			&.FlySelect_Option__Striped:nth-child(even):not(:hover) {
+				@include theme-background-gray2-else-gray2row;
 			}
 		}
 	}


### PR DESCRIPTION
## Audience

Users | Local Engineers | Third-Party Developers

## Summary

* Adds a striped/alternate rows option to FlySelect via `striped` prop and adds the corresponding styles.
* Adds a styleguidist example to demonstrate alternate row colors which includes an option groups code example as part of it.