### PR TITLE
ci: change how secureFilepath is referenced for GitHub SSH key

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,12 +23,13 @@ steps:
   displayName: 'Configure Git'
   
 - task: DownloadSecureFile@1
+  name: downloadKey
   inputs:
     secureFile: local_components_deploy_key
   displayName: 'Get the deploy key'
 
 - script: |
-    mkdir ~/.ssh && mv $DOWNLOADSECUREFILE_SECUREFILEPATH ~/.ssh/id_rsa
+    mkdir ~/.ssh; mv $(downloadKey.secureFilePath) ~/.ssh/id_rsa
     chmod 700 ~/.ssh && chmod 600 ~/.ssh/id_rsa
     ssh-keyscan -t rsa github.com >> ~/.ssh/known_hosts
   displayName: 'Add Deploy Key'


### PR DESCRIPTION
**Audience:** 

Developers referencing [the styleguide](https://getflywheel.github.io/local-components)

**Summary:**

Adjust CI steps for adding deploy key to fix a failure that was preventing Styleguidist from rebuilding on GitHub Pages.