### PR TITLE
Show progress stepper during add site

### DIFF
--- a/src/styles/containers/AddSitePage.scss
+++ b/src/styles/containers/AddSitePage.scss
@@ -3,11 +3,11 @@
 :global {
 	.AddSiteContent {
 		width: 100%;
-		height: 100%;
 		display: flex;
 		flex-direction: column;
 		align-items: center;
 		position: relative;
+		flex: 1;
 
 		.TabNav {
 			padding: 0;


### PR DESCRIPTION
### **Audience**

All Local users

### **Summary**

Show progress stepper when user adds a new site.

### **Technical**

Remove 100% height and add flex: 1 to .AddSiteContent class. 

### **Example**
![image](https://user-images.githubusercontent.com/10208759/80982201-9afa8c00-8df0-11ea-8688-befc389d966b.png)
