### PR TITLE
chore(LOC-1528): enable strictNullChecks and refactor to resolve all issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
 	"description": "",
 	"main": "dist/index.js",
 	"jsnext:main": "src/index.ts",
+	"types": "./src/index.ts",
 	"author": "",
 	"license": "MIT",
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
 	"description": "",
 	"main": "dist/index.js",
 	"jsnext:main": "src/index.ts",
-	"types": "./src/index.ts",
 	"author": "",
 	"license": "MIT",
 	"dependencies": {

--- a/src/components/buttons/_private/ButtonBase/ButtonBase.tsx
+++ b/src/components/buttons/_private/ButtonBase/ButtonBase.tsx
@@ -39,6 +39,8 @@ export interface IButtonCommonProps extends ILocalContainerProps {
 	onClick?: FunctionGeneric;
 	/** The html element tag used for the button. */
 	tag?: string;
+	/** Props specific to the tag prop tag defined and applied to this component. */
+	tagProps?: {[prop: string]: any};
 	/** The default behavior of the button. */
 	type?: 'button' | 'submit' | 'reset';
 }
@@ -66,7 +68,7 @@ export class ButtonBase extends React.Component<IButtonBaseProps> {
 	};
 
 	render () {
-		const {children, color, container, className, disabled, fontSize, form, innerRef, onClick, padding, tag, ...otherProps} = this.props;
+		const {children, color, container, className, disabled, fontSize, form, innerRef, onClick, padding, tag, tagProps, ...otherProps} = this.props;
 		const Tag: any = tag;
 
 		return (
@@ -97,6 +99,7 @@ export class ButtonBase extends React.Component<IButtonBaseProps> {
 					onClick={onClick}
 					ref={innerRef}
 					{...otherProps}
+					{...tagProps}
 				>
 					{children}
 				</Tag>

--- a/src/components/inputs/InputPasswordToggle/InputPasswordToggle.tsx
+++ b/src/components/inputs/InputPasswordToggle/InputPasswordToggle.tsx
@@ -1,17 +1,20 @@
 import * as React from 'react';
 import classnames from 'classnames';
 import EyeSVG from '../../../svg/eye';
-import IReactComponentProps from '../../../common/structures/IReactComponentProps';
+import ILocalContainerProps from '../../../common/structures/ILocalContainerProps';
 
-interface IState {
-
-	inputType: 'password' | 'text';
-
+interface IProps extends ILocalContainerProps {
+	onChange?: any;
+	value?: string;
 }
 
-export default class InputPasswordToggle extends React.Component<IReactComponentProps, IState> {
+interface IState {
+	inputType: 'password' | 'text';
+}
 
-	constructor (props: IReactComponentProps) {
+export default class InputPasswordToggle extends React.Component<IProps, IState> {
+
+	constructor (props: IProps) {
 		super(props);
 
 		this.state = {

--- a/src/components/overlays/FlyModal/FlyModal.tsx
+++ b/src/components/overlays/FlyModal/FlyModal.tsx
@@ -28,9 +28,9 @@ else {
 }
 
 interface IProps extends IReactComponentProps {
-
 	ariaHideApp?: boolean;
 	closeTimeoutMS?: number;
+	contentLabel: string; // improves accessibility
 	hasIcon?: boolean;
 	isOpen?: boolean;
 	onRequestClose?: () => void;

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ export {TextButton} from './components/buttons/TextButton/TextButton';
 export {default as BrowseInput} from './components/inputs/BrowseInput/BrowseInput';
 export {default as Checkbox} from './components/inputs/Checkbox/Checkbox';
 export {default as FlyDropdown} from './components/inputs/FlyDropdown/FlyDropdown';
-export {default as FlySelect} from './components/inputs/FlySelect/FlySelect';
+export {default as FlySelect, FlySelectOption, FlySelectOptions, FlySelectOptionGroups} from './components/inputs/FlySelect/FlySelect';
 export {default as InputPasswordToggle} from './components/inputs/InputPasswordToggle/InputPasswordToggle';
 export {default as InputSearch} from './components/inputs/InputSearch/InputSearch';
 export {default as RadioBlock} from './components/inputs/RadioBlock/RadioBlock';
@@ -73,3 +73,11 @@ export {Text} from './components/text/Text/Text';
 export {TextBase} from './components/text/_private/TextBase/TextBase';
 export {Title} from './components/text/Title/Title';
 export {default as Truncate} from './components/text/Truncate/Truncate';
+export {default as IReactComponentProps} from './common/structures/IReactComponentProps';
+export {
+	IVirtualTableCellRendererDataArgs,
+	IVirtualTableOnChangeRowDataArgs,
+	IVirtualTableRowRendererDataArgs,
+	VirtualTableCellRenderer,
+	VirtualTableRowRenderer,
+} from './components/modules/VirtualTable/VirtualTable';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
 		"lib": ["es2017", "dom", "dom.iterable"],
 		"sourceMap": true,
 		"declaration": true,
+		"declarationDir": "dist",
 		"strict": true,
 		"experimentalDecorators": true,
 		"target": "es2015"


### PR DESCRIPTION
## Audience

Flywheel Engineers

## Summary

To support flywheel-local enabling `strictNullChecks`, several typings, exports, and configs have to be modified or added.

## Technical

See inline comments for the files changed and the reason why.