### PR TITLE
fix: Enums where key/value don't match blow up keyof typeof

### DIFF
--- a/src/components/buttons/CopyButton/CopyButton.tsx
+++ b/src/components/buttons/CopyButton/CopyButton.tsx
@@ -19,8 +19,8 @@ export enum CopiedStateBGStyleVariants {
 }
 
 enum PaddingAmount {
-	small = 's',
-	medium = 'm',
+	small = 'small',
+	medium = 'medium',
 }
 
 export interface ICopyButtonProps extends ILocalContainerProps {


### PR DESCRIPTION
It turns out that `keyof typeof` requires enums to have exact matching `key` `value` pairs. Here is one more small fix to get this working correctly from a consumer standpoint.