### PR TITLE
fix: yarn link issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
 		"@types/jest": "^23.3.11",
 		"@types/lodash.isequal": "^4.5.3",
 		"@types/node": "^10.12.18",
-		"@types/react": "^16.9.2",
+		"@types/react": "^16.9.41",
 		"@types/react-dom": "^16.9.0",
 		"@types/react-modal": "^3.6.0",
 		"@types/react-router-dom": "^5.0.1",
@@ -110,6 +110,7 @@
 		"write-file-webpack-plugin": "^4.4.0"
 	},
 	"resolutions": {
+		"@types/react": "^16.9.41",
 		"js-yaml": ">=3.13.1",
 		"fstream": ">=1.0.12",
 		"tar": ">=2.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -604,10 +604,10 @@
     "@types/history" "*"
     "@types/react" "*"
 
-"@types/react@*", "@types/react@^16.9.2":
-  version "16.9.35"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.35.tgz#a0830d172e8aadd9bd41709ba2281a3124bbd368"
-  integrity sha512-q0n0SsWcGc8nDqH2GJfWQWUOmZSJhXV64CjVN5SvcNti3TdEaA3AH0D8DwNmMdzjMAC/78tB8nAZIlV8yTz+zQ==
+"@types/react@*", "@types/react@^16.9.41":
+  version "16.9.41"
+  resolved "https://registry.npmjs.org/@types/react/-/react-16.9.41.tgz#925137ee4d2ff406a0ecf29e8e9237390844002e"
+  integrity sha512-6cFei7F7L4wwuM+IND/Q2cV1koQUvJ8iSV+Gwn0c3kvABZ691g7sp3hfEQHOUBJtccl1gPi+EyNjMIl9nGA0ug==
   dependencies:
     "@types/prop-types" "*"
     csstype "^2.2.0"


### PR DESCRIPTION
`yarn link`ing this package with `flywheel-local` has been causing TS errors due to differing `@types/react` versions in this package, this package's deps and Local. The fix is to use Yarn `resolutions` to ensure that the same version is used for all packages involved.