### PR TITLE
feat(PRO-260): Make TertiaryNav fixed width; change dark theme active nav item bg color

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@getflywheel/local-components",
-	"version": "13.3.2",
+	"version": "13.3.3",
 	"repository": "https://github.com/getflywheel/local-components",
 	"homepage": "https://build.localbyflywheel.com",
 	"description": "",

--- a/src/components/menus/TertiaryNav/TertiaryNav.sass
+++ b/src/components/menus/TertiaryNav/TertiaryNav.sass
@@ -20,7 +20,7 @@
 		list-style-type: none
 
 	.TertiaryNav
-		width: 200px;
+		width: 200px
 		padding: 16px 12px
 		overflow-y: auto
 		@include theme-border-right

--- a/src/components/menus/TertiaryNav/TertiaryNav.sass
+++ b/src/components/menus/TertiaryNav/TertiaryNav.sass
@@ -20,9 +20,7 @@
 		list-style-type: none
 
 	.TertiaryNav
-		width: 25%
-		min-width: 230px
-		max-width: 480px
+		width: 200px;
 		padding: 16px 12px
 		overflow-y: auto
 		@include theme-border-right
@@ -47,7 +45,7 @@
 			@include if-theme-light()
 				background: $gray5
 			@include if-theme-dark()
-				background: none
+				background: $gray-dark50
 
 			svg path
 				fill: $white

--- a/src/components/menus/TertiaryNav/TertiaryNav.tsx
+++ b/src/components/menus/TertiaryNav/TertiaryNav.tsx
@@ -30,7 +30,7 @@ export class TertiaryNav extends React.Component<ITertiaryNavProps & IReactCompo
 				</ul>
 				<div className={classnames(styles.TertiaryContent)}>
 					<Switch>
-						{React.Children.map(this.props.children, (child: any, index: number) => {
+						{React.Children.map(this.props.children, (child: any) => {
 							const propsWithoutChildren = { ...child.props };
 							delete propsWithoutChildren.children;
 							return (

--- a/src/components/menus/TertiaryNav/TertiaryNav.tsx
+++ b/src/components/menus/TertiaryNav/TertiaryNav.tsx
@@ -7,7 +7,7 @@ import { FunctionGeneric } from '../../../common/structures/Generics';
 
 interface ITertiaryNavProps extends IReactComponentProps {
 
-	children?: Array<React.ReactElement<TertiaryNavItem>> | React.ReactElement<TertiaryNavItem>;
+	children?: TertiaryNavItem[];
 
 }
 
@@ -17,9 +17,7 @@ interface ITertiaryNavProps extends IReactComponentProps {
 // https://github.com/DefinitelyTyped/DefinitelyTyped/issues/24077#issuecomment-455487092
 @(withRouter as any)
 export class TertiaryNav extends React.Component<ITertiaryNavProps & IReactComponentProps & RouteComponentProps> {
-
 	render () {
-		let firstNavItem: any;
 		return (
 			<div
 				className={classnames(
@@ -35,9 +33,6 @@ export class TertiaryNav extends React.Component<ITertiaryNavProps & IReactCompo
 						{React.Children.map(this.props.children, (child: any, index: number) => {
 							const propsWithoutChildren = { ...child.props };
 							delete propsWithoutChildren.children;
-							if (index === 0) {
-								firstNavItem = child;
-							}
 							return (
 								<Route
 									{...propsWithoutChildren}
@@ -45,11 +40,11 @@ export class TertiaryNav extends React.Component<ITertiaryNavProps & IReactCompo
 								/>
 							);
 						})}
-						{firstNavItem &&
+						{this.props.children?.length &&
 							(
 								<Redirect
 									from={`${this.props.match.url}`}
-									to={`${this.props.match.url}${firstNavItem.props.path}`}
+									to={`${this.props.match.url}${this.props.children?.[0].props.path}`}
 								/>
 							)
 

--- a/src/components/menus/TertiaryNav/TertiaryNav.tsx
+++ b/src/components/menus/TertiaryNav/TertiaryNav.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import classnames from 'classnames';
-import { Switch, Route, NavLink, RouteComponentProps, withRouter } from 'react-router-dom';
+import { Switch, Route, NavLink, RouteComponentProps, withRouter, Redirect } from 'react-router-dom';
 import * as styles from './TertiaryNav.sass';
 import IReactComponentProps from '../../../common/structures/IReactComponentProps';
 import { FunctionGeneric } from '../../../common/structures/Generics';
@@ -19,6 +19,7 @@ interface ITertiaryNavProps extends IReactComponentProps {
 export class TertiaryNav extends React.Component<ITertiaryNavProps & IReactComponentProps & RouteComponentProps> {
 
 	render () {
+		let firstNavItem: any;
 		return (
 			<div
 				className={classnames(
@@ -31,10 +32,12 @@ export class TertiaryNav extends React.Component<ITertiaryNavProps & IReactCompo
 				</ul>
 				<div className={classnames(styles.TertiaryContent)}>
 					<Switch>
-						{React.Children.map(this.props.children, (child: any) => {
+						{React.Children.map(this.props.children, (child: any, index: number) => {
 							const propsWithoutChildren = { ...child.props };
 							delete propsWithoutChildren.children;
-
+							if (index === 0) {
+								firstNavItem = child;
+							}
 							return (
 								<Route
 									{...propsWithoutChildren}
@@ -42,6 +45,15 @@ export class TertiaryNav extends React.Component<ITertiaryNavProps & IReactCompo
 								/>
 							);
 						})}
+						{firstNavItem &&
+							(
+								<Redirect
+									from={`${this.props.match.url}`}
+									to={`${this.props.match.url}${firstNavItem.props.path}`}
+								/>
+							)
+
+						}
 					</Switch>
 				</div>
 			</div>


### PR DESCRIPTION
**Summary:**

Needed to update the TertiaryNav and TertiaryNavItem styling a bit.
- TertiaryNav to be a fixed 200px.
- When in Dark Mode and a TertiaryNavItem is selected there was no active background color -- changing this to be $gray-dark50

**Important**: If you want to test this via the Local app there are 2 other PRs coming, one for Flywheel-Local and one for Local-Addon-Broken-Link-Checker

<img width="1000" alt="Screen Shot 2020-06-10 at 9 42 08 AM" src="https://user-images.githubusercontent.com/62450648/84281864-b1d28380-aafe-11ea-9084-4d068e445e2f.png">
