### PR TITLE
feat(PRO-230): change "LOGIN" to "LOGIN TO HUB" in WorkspaceSwitcher

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@getflywheel/local-components",
-	"version": "13.2.1",
+	"version": "13.2.2",
 	"repository": "https://github.com/getflywheel/local-components",
 	"homepage": "https://build.localbyflywheel.com",
 	"description": "",

--- a/src/components/modules/VerticalNav/components/WorkspaceSwitcher.tsx
+++ b/src/components/modules/VerticalNav/components/WorkspaceSwitcher.tsx
@@ -232,7 +232,7 @@ export class WorkspaceSwitcher extends React.Component<IWorkspaceSwitcherProps, 
 
 						{showLoginButton
 							? <TextButton onClick={onClickLogin}>
-								LOGIN
+								LOGIN TO HUB
 							</TextButton>
 							: <TextButton onClick={onClickLogout}>
 								LOGOUT


### PR DESCRIPTION
## Summary

Change "LOGIN" to "LOGIN TO HUB" in `<WorkspaceSwitcher />` to improve clarity.

## Technical

This PR includes the version bump.