### PR TITLE
fix: Don't sync value prop to state.

### DIFF
--- a/src/components/inputs/InputSearch/InputSearch.tsx
+++ b/src/components/inputs/InputSearch/InputSearch.tsx
@@ -21,36 +21,13 @@ interface IProps extends IReactComponentProps {
 	onChange?: FunctionGeneric;
 	placeholder?: string;
 	value?: string | number;
-
 }
 
-interface IState {
-
-	value: string | number | undefined;
-
-}
-
-export default class InputSearch extends React.Component<IProps, IState> {
+export default class InputSearch extends React.Component<IProps> {
 
 	static defaultProps: Partial<IProps> = {
 		value: '',
 	};
-
-	constructor (props: IProps) {
-		super(props);
-
-		this.state = {
-			value: props.value, // set to the props initial value
-		};
-	}
-
-	onChangeInternal = (event: any) => {
-		this.setState({
-			value: event.target.value,
-		});
-
-		this.props.onChange && this.props.onChange.call(this, event);
-	}
 
 	render () {
 		const undeclaredProps = ObjectUtils.omitPropsInObject(this.props, excludeProps, true);
@@ -68,10 +45,10 @@ export default class InputSearch extends React.Component<IProps, IState> {
 						styles.InputSearch,
 						this.props.className,
 					)}
-					onChange={event => this.onChangeInternal(event)}
+					onChange={this.props.onChange}
 					placeholder={this.props.placeholder}
 					type="text"
-					value={this.state.value}
+					value={this.props.value}
 					{...undeclaredProps}
 				/>
 			</div>


### PR DESCRIPTION
This issue is causing a bug that is preventing me from finishing my current ticket. 

Basically when I clear the value prop, the input text does not update since it doesn't trigger the onChange event.

Here's a video demonstrating the bug: 


[Screen Recording 2020-04-09 at 4.40.11 PM.zip](https://github.com/getflywheel/local-components/files/4458764/Screen.Recording.2020-04-09.at.4.40.11.PM.zip)
