### PR TITLE
refactor(PRO-297): styling changes to CopyButton component

### DIFF
--- a/src/components/buttons/CopyButton/CopyButton.scss
+++ b/src/components/buttons/CopyButton/CopyButton.scss
@@ -6,6 +6,7 @@
 	display: flex;
 	align-items: center;
 	padding: 5px;
+	font-weight: 700;
 	background: transparent;
 	border: none;
 	border-radius: 5px;
@@ -45,7 +46,7 @@
 }
 
 .CopyButton__Color_Gray_Padding_Small {
-	@include setThemeVar('--Button_Padding', 5px);
+	@include setThemeVar('--Button_Padding', 5px 10px);
 }
 .CopyButton__Color_Gray_Padding_Medium {
 	@include setThemeVar('--Button_Padding', 10px);
@@ -59,7 +60,7 @@
 }
 
 .CopyButton__Color_Green_Padding_Small {
-	@include setThemeVar('--Button_Padding', 5px);
+	@include setThemeVar('--Button_Padding', 5px 10px);
 }
 
 .CopyButton__Color_Green_Padding_Medium {


### PR DESCRIPTION
## Audience

Local Users

## Summary

Updates the CopyButton component to increase font weight and add additional right/left padding on the "Padding_Small" class variations.

One of two pull requests submitted for PRO-297; second PR located [here.](https://github.com/getflywheel/flywheel-local/pull/684)

## Technical

Minor SCSS changes only.

## Reference

- [PRO-297](https://getflywheel.atlassian.net/browse/PRO-297)