### PR TITLE
fix: link default outline with using-mouse class & adjust outline styles

### DIFF
--- a/src/components/buttons/Close/Close.scss
+++ b/src/components/buttons/Close/Close.scss
@@ -29,8 +29,4 @@
 	&:hover svg path {
 		@include theme-fill-greendark50-else-white-hover;
 	}
-
-	&:focus {
-		@include defaultOutline;
-	}
 }

--- a/src/components/buttons/_private/ButtonBase/ButtonBase.scss
+++ b/src/components/buttons/_private/ButtonBase/ButtonBase.scss
@@ -81,10 +81,6 @@ $disabled-text-dark: $gray-dark50;
 		}
 	}
 
-	&:focus {
-		@include defaultOutline;
-	}
-
 	// if default 'button' tag (otherwise don't impose display style)
 	@at-root button#{&} {
 		display: inline-block;

--- a/src/components/inputs/BrowseInput/BrowseInput.sass
+++ b/src/components/inputs/BrowseInput/BrowseInput.sass
@@ -15,8 +15,6 @@
 
 	button
 		margin-left: auto
-		&:focus
-			@include defaultOutline
 
 	&.BrowseInput__FormInput
 		@include flywheelInput

--- a/src/components/inputs/RadioBlock/RadioBlock.sass
+++ b/src/components/inputs/RadioBlock/RadioBlock.sass
@@ -75,9 +75,6 @@ $zIndexOptionTooltip: $zIndexOptionSelected + 3
 		height: 100%
 		border-radius: 0
 
-		&:focus
-			@include defaultOutline
-
 		@include selectors_setAsDefaults
 			padding: 29px
 		@include selectors_appendToNthParentSelector('.RadioBlock_Option__HeightSizeMedium', 1)

--- a/src/components/layout/AdvancedToggle/AdvancedToggle.sass
+++ b/src/components/layout/AdvancedToggle/AdvancedToggle.sass
@@ -47,9 +47,6 @@
 		&, *
 		 cursor: pointer
 
-		&:focus
-			@include defaultOutline
-
 		svg
 			display: inline
 			width: 14px

--- a/src/components/modules/InnerPaneSidebar/InnerPaneSidebar.sass
+++ b/src/components/modules/InnerPaneSidebar/InnerPaneSidebar.sass
@@ -131,6 +131,7 @@
 			box-shadow: inset 0 0 0 1px $theme-border-light
 
 		&:focus
+			outline: none
 			box-shadow: 0 0 0 2px $green
 
 	p:global(.FormattingHelp)

--- a/src/components/tables/TableList/TableList.sass
+++ b/src/components/tables/TableList/TableList.sass
@@ -87,6 +87,7 @@
 			transition: border .1s ease 0ms
 
 			&:focus
+				outline: none
 				border-color: $gray25
 
 ul.TableList
@@ -120,6 +121,7 @@ ul.TableList
 				color: $gray25
 
 			&:focus
+				outline: none;
 				box-shadow: 0 0 0 2px $green !important
 				border-radius: 3px
 

--- a/src/styles/_partials/_forms.scss
+++ b/src/styles/_partials/_forms.scss
@@ -12,6 +12,7 @@
 	cursor: text;
 
 	&:focus {
+		outline: none;
 		box-shadow: inset 0 0 0 2px $green;
 	}
 

--- a/src/styles/_partials/_mixins.scss
+++ b/src/styles/_partials/_mixins.scss
@@ -60,5 +60,5 @@
 }
 
 @mixin defaultOutline {
-	outline: 5px auto -webkit-focus-ring-color !important; // default chrome outline style
+	outline: 5px auto -webkit-focus-ring-color; // default chrome outline style
 }

--- a/src/styles/base.scss
+++ b/src/styles/base.scss
@@ -4,7 +4,6 @@
 	* {
 		box-sizing: border-box;
 		cursor: default;
-		outline: none;
 		-webkit-user-drag: none;
 	}
 
@@ -12,6 +11,18 @@
 		width: 100%;
 		height: 100%;
 		font-size: 62.5%; // set rems to have a base of 10
+	}
+
+	body {
+		outline: none;
+
+		&.using-mouse :focus {
+			outline: none;
+		}
+
+		&:focus {
+			@include defaultOutline;
+		}
 	}
 
 	body,

--- a/src/styles/components/Popup.scss
+++ b/src/styles/components/Popup.scss
@@ -58,6 +58,7 @@
 				}
 
 				&:focus {
+					outline: none;
 					border-color: #888;
 				}
 			}

--- a/src/styles/forms.scss
+++ b/src/styles/forms.scss
@@ -31,6 +31,7 @@
 		&:not(.FlySelect__Open) {
 			&.FlySelect__Focus,
 			&:focus {
+				outline: none;
 				box-shadow: 0 0 0 2px $green;
 			}
 		}
@@ -177,6 +178,7 @@
 
 			&:hover,
 			&:focus {
+				outline: none;
 				color: $white;
 				background: $green-dark50;
 
@@ -354,10 +356,6 @@
 				svg path {
 					fill: $green;
 				}
-			}
-
-			&:focus {
-				@include defaultOutline;
 			}
 		}
 	}


### PR DESCRIPTION
## Audience

Local users

## Summary

This PR adjusts focus styles so the default outline only shows if the 'using-mouse' class isn't added to the body. This impacts the entire app, so if the user tabs outside the Add Site form they will see default outlines. They will not see default outlines, however, if they click. Requires [this pr](https://github.com/getflywheel/flywheel-local/pull/581) to work.

## Technical

If the 'using-mouse' class is added to the body then they outline style is set to none, otherwise the focus style is set to show the default outline. Outlines are still set to none by default.

## Reference

- **NOJIRA**
