### PR TITLE
feat(PRO-202): add CopyButton component and new style options to Text Button

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
 		"@getflywheel/memoize-one-ts": "^0.0.2",
 		"@types/untildify": "^3.0.0",
 		"classnames": "^2.2.6",
+		"clipboard-copy": "^3.1.0",
 		"highlight.js": "^9.13.1",
 		"lodash.isequal": "^4.5.0",
 		"react-lowlight": "^2.0.0",

--- a/src/components/buttons/CopyButton/CopyButton.scss
+++ b/src/components/buttons/CopyButton/CopyButton.scss
@@ -1,0 +1,66 @@
+@import '../../../styles/_partials/index.scss';
+@import '../../../common/styles/themeUtils';
+
+.CopyButton {
+	cursor: pointer;
+	display: flex;
+	align-items: center;
+	padding: 5px;
+	background: transparent;
+	border: none;
+	border-radius: 5px;
+	@include defaultFontSettings;
+	@include tracking(40);
+	@include setupThemeVars(
+		'--Button_Background',
+		'--Button_Background_Hover',
+		'--Button_Text_Color',
+		'--Button_Text_Color_Hover',
+		'--Button_Padding'
+	);
+
+	color: var(--Button_Text_Color);
+	background: var(--Button_Background);
+	padding: var(--Button_Padding);
+
+	&:hover {
+		color: var(--Button_Text_Color_Hover);
+		background: var(--Button_Background_Hover);
+	}
+
+	&:active {
+		transform: scale(.98);
+	}
+
+	span, svg, g, path, circle {
+		cursor: pointer;
+	}
+}
+
+.CopyButton__Color_Gray {
+	@include setThemeVar('--Button_Background', $gray5);
+	@include setThemeVar('--Button_Background_Hover', $gray15);
+	@include setThemeVar('--Button_Text_Color', $gray-dark50);
+	@include setThemeVar('--Button_Text_Color_Hover', $gray-dark50);
+	@include setThemeVar('--Button_Padding', 5px);
+}
+
+.CopyButton__Color_Green {
+	@include setThemeVar('--Button_Background', $green);
+	@include setThemeVar('--Button_Background_Hover', $green-dark50);
+	@include setThemeVar('--Button_Text_Color', $white);
+	@include setThemeVar('--Button_Text_Color_Hover', $white);
+	@include setThemeVar('--Button_Padding', 5px);
+}
+
+.CopyButton__Color_None {
+	@include setThemeVar('--Button_Background', none);
+	@include setThemeVar('--Button_Background_Hover', none);
+	@include setThemeVar('--Button_Text_Color', $green);
+	@include setThemeVar('--Button_Text_Color_Hover', $green-dark50);
+	@include setThemeVar('--Button_Padding', 0 10px);
+}
+
+.CopyButtonText__Margin {
+	margin-left: 5px;
+}

--- a/src/components/buttons/CopyButton/CopyButton.tsx
+++ b/src/components/buttons/CopyButton/CopyButton.tsx
@@ -1,0 +1,107 @@
+import * as React from 'react';
+import classnames from 'classnames';
+import ILocalContainerProps from '../../../common/structures/ILocalContainerProps';
+import { Container } from '../../modules/Container/Container';
+import { CopyButtonIcon, CopiedStateIconVariants, UncopiedStateIconVariants } from './_private/CopyButtonIcon';
+import * as styles from './CopyButton.scss';
+
+/**
+ * This lib is only exported as a CommonJS module, so the require syntax must be used
+ * unless the EsModuleInterop flag is turned on for this project
+ */
+const copy = require('clipboard-copy');
+
+const { useState } = React;
+
+export enum CopiedStateBGStyleVariants {
+	green = 'green',
+	transparent = 'transparent',
+}
+
+export interface ICopyButtonProps extends ILocalContainerProps {
+	tag?: string;
+	/* Timeout for how long to show "copied" state after a click */
+	copiedTimeout?: number;
+	/* Text to show in uncopied state */
+	uncopiedStateText?: string;
+	/* Text to show in copied state */
+	copiedStateText?: string;
+	/* Icon to show in uncopied state */
+	uncopiedStateIconVariant?: UncopiedStateIconVariants | null;
+	/* Icon to show in copied state */
+	copiedStateIconVariant?: UncopiedStateIconVariants | null
+	/* Background styling for copied state */
+	copiedStateBGStyleVariant?: CopiedStateBGStyleVariants;
+	/* Text to copy to the clipboard */
+	textToCopy: string;
+};
+
+export const CopyButton = (props: ICopyButtonProps) => {
+	const {
+		tag,
+		className,
+		copiedTimeout,
+		uncopiedStateText,
+		copiedStateText,
+		uncopiedStateIconVariant,
+		copiedStateIconVariant,
+		textToCopy,
+		copiedStateBGStyleVariant,
+	} = props;
+
+	const Tag: any = tag;
+
+	const [isCopied, setIsCopied] = useState(false);
+
+	return (
+		<Container>
+			<Tag
+				onClick={() => {
+					copy(textToCopy);
+					setIsCopied(true);
+					setTimeout(() => setIsCopied(false), copiedTimeout);
+				}}
+				className={classnames(
+					styles.CopyButton,
+					'CopyButton',
+					className,
+					{
+						[styles.CopyButton__Color_Gray]: !isCopied,
+						[styles.CopyButton__Color_Green]: isCopied && copiedStateBGStyleVariant === CopiedStateBGStyleVariants.green,
+						[styles.CopyButton__Color_None]: isCopied && copiedStateBGStyleVariant === CopiedStateBGStyleVariants.transparent,
+					}
+				)}
+			>
+				<CopyButtonIcon
+					variant={isCopied ? copiedStateIconVariant : uncopiedStateIconVariant}
+					classNames={styles.CopyButtonIcon}
+				/>
+				<span
+					className={classnames(
+						styles.CopyButtonText,
+						{
+							[styles.CopyButtonText__Margin]: !!(isCopied ? copiedStateIconVariant : uncopiedStateIconVariant)
+						}
+					)}
+				>
+					{isCopied ? copiedStateText : uncopiedStateText}
+				</span>
+			</Tag>
+		</Container>
+	)
+};
+
+CopyButton.defaultProps = {
+	tag: 'button',
+	copiedTimeout: 1000,
+	uncopiedStateText: 'COPY',
+	copiedStateText: 'COPIED',
+	uncopiedStateIconVariant: UncopiedStateIconVariants.link,
+	copiedStateIconVariant: CopiedStateIconVariants.checkmark,
+	copiedStateBGStyleVariant: CopiedStateBGStyleVariants.green,
+	/**
+	 * Though this prop is optional, it is included here so that any falsy JS values (null & undefined in particular)
+	 * are passed into the user's clipboard as an empty string
+	 */
+	textToCopy: '',
+};

--- a/src/components/buttons/CopyButton/README.md
+++ b/src/components/buttons/CopyButton/README.md
@@ -1,0 +1,5 @@
+```js
+import { CopyButtonExample } from './examples/CopyButtonExample';
+
+<CopyButtonExample />
+```

--- a/src/components/buttons/CopyButton/_private/CopyButtonIcon.tsx
+++ b/src/components/buttons/CopyButton/_private/CopyButtonIcon.tsx
@@ -1,0 +1,64 @@
+import * as React from 'react';
+
+export enum CopiedStateIconVariants {
+	checkmark = 'checkmark',
+	checkmarkBackground = 'checkmarkBackground',
+}
+
+export enum UncopiedStateIconVariants {
+	link = 'link',
+}
+
+interface ICopyButtonIconProps {
+	/* Icon variant to display */
+	variant: CopiedStateIconVariants | UncopiedStateIconVariants | null;
+	classNames: string;
+};
+
+export const CopyButtonIcon = (props: ICopyButtonIconProps) => {
+	const { variant } = props;
+	const { checkmark, checkmarkBackground } = CopiedStateIconVariants;
+	const { link } = UncopiedStateIconVariants;
+
+	if (variant === link) {
+		return (
+			<svg xmlns="http://www.w3.org/2000/svg" width="10.511" height="10.507" viewBox="0 0 10.511 10.507">
+  				<g id="Group_21084" data-name="Group 21084" transform="translate(8955.2 12611.389)">
+    				<path id="url" d="M1586.311,1764.995l-3.386-3.385a.506.506,0,0,1,.716-.716l3.386,3.385a.506.506,0,0,1-.716.716Zm2.651-2.36-.258-.258a.506.506,0,1,0-.716.716l.317.317a2.06,2.06,0,0,1,.311,2.572,2.028,2.028,0,0,1-3.134.331l-.358-.358a.506.506,0,0,0-.716.716l.358.358a3.038,3.038,0,0,0,4.352-.057A3.129,3.129,0,0,0,1588.962,1762.635Zm-7.356-.2a2.027,2.027,0,0,1,.331-3.133,2.062,2.062,0,0,1,2.573.311l.317.316a.506.506,0,0,0,.716-.715l-.268-.268a3.123,3.123,0,0,0-4.319-.155,3.035,3.035,0,0,0-.067,4.359l.358.358a.506.506,0,0,0,.716-.716Z" transform="translate(-10535 -14369)" fill="#434344" stroke="#434344" stroke-width="0.4"/>
+  				</g>
+			</svg>
+		);
+	}
+
+	if (variant === checkmark) {
+		return (
+			<svg xmlns="http://www.w3.org/2000/svg" width="9.62" height="7.709" viewBox="0 0 9.62 7.709">
+				<g id="Group_384" data-name="Group 384" transform="translate(-1032.5 -467.687)">
+				  <path id="Path_217" data-name="Path 217" d="M14.831,5.239,9.54,11.107a.873.873,0,0,1-.673.289h0a.873.873,0,0,1-.673-.289l-2.4-2.4A.952.952,0,0,1,7.135,7.355L8.867,9.086l4.617-5.1a1.03,1.03,0,0,1,1.347-.1A.93.93,0,0,1,14.831,5.239Z" transform="translate(1027 464)" fill="#fff"/>
+				</g>
+ 			 </svg>
+		);
+	}
+
+	if (variant === checkmarkBackground) {
+		return (
+			<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20">
+			  <g id="Group_21010" data-name="Group 21010" transform="translate(8278 14494)">
+			    <g id="Group_20997" data-name="Group 20997" transform="translate(334 -33)">
+			      <circle id="Ellipse_4039" data-name="Ellipse 4039" cx="10" cy="10" r="10" transform="translate(-8612 -14461)" fill="#51bb7b"/>
+			    </g>
+			    <g id="Group_384" data-name="Group 384" transform="translate(-9305.5 -14955.687)">
+			      <path id="Path_217" data-name="Path 217" d="M15.2,5.3,9.7,11.4a.908.908,0,0,1-.7.3H9a.908.908,0,0,1-.7-.3L5.8,8.9A.99.99,0,0,1,7.2,7.5L9,9.3,13.8,4a1.071,1.071,0,0,1,1.4-.1A.967.967,0,0,1,15.2,5.3Z" transform="translate(1027 464)" fill="#fff"/>
+			    </g>
+			  </g>
+			</svg>
+		);
+	}
+
+	return null;
+
+};
+
+CopyButtonIcon.defaultProps = {
+	variant: null,
+};

--- a/src/components/buttons/CopyButton/examples/CopyButtonExample.tsx
+++ b/src/components/buttons/CopyButton/examples/CopyButtonExample.tsx
@@ -1,0 +1,58 @@
+
+import { ComponentExampleBase } from '../../../../common/helpers/ComponentExampleBase';
+import { CopyButton, ICopyButtonProps, CopiedStateBGStyleVariants } from '../CopyButton';
+import { CopiedStateIconVariants, UncopiedStateIconVariants } from '../_private/CopyButtonIcon';
+
+export class CopyButtonExample extends ComponentExampleBase {
+
+	constructor (props: ICopyButtonProps) {
+		super(
+			props,
+			CopyButton,
+			'CopyButton',
+			[
+				{
+					defaultValue: 'Copy Button',
+					propName: 'content (children)',
+					type: 'html',
+				},
+				{
+					propName: 'tag',
+					type: 'string',
+				},
+				{
+					propName: 'copiedTimeout',
+					type: 'string',
+				},
+				{
+					propName: 'uncopiedStateText',
+					type: 'string',
+				},
+				{
+					propName: 'copiedStateText',
+					type: 'string',
+				},
+				{
+					propName: 'uncopiedStateIconVariant',
+					type: 'enum',
+					options: { none: '', ...UncopiedStateIconVariants as object },
+				},
+				{
+					propName: 'copiedStateIconVariant',
+					type: 'enum',
+					options: { none: '', ...CopiedStateIconVariants as object },
+				},
+				{
+					propName: 'copiedStateBGStyleVariant',
+					type: 'enum',
+					options: { none: '', ...CopiedStateBGStyleVariants as object },
+				},
+				{
+					propName: 'textToCopy',
+					type: 'string',
+				},
+			],
+		);
+	}
+
+}

--- a/src/components/buttons/TextButton/TextButton.tsx
+++ b/src/components/buttons/TextButton/TextButton.tsx
@@ -4,7 +4,8 @@ import {
 	ButtonBase,
 	ButtonPropColor,
 	ButtonPropFontSize,
-	ButtonPropForm, IButtonBaseProps,
+	ButtonPropForm,
+	IButtonBaseProps,
 	IButtonCommonProps,
 } from '../_private/ButtonBase/ButtonBase';
 

--- a/src/components/buttons/_private/ButtonBase/ButtonBase.scss
+++ b/src/components/buttons/_private/ButtonBase/ButtonBase.scss
@@ -13,8 +13,6 @@ $disabled-text-dark: $gray-dark50;
 	// base styles
 	position: relative;
 	background: transparent;
-	text-transform: uppercase;
-	font-weight: 700;
 	transition: transform 0.1s ease 0s;
 	text-decoration: none;
 	text-align: center;
@@ -34,12 +32,16 @@ $disabled-text-dark: $gray-dark50;
 		'--Button_IfFill__Background',
 		'--Button_IfFill__Background_Hover',
 		'--Button_IfFill__TextColor',
-		'--Button_IfFill__TextColor_Hover'
+		'--Button_IfFill__TextColor_Hover',
+		'--Button__FontWeight',
+		'--Button__TextTransform'
 	);
 
 	// css variable-based styles
 	color: var(--Button_TextColor);
 	background: var(--Button_Background);
+	font-weight: var(--Button__FontWeight);
+	text-transform: var(--Button__TextTransform);
 	border: none;
 
 	// use explicit hover color rather than default color to ensure tags like 'a' don't inherit their global style
@@ -176,6 +178,22 @@ $disabled-text-dark: $gray-dark50;
 	@include setThemeVar('--Button_IfFill__TextColor', $white);
 	@include setThemeVar('--Button_IfFill__Background_Hover', $red-dark50);
 	@include setThemeVar('--Button_IfFill__TextColor_Hover', $white);
+}
+
+.ButtonBase__FontWeight_Heavy {
+	@include setThemeVar('--Button__FontWeight', 700);
+}
+
+.ButtonBase__FontWeight_Medium {
+	@include setThemeVar('--Button__FontWeight', 500);
+}
+
+.ButtonBase__TextTransform_Upper {
+	@include setThemeVar('--Button__TextTransform', uppercase);
+}
+
+.ButtonBase__TextTransform_None {
+	@include setThemeVar('--Button__TextTransform', none);
 }
 
 .ButtonBase__FontSize_XSmall {

--- a/src/components/buttons/_private/ButtonBase/ButtonBase.tsx
+++ b/src/components/buttons/_private/ButtonBase/ButtonBase.tsx
@@ -25,11 +25,21 @@ export enum ButtonPropFontSize {
 	m = 'm',
 }
 
+export enum ButtonPropFontWeight {
+	heavy = 'heavy',
+	medium = 'medium',
+}
+
 export enum ButtonPropForm {
 	fill = 'fill',
 	outline = 'outline',
 	reversed = 'reversed',
 	text = 'text',
+}
+
+enum ButtonPropTextTransform {
+	none = 'none',
+	upper = 'upper',
 }
 
 export interface IButtonCommonProps extends ILocalContainerProps {
@@ -54,6 +64,10 @@ export interface IButtonBaseProps extends IButtonCommonProps {
 	padding?: ButtonPropPadding | keyof typeof ButtonPropPadding;
 	/** The font-fontSize applied to the button. */
 	fontSize?: ButtonPropFontSize | keyof typeof ButtonPropFontSize;
+	/** The font-weight applied to the button */
+	fontWeight?: ButtonPropFontWeight;
+	/** The casing applied to the button */
+	textTransform: ButtonPropTextTransform;
 }
 
 export class ButtonBase extends React.Component<IButtonBaseProps> {
@@ -65,11 +79,15 @@ export class ButtonBase extends React.Component<IButtonBaseProps> {
 		form: ButtonPropForm.fill,
 		padding: ButtonPropPadding.m,
 		tag: 'button',
+		fontWeight: ButtonPropFontWeight.heavy,
+		textTransform: ButtonPropTextTransform.upper,
 	};
 
 	render () {
-		const {children, color, container, className, disabled, fontSize, form, innerRef, onClick, padding, tag, tagProps, ...otherProps} = this.props;
+		const {children, color, container, className, disabled, fontSize, form, innerRef, onClick, padding, fontWeight, textTransform, tag, tagProps, ...otherProps} = this.props;
 		const Tag: any = tag;
+
+		console.log('Button Base', this.props)
 
 		return (
 			<Container {...container}>
@@ -93,6 +111,10 @@ export class ButtonBase extends React.Component<IButtonBaseProps> {
 							[styles.ButtonBase__Padding_Small]: padding === ButtonPropPadding.s,
 							[styles.ButtonBase__Padding_Medium]: padding === ButtonPropPadding.m,
 							[styles.ButtonBase__Padding_Large]: padding === ButtonPropPadding.l,
+							[styles.ButtonBase__FontWeight_Heavy]: fontWeight === ButtonPropFontWeight.heavy,
+							[styles.ButtonBase__FontWeight_Medium]: fontWeight === ButtonPropFontWeight.medium,
+							[styles.ButtonBase__TextTransform_Upper]: textTransform === ButtonPropTextTransform.upper,
+							[styles.ButtonBase__TextTransform_None]: textTransform === ButtonPropTextTransform.none,
 						},
 					)}
 					disabled={disabled}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1965,7 +1965,7 @@ cli-width@^2.0.0:
   resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-2.2.0.tgz#ff19ede8a9a5e579324147b0c11f0fbcbabed639"
   integrity sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=
 
-clipboard-copy@^3.0.0:
+clipboard-copy@^3.0.0, clipboard-copy@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/clipboard-copy/-/clipboard-copy-3.1.0.tgz#4c59030a43d4988990564a664baeafba99f78ca4"
   integrity sha512-Xsu1NddBXB89IUauda5BIq3Zq73UWkjkaQlPQbLNvNsd5WBMnTWPNKYR6HGaySOxGYZ+BKxP2E9X4ElnI3yiPA==


### PR DESCRIPTION
### Audience

Local devs and add-on developers

### Summary

Some of our sweet new designs call for some new components including a `CopyButton` and a `LinkButton`. This adds a `CopyButton` component as well as exposing a new prop on `TextButton` that will allow it to be flexible enough to be used as a `LinkButton`.

### Technical

I debated between using [clipboard-copy](https://github.com/feross/clipboard-copy), [clipboard.js](https://github.com/zenorocha/clipboard.js),
 or rolling my own and landed on the first (`clipboard-copy`). It's tiny (433B) [according to Bundlephobia](https://bundlephobia.com/result?p=clipboard-copy@3.1.0). It attempts to use the Async Clipboard API and if not available falls back to `execCommand`.

Adds some additional `props` to `BaseButton` & `LinkButton` to allow for some more styling flexibility. This will allow us to use `TextButton` for the aforementioned `LinkButton`.

### Screenshots

![CopyButton](https://user-images.githubusercontent.com/21110659/81440310-7296c880-9135-11ea-8e6e-1b628372c7f7.gif)

### JIRA
[PRO-202](https://getflywheel.atlassian.net/browse/PRO-202)