### PR TITLE
fix(PRO-340): don't pass down extra props to cloned nodes in cloneNodes

### DIFF
--- a/src/utils/cloneNodes.ts
+++ b/src/utils/cloneNodes.ts
@@ -1,16 +1,28 @@
 import { Children, isValidElement, cloneElement } from 'react';
+import { isString } from 'lodash';
 
 /**
- * Helper to clone React nodes and shallow merge an props
  * @param nodes nodes to clone
- * @param extraProps additional props to shallow merge in with addrtional props
+ * @param extraProps additional props to shallow merge in with props
+ * Helper to clone React nodes and shallow merge in additional props
+ * *Note that this will not merge in the additional props if the node is a native DOM element to avoid passing down invalid props to DOM elements*
  */
-export default function cloneNodes(nodes: React.ReactNode, extraProps: { [key: string]: any }): React.ReactNode {
+export default function cloneNodes(nodes: React.ReactNode, props: { [key: string]: any }): React.ReactNode {
 	return Children.map(nodes, (node) => {
 		if (!isValidElement(node))	{
 			return node;
 		}
 
-		return cloneElement(node, { ...extraProps });
+		/**
+		 * if the node is a primitive DOM element rather than a React element, clone it but don't pass it props
+		 * React elements (primitive DOM nodes) type property is a string while React coponents will be of type function or class
+		 * see this for more info: https://reactjs.org/blog/2015/12/18/react-components-elements-and-instances.html
+		 */
+		if (isString(node.type)) {
+			return cloneElement(node);
+		}
+
+		return cloneElement(node, { ...props });
 	});
 }
+


### PR DESCRIPTION
## Summary

We're getting few warnings in the flavor of:

```
Warning: React does not recognize the `<propName>` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `<propname>` instead. If you accidentally passed it from a parent component, remove it from the DOM element.
```

This is due to the `cloneNodes` function blindly merging in additional `props` with all nodes it is cloning. This can be avoided by only passing additional props to React components and NOT React elements.

Checking wether or not a `node` is a component or element was relatively straightforward once I understood how React represents these two entities. If you're curious to know more, I highly recommend [this doc](https://reactjs.org/blog/2015/12/18/react-components-elements-and-instances.html)