### PR TITLE
fix(PRO-486): windows style bugs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@getflywheel/local-components",
-	"version": "14.0.1",
+	"version": "14.0.2",
 	"repository": "https://github.com/getflywheel/local-components",
 	"homepage": "https://build.localbyflywheel.com",
 	"description": "",

--- a/src/components/menus/TertiaryNav/TertiaryNav.sass
+++ b/src/components/menus/TertiaryNav/TertiaryNav.sass
@@ -67,6 +67,6 @@
 
 	.TertiaryContent
 		flex: 1
-		overflow-y: auto
+		overflow: inherit
 
 

--- a/src/components/modules/SiteInfoInnerPane/SiteInfoInnerPane.sass
+++ b/src/components/modules/SiteInfoInnerPane/SiteInfoInnerPane.sass
@@ -3,4 +3,4 @@
 .SiteInfoInnerPane
 	flex: 1
 	display: flex
-	overflow-y: auto
+	overflow: inherit

--- a/src/components/modules/SiteInfoInnerPane/SiteInfoInnerPane.tsx
+++ b/src/components/modules/SiteInfoInnerPane/SiteInfoInnerPane.tsx
@@ -2,18 +2,15 @@ import * as React from 'react';
 import IReactComponentProps from '../../../common/structures/IReactComponentProps';
 import * as styles from './SiteInfoInnerPane.sass';
 
-export default class SiteInfoInnerPane extends React.Component<IReactComponentProps> {
-	render () {
-		const propsWithoutChildren = { ...this.props };
-		delete propsWithoutChildren.children;
+export default function SiteInfoInnerPane(props: IReactComponentProps) {
+	const { children, ...propsWithoutChildren } = props;
 
-		return (
-			<div
-				className={styles.SiteInfoInnerPane}
-				{...propsWithoutChildren}
-			>
-				{this.props.children}
-			</div>
-		);
-	}
+	return (
+		<div
+			className={styles.SiteInfoInnerPane}
+			{...propsWithoutChildren}
+		>
+			{children}
+		</div>
+	);
 }


### PR DESCRIPTION
## Summary
- fixes the Pro tab -> Instant Reload -> Info Tootip is hidden on Windows
- sneaks in a little class to function upgrade for `<SiteInfoPane />`


## Reference
[PRO-486](https://getflywheel.atlassian.net/browse/PRO-486)
[Flywheel Local Sister PR](https://github.com/getflywheel/flywheel-local/pull/761)