### PR TITLE
feat(LOC-1451): render and layout children in middle of hr if defined for Divider

### DIFF
--- a/src/components/layout/Divider/Divider.sass
+++ b/src/components/layout/Divider/Divider.sass
@@ -1,6 +1,0 @@
-@import '../../../styles/_partials/index'
-
-.Divider
-	@import '../../../styles/partials/margin'
-
-	@include theme-border-bottom

--- a/src/components/layout/Divider/Divider.scss
+++ b/src/components/layout/Divider/Divider.scss
@@ -1,0 +1,15 @@
+@import '../../../styles/_partials/index';
+
+.Divider {
+	@import '../../../styles/partials/margin';
+
+	position: relative;
+	@include theme-border-bottom;
+}
+
+.Divider_ChildrenCont {
+	position: absolute;
+	top: 50%;
+	left: 50%;
+	transform: translate(-50%, -50%);
+}

--- a/src/components/layout/Divider/Divider.tsx
+++ b/src/components/layout/Divider/Divider.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import classnames from 'classnames';
-import * as styles from './Divider.sass';
+import * as styles from './Divider.scss';
 import IReactComponentProps from '../../../common/structures/IReactComponentProps';
 
 const marginsClassMixin = (stylesRef: {[key: string]: any}, props: {[key: string]: any}) => ({
@@ -17,11 +17,9 @@ const marginsClassMixin = (stylesRef: {[key: string]: any}, props: {[key: string
 });
 
 export interface IDividerProps extends IReactComponentProps {
-
 	marginSize?: 'xs' | 's' | 'm' | 'l' | 'xl';
 	marginSizeBottom?: 'xs' | 's' | 'm' | 'l' | 'xl';
 	marginSizeTop?: 'xs' | 's' | 'm' | 'l' | 'xl';
-
 }
 
 const Divider = (props: IDividerProps) => (
@@ -33,7 +31,13 @@ const Divider = (props: IDividerProps) => (
 		)}
 		onClick={props.onClick}
 		style={props.style}
-	/>
+	>
+		{ props.children && (
+			<div className={styles.Divider_ChildrenCont}>
+				{props.children}
+			</div>
+		)}
+	</div>
 );
 
 export default Divider;

--- a/src/components/layout/Divider/README.md
+++ b/src/components/layout/Divider/README.md
@@ -27,3 +27,14 @@ A horizontal divider with extra-large (40px) margin below it.
 	<div>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin tincidunt nec orci ac elementum. Sed vitae ligula non dolor egestas congue. Etiam at luctus sem. Sed metus lorem, dapibus non congue nec, mattis eu leo. In condimentum mi nec tristique pretium. Aliquam vel urna vitae justo accumsan auctor. Mauris purus orci, hendrerit et dignissim eu, efficitur non dui. Donec fringilla ipsum eu rutrum ultricies. Mauris vel neque fermentum, porta justo id, pretium mauris. Donec rhoncus, ante et laoreet tincidunt, leo lorem dapibus dolor, vel ultrices metus odio et felis.</div>
 </div>
 ```
+Divider with a horizontally and vertically centered child element.
+
+```js
+<div>
+	<div>Some text</div>
+	<Divider marginSize="m">
+        <div style={{background: "yellow", padding: "5px 10px"}}>Some Badge</div>
+    </Divider>
+	<div>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin tincidunt nec orci ac elementum. Sed vitae ligula non dolor egestas congue. Etiam at luctus sem. Sed metus lorem, dapibus non congue nec, mattis eu leo. In condimentum mi nec tristique pretium. Aliquam vel urna vitae justo accumsan auctor. Mauris purus orci, hendrerit et dignissim eu, efficitur non dui. Donec fringilla ipsum eu rutrum ultricies. Mauris vel neque fermentum, porta justo id, pretium mauris. Donec rhoncus, ante et laoreet tincidunt, leo lorem dapibus dolor, vel ultrices metus odio et felis.</div>
+</div>
+```


### PR DESCRIPTION
## Audience

Local Engineers and Third Party Developers

## Summary

Several components and design elements require an element or component to be vertically and horizontally centered within an <hr> tag. This PR adds support for this within the Divider component.

## Technical

- if Divider implementation defines children, then a wrapper div is renderer children absolutely positioned to be vertically and horizontally centered
- Readme.md example added with simple badge
- converted Divider.sass to .scss

## Screenshots

### Example

![image](https://user-images.githubusercontent.com/41925404/77086643-abcd7a80-69c7-11ea-93d3-7759fc8c3713.png)