### PR TITLE
feat: add more "closing" configurability to Popup

### DIFF
--- a/src/components/buttons/CopyButton/CopyButton.scss
+++ b/src/components/buttons/CopyButton/CopyButton.scss
@@ -81,6 +81,10 @@
 	@include setThemeVar('--Button_Padding', 0px);
 }
 
-.CopyButtonText__Margin {
+.CopyButton__Text {
+	font-size: 12px;
+}
+
+.CopyButton__Text_Margin {
 	margin-left: 5px;
 }

--- a/src/components/buttons/CopyButton/CopyButton.tsx
+++ b/src/components/buttons/CopyButton/CopyButton.tsx
@@ -97,9 +97,9 @@ export const CopyButton = (props: ICopyButtonProps) => {
 				/>
 				<span
 					className={classnames(
-						styles.CopyButtonText,
+						styles.CopyButton__Text,
 						{
-							[styles.CopyButtonText__Margin]: !!(isCopied ? copiedStateIconVariant : uncopiedStateIconVariant)
+							[styles.CopyButton__Text_Margin]: !!(isCopied ? copiedStateIconVariant : uncopiedStateIconVariant)
 						}
 					)}
 				>

--- a/src/components/overlays/Popup/Popup.sass
+++ b/src/components/overlays/Popup/Popup.sass
@@ -7,7 +7,6 @@
 
 	position: relative
 	display: inline-block
-	@include cursorPointer
 
 	// states / modifiers
 	&.Popup__Open
@@ -16,6 +15,7 @@
 	&.Popup__PositionRight
 	&.Popup__PositionTop
 	&.Popup__CenteredTail
+	&.Popup__Cursor_Pointer
 
 	.Popup_BubbleWrapper
 		position: absolute
@@ -132,3 +132,7 @@
 			opacity: 0
 		@include selectors_ifHostHasModifier('.Popup__Open')
 			opacity: 1
+
+
+	@include selectors_ifHostHasModifier('.Popup__Cursor_Pointer')
+		@include cursorPointer

--- a/src/components/overlays/Popup/Popup.tsx
+++ b/src/components/overlays/Popup/Popup.tsx
@@ -2,8 +2,7 @@ import * as React from 'react';
 import classnames from 'classnames';
 import * as styles from './Popup.sass';
 import IReactComponentProps from '../../../common/structures/IReactComponentProps';
-
-const { Children, cloneElement, isValidElement } = React;
+import cloneNodes from '../../../utils/cloneNodes';
 
 /**
  * Try catch for Local vs. Styleguidist
@@ -92,6 +91,8 @@ export default class Popup extends React.Component<IProps, IState> {
 		catch (error) {}
 	}
 
+	handleClose = () => this.setState({ open: false });
+
 	render () {
 		const transformStyles = [
 			...(this.props.offsetX ? [`translateX(${this.props.offsetX})`] : []),
@@ -135,7 +136,10 @@ export default class Popup extends React.Component<IProps, IState> {
 							)}
 						>
 							<div className={styles.Popup_BubbleContent}>
-								{this.props.children}
+								{/**
+								 * Clone children and pass a handler function to close the Popup so child nodes can control closing the popup if necessary
+								 */}
+								{cloneNodes(this.props.children, { handleClosePopup: this.handleClose })}
 							</div>
 						</div>
 					</div>
@@ -144,13 +148,7 @@ export default class Popup extends React.Component<IProps, IState> {
 				 * Clone top level triggerContents elements and pass this.state to them
 				 * This will allow triggerContents to be state aware to make appropriate styling decisions, etc.
 				 */}
-				{Children.map(this.props.triggerContent, child => {
-					if (!isValidElement(child)) {
-						return child;
-					}
-
-					return cloneElement(child, { popupState: { ...this.state }});
-				})}
+				{cloneNodes(this.props.triggerContent, { popupState: { ...this.state }})}
 			</div>
 		);
 	}

--- a/src/components/overlays/Popup/Popup.tsx
+++ b/src/components/overlays/Popup/Popup.tsx
@@ -27,7 +27,7 @@ interface IProps extends IReactComponentProps {
 	triggerContent?: React.ReactNode;
 	triggerAble?: boolean;
 	closeOnPopupClick?: boolean;
-	centerTail: boolean;
+	centerTail?: boolean;
 }
 
 interface IState {

--- a/src/components/overlays/Popup/Popup.tsx
+++ b/src/components/overlays/Popup/Popup.tsx
@@ -26,7 +26,8 @@ interface IProps extends IReactComponentProps {
 	padding?: boolean;
 	position?: 'bottom' | 'right' | 'top';
 	triggerContent?: React.ReactNode;
-	triggerAble: boolean;
+	triggerAble?: boolean;
+	closeOnPopupClick?: boolean;
 	centerTail: boolean;
 }
 
@@ -42,6 +43,7 @@ export default class Popup extends React.Component<IProps, IState> {
 		padding: true,
 		position: 'bottom',
 		triggerAble: true,
+		closeOnPopupClick: true,
 		centerTail: false,
 	};
 
@@ -67,8 +69,8 @@ export default class Popup extends React.Component<IProps, IState> {
 
 	onClick () {
 		const { open } = this.state;
-		const { triggerAble } = this.props;
-		if (!open && !triggerAble) {
+		const { triggerAble, closeOnPopupClick } = this.props;
+		if ((!open && !triggerAble) || (open && !closeOnPopupClick)) {
 			return;
 		}
 
@@ -107,6 +109,7 @@ export default class Popup extends React.Component<IProps, IState> {
 						[styles.Popup__PositionRight]: this.props.position === 'right',
 						[styles.Popup__PositionTop]: this.props.position === 'top',
 						[styles.Popup__CenteredTail]: this.props.centerTail,
+						[styles.Popup__Cursor_Pointer]: this.props.closeOnPopupClick,
 					},
 					this.props.className,
 				)}

--- a/src/utils/cloneNodes.ts
+++ b/src/utils/cloneNodes.ts
@@ -1,0 +1,16 @@
+import { Children, isValidElement, cloneElement } from 'react';
+
+/**
+ * Helper to clone React nodes and shallow merge an props
+ * @param nodes nodes to clone
+ * @param extraProps additional props to shallow merge in with addrtional props
+ */
+export default function cloneNodes(nodes: React.ReactNode, extraProps: { [key: string]: any }): React.ReactNode {
+	return Children.map(nodes, (node) => {
+		if (!isValidElement(node))	{
+			return node;
+		}
+
+		return cloneElement(node, { ...extraProps });
+	});
+}


### PR DESCRIPTION
The Popup component needed some love to make it more versatile and useable for Live Links UI. Here it is!

- Adds ability to toggle whether or not clicking the `Popup` contents will close the `Popup`
- Passes a handler function to child nodes that allow child components to close the `Popup`
- Fixes font size issue on Copy Button
- Adds a new util function to assist in cloning React nodes and shallow merging arbitrary props in with cloned nodes