### PR TITLE
fix(LOC-1905): correction to site info page so live link popups display properly

### DIFF
--- a/src/styles/containers/SiteInfo.scss
+++ b/src/styles/containers/SiteInfo.scss
@@ -6,7 +6,7 @@
 		display: flex;
 		flex-direction: column;
 		position: relative;
-		width: 0;
+		min-width: 0;
 	}
 
 	.DownloaderOverlay {

--- a/src/styles/containers/SiteInfo.scss
+++ b/src/styles/containers/SiteInfo.scss
@@ -6,7 +6,7 @@
 		display: flex;
 		flex-direction: column;
 		position: relative;
-		overflow: hidden;
+		width: 0;
 	}
 
 	.DownloaderOverlay {


### PR DESCRIPTION
**Audience**

Local users.

**Summary**

Update the CSS for site info overview page; this fix allows live link popups to display properly without being cut off.

**Technical**

The `overflow` property of the overarching `SiteInfo` class was removed in favor of `min-width: 0`. This restricts the flexbox content from extending beyond the window size, but still allows "overflow" from elements such as the live link popups. [An extended explanation can be found here.](https://makandracards.com/makandra/66994-css-flex-and-min-width)
