### PR TITLE
refactor(LOC-1699): remove all "by Flywheel" references

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# Local by Flywheel component library
+# Local component library
 
-Welcome to the official component library for [Local by Flywheel](https://local.getflywheel.com/)!
+Welcome to the official component library for [Local](https://localwp.com/)!
 
 ## What's included in this component library?
 
-We appreciate curious minds and that's a great question! 
+We appreciate curious minds and that's a great question!
 Take a quick look at our living component documentation [here](https://getflywheel.github.io/local-components/).
 
 In additional to a quickly growing set of React components, we also having SVGs, SASS partials, and more to come!
@@ -26,8 +26,8 @@ The `local-components` library can be broken down into 3 main parts:
 
 ### Components
 
-These are the visual elements that make up both Local and its Add-ons. 
-There are currently 40+ React components in the library. 
+These are the visual elements that make up both Local and its Add-ons.
+There are currently 40+ React components in the library.
 Each component consists of a `.tsx`, `index.js`, `README.md` and optional `.sass` file.
 
 Try it out for yourself!
@@ -38,13 +38,13 @@ Try it out for yourself!
 
 ### Styles
 
-The component library leverages CSS Modules to manage and scope styles. 
+The component library leverages CSS Modules to manage and scope styles.
 These are considered **local** styles (not to be confused with the Local app 😉)
 Scoped local styles are a beautiful thing that allow Local to isolate components, run Add-ons with multiple versions of `local-components` and avoid collisions.
 
 As wonderful as local styles are, there are instances where CSS needs to transcend a component.
 For that, we make use of **global** styles.
-Global styles should be familiar to most as that's all the web had for 20+ years. 
+Global styles should be familiar to most as that's all the web had for 20+ years.
 These styles are intended to be used sparingly as they introduce a lot of challenges when scaling an app with a library of Add-ons and Environments.
 
 The following is an instance where a scoped component may use a combination of local and global styles to achieve a specific result:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@getflywheel/local-components",
-	"version": "12.1.0",
+	"version": "12.1.1",
 	"repository": "https://github.com/getflywheel/local-components",
 	"homepage": "https://build.localbyflywheel.com",
 	"description": "",

--- a/src/components/modules/WindowsToolbar/README.md
+++ b/src/components/modules/WindowsToolbar/README.md
@@ -1,7 +1,7 @@
 Basic:
 ```js
 <div style={{ contain: 'strict', height: '32px' }}>
-    <WindowsToolbar title="Local by Flywheel Storybook" onMinimize={() => console.log('onMinimize')}
+    <WindowsToolbar title="Local Storybook" onMinimize={() => console.log('onMinimize')}
                 onMaximize={() => console.log('onMaximize')} onQuit={() => console.log('onQuit')} resizable={true} />
 </div>
 ```
@@ -9,7 +9,7 @@ Basic:
 With Menu:
 ```js
 <div style={{ contain: 'strict', height: '32px' }}>
-    <WindowsToolbar title="Local by Flywheel Storybook" onMinimize={() => console.log('onMinimize')}
+    <WindowsToolbar title="Local Storybook" onMinimize={() => console.log('onMinimize')}
 			onShowMenu={() => console.log('onShowMenu')} onMaximize={() => console.log('onMaximize')} onQuit={() => console.log('onQuit')}/>
 </div>
 ```
@@ -17,7 +17,7 @@ With Menu:
 With Back:
 ```js
 <div style={{ contain: 'strict', height: '32px' }}>
-    <WindowsToolbar title="Local by Flywheel Storybook" onMinimize={() => console.log('onMinimize')}
+    <WindowsToolbar title="Local Storybook" onMinimize={() => console.log('onMinimize')}
 			onBack={() => console.log('onBack')} onMaximize={() => console.log('onMaximize')} onQuit={() => console.log('onQuit')}/>
 </div>
 ```

--- a/src/components/text/List/README.md
+++ b/src/components/text/List/README.md
@@ -5,7 +5,6 @@ Basic unordered (default) list. When the list items are not 'li' elements, they 
 	<a>Featured</a>
 	<a>New</a>
 	<a>Popular</a>
-	<a>made by Flywheel</a>
 </List>
 ```
 
@@ -16,7 +15,6 @@ Ordered list.
 	<a>Featured</a>
 	<a>New</a>
 	<a>Popular</a>
-	<a>made by Flywheel</a>
 </List>
 ```
 
@@ -32,11 +30,10 @@ List with header (large), divider, and no bullets.
 	<a>Featured</a>
 	<a>New</a>
 	<a>Popular</a>
-	<a>made by Flywheel</a>
 </List>
 ```
 
-List with non-li elements and the element wrap feature disabled. 
+List with non-li elements and the element wrap feature disabled.
 Notice that the items' display type is no longer 'list-item' but rather defaults to that of the passed in children.
 ```js
 <List
@@ -61,6 +58,5 @@ List directly using 'li' elements (therefore not wrapped in additional 'li' tags
 	<li>Featured</li>
 	<li>New</li>
 	<li>Popular</li>
-	<li>made by Flywheel</li>
 </List>
 ```

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -107,7 +107,7 @@ module.exports = {
 			}
 		},
 	},
-	title: 'Local by Flywheel Style Guide',
+	title: 'Local Style Guide',
     webpackConfig: () => {
         return merge.strategy({
 			plugins: 'replace',


### PR DESCRIPTION
## Audience

Developers

## Summary

Replace all references to "by Flywheel" within the style guide.

## Technical

Simple search and replace of static references used in non-critical documentation.

## Reference

- [LOC-1699](https://getflywheel.atlassian.net/browse/LOC-1699)
