### PR TITLE
feat(LOC-2034): add id, className, and style to all remaining component candidates

### DIFF
--- a/src/common/structures/IReactComponentProps.ts
+++ b/src/common/structures/IReactComponentProps.ts
@@ -4,6 +4,7 @@ export default interface IReactComponentProps {
 	children?: React.ReactNode;
 	className?: string;
 	key?: string | number;
+	id?: string;
 	innerRef?: (element: HTMLElement) => void | string;
 	onClick?: any;
 	style?: object;

--- a/src/components/alerts/Banner/Banner.test.tsx
+++ b/src/components/alerts/Banner/Banner.test.tsx
@@ -1,7 +1,15 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
 import Banner from './Banner';
+import TestComponentPropUtils from '../../../utils/TestComponentPropUtils';
 
-it('renders without crashing', () => {
-	shallow(<Banner />);
+describe('Banner', () => {
+	it('renders without crashing', () => {
+		shallow(<Banner />);
+	});
+
+	it('renders basic react props like id, className, and style as element attributes', () => {
+		const shallowWrapper = shallow(<Banner {...TestComponentPropUtils.basicReactProps} />);
+		TestComponentPropUtils.expectsBasicReactProps(shallowWrapper, false);
+	});
 });

--- a/src/components/alerts/Banner/Banner.tsx
+++ b/src/components/alerts/Banner/Banner.tsx
@@ -8,8 +8,7 @@ import { ButtonPropColor, ButtonPropForm } from '../../buttons/_private/ButtonBa
 import { TextButton, TextButtonPropSize } from '../../buttons/TextButton/TextButton';
 import { FunctionGeneric } from '../../../common/structures/Generics';
 
-interface IProps extends IReactComponentProps {
-
+interface BannerProps extends IReactComponentProps {
 	buttonText?: string;
 	currentIndex?: number;
 	buttonOnClick?: FunctionGeneric;
@@ -18,19 +17,17 @@ interface IProps extends IReactComponentProps {
 	onDismiss?: FunctionGeneric;
 	onIndexChange?: FunctionGeneric;
 	variant?: 'warning' | 'neutral' | 'success' | 'error';
-
 }
 
-export default class Banner extends React.Component<IProps> {
-
-	static defaultProps: Partial<IProps> = {
+export default class Banner extends React.Component<BannerProps> {
+	static defaultProps: Partial<BannerProps> = {
 		currentIndex: 0,
 		icon: 'warning',
 		numBanners: 1,
 		variant: 'neutral',
 	};
 
-	constructor (props: IProps) {
+	constructor (props: BannerProps) {
 		super(props);
 	}
 
@@ -136,7 +133,10 @@ export default class Banner extends React.Component<IProps> {
 						[styles.Banner__Error]: this.props.variant === 'error',
 						[styles.Banner__Success]: this.props.variant === 'success',
 					},
+					this.props.className
 				)}
+				id={this.props.id}
+				style={this.props.style}
 			>
 				{this.renderCarousel()}
 				{this.renderIcon()}

--- a/src/components/alerts/BannerCarousel/BannerCarousel.test.tsx
+++ b/src/components/alerts/BannerCarousel/BannerCarousel.test.tsx
@@ -1,7 +1,15 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
 import BannerCarousel from './BannerCarousel';
+import TestComponentPropUtils from '../../../utils/TestComponentPropUtils';
 
-it('renders without crashing', () => {
-	shallow(<BannerCarousel />);
+describe('BannerCarousel', () => {
+	it('renders without crashing', () => {
+		shallow(<BannerCarousel />);
+	});
+
+	it('renders basic react props like id, className, and style as element attributes', () => {
+		const shallowWrapper = shallow(<BannerCarousel {...TestComponentPropUtils.basicReactProps} />);
+		TestComponentPropUtils.expectsBasicReactProps(shallowWrapper, false);
+	});
 });

--- a/src/components/alerts/BannerCarousel/BannerCarousel.tsx
+++ b/src/components/alerts/BannerCarousel/BannerCarousel.tsx
@@ -2,13 +2,10 @@ import * as React from 'react';
 import IReactComponentProps from '../../../common/structures/IReactComponentProps';
 
 interface IState {
-
 	currentIndex?: number;
-
 }
 
 export default class BannerCarousel extends React.Component<IReactComponentProps, IState> {
-
 	constructor (props: IReactComponentProps) {
 		super(props);
 
@@ -19,7 +16,11 @@ export default class BannerCarousel extends React.Component<IReactComponentProps
 
 	render () {
 		return (
-			<div>
+			<div
+				className={this.props.className}
+				id={this.props.id}
+				style={this.props.style}
+			>
 				{React.Children.map(this.props.children as React.ReactElement, (banner: React.ReactChild, index: number) => {
 					if (this.state.currentIndex !== index) {
 						return null;

--- a/src/components/buttons/Button/Button.test.tsx
+++ b/src/components/buttons/Button/Button.test.tsx
@@ -1,15 +1,15 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
-import FlyTooltip from './FlyTooltip';
 import TestComponentPropUtils from '../../../utils/TestComponentPropUtils';
+import { Button } from './Button';
 
-describe('FlyTooltip', () => {
+describe('Button', () => {
 	it('renders without crashing', () => {
-		shallow(<FlyTooltip/>);
+		shallow(<Button />);
 	});
 
 	it('renders basic react props like id, className, and style as element attributes', () => {
-		const shallowWrapper = shallow(<FlyTooltip {...TestComponentPropUtils.basicReactProps} />);
+		const shallowWrapper = shallow(<Button {...TestComponentPropUtils.basicReactProps} />);
 		TestComponentPropUtils.expectsBasicReactProps(shallowWrapper, false);
 	});
 });

--- a/src/components/buttons/Button/Button.tsx
+++ b/src/components/buttons/Button/Button.tsx
@@ -19,7 +19,14 @@ interface IProps extends IButtonCommonProps {
 }
 
 export const Button = (props: IProps) => {
-	const {className, intent, privateOptions, ...otherProps} = props;
+	const {
+		className,
+		id,
+		intent,
+		privateOptions,
+		style,
+		...otherProps
+	} = props;
 
 	return (
 		<ButtonBase
@@ -28,8 +35,10 @@ export const Button = (props: IProps) => {
 				'Button',
 			)}
 			color={setIntentColor(props, ButtonPropColor.gray)}
+			id={id}
 			form={setForm(props, ButtonPropForm.outline)}
 			padding={ButtonPropPadding.m}
+			style={style}
 			{...privateOptions}
 			{...otherProps}
 		/>

--- a/src/components/buttons/Close/Close.test.tsx
+++ b/src/components/buttons/Close/Close.test.tsx
@@ -1,7 +1,16 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
 import Close from './Close';
+import TestComponentPropUtils from '../../../utils/TestComponentPropUtils';
 
-it('renders without crashing', () => {
-	shallow(<Close onClick={() => {}} />);
+describe('Close', () => {
+	it('renders without crashing', () => {
+		shallow(<Close onClick={() => {
+		}}/>);
+	});
+
+	it('renders basic react props like id, className, and style as element attributes', () => {
+		const shallowWrapper = shallow(<Close {...TestComponentPropUtils.basicReactProps} />);
+		TestComponentPropUtils.expectsBasicReactProps(shallowWrapper, false);
+	});
 });

--- a/src/components/buttons/Close/Close.tsx
+++ b/src/components/buttons/Close/Close.tsx
@@ -11,7 +11,6 @@ interface IProps extends IReactComponentProps {
 }
 
 export default class Close extends React.Component<IProps> {
-
 	static defaultProps: Partial<IProps> = {
 		position: 'absolute',
 	};
@@ -34,6 +33,7 @@ export default class Close extends React.Component<IProps> {
 					},
 					this.props.className,
 				)}
+				id={this.props.id}
 				onClick={this.props.onClick}
 				onKeyDown={this.onKeyDown}
 				style={this.props.style}
@@ -42,5 +42,4 @@ export default class Close extends React.Component<IProps> {
 			</span>
 		);
 	}
-
 }

--- a/src/components/buttons/CopyButton/CopyButton.test.tsx
+++ b/src/components/buttons/CopyButton/CopyButton.test.tsx
@@ -1,15 +1,15 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
-import FlyTooltip from './FlyTooltip';
 import TestComponentPropUtils from '../../../utils/TestComponentPropUtils';
+import { CopyButton } from './CopyButton';
 
-describe('FlyTooltip', () => {
+describe('CopyButton', () => {
 	it('renders without crashing', () => {
-		shallow(<FlyTooltip/>);
+		shallow(<CopyButton />);
 	});
 
 	it('renders basic react props like id, className, and style as element attributes', () => {
-		const shallowWrapper = shallow(<FlyTooltip {...TestComponentPropUtils.basicReactProps} />);
-		TestComponentPropUtils.expectsBasicReactProps(shallowWrapper, false);
+		const shallowWrapper = shallow(<CopyButton {...TestComponentPropUtils.basicReactProps} />);
+		TestComponentPropUtils.expectsBasicReactProps(shallowWrapper, true);
 	});
 });

--- a/src/components/buttons/CopyButton/CopyButton.tsx
+++ b/src/components/buttons/CopyButton/CopyButton.tsx
@@ -45,16 +45,18 @@ export interface ICopyButtonProps extends ILocalContainerProps {
 
 export const CopyButton = (props: ICopyButtonProps) => {
 	const {
-		tag,
 		className,
-		copiedTimeout,
-		uncopiedStateText,
-		copiedStateText,
-		uncopiedStateIconVariant,
-		copiedStateIconVariant,
-		textToCopy,
-		padding,
 		copiedStateBGStyleVariant,
+		copiedStateIconVariant,
+		copiedStateText,
+		copiedTimeout,
+		id,
+		padding,
+		style,
+		tag,
+		textToCopy,
+		uncopiedStateText,
+		uncopiedStateIconVariant,
 	} = props;
 
 	const Tag: any = tag;
@@ -90,6 +92,8 @@ export const CopyButton = (props: ICopyButtonProps) => {
 						[styles.CopyButton__Color_None_Padding_Medium]: isCopied && isTransparentCopiedStateBG && mediumPadding,
 					}
 				)}
+				id={id}
+				style={style}
 			>
 				<CopyButtonIcon
 					variant={isCopied ? copiedStateIconVariant as CopiedStateIconVariants : uncopiedStateIconVariant as UncopiedStateIconVariants}

--- a/src/components/buttons/PrimaryButton/PrimaryButton.test.tsx
+++ b/src/components/buttons/PrimaryButton/PrimaryButton.test.tsx
@@ -1,15 +1,15 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
-import FlyTooltip from './FlyTooltip';
 import TestComponentPropUtils from '../../../utils/TestComponentPropUtils';
+import { PrimaryButton } from './PrimaryButton';
 
-describe('FlyTooltip', () => {
+describe('PrimaryButton', () => {
 	it('renders without crashing', () => {
-		shallow(<FlyTooltip/>);
+		shallow(<PrimaryButton />);
 	});
 
 	it('renders basic react props like id, className, and style as element attributes', () => {
-		const shallowWrapper = shallow(<FlyTooltip {...TestComponentPropUtils.basicReactProps} />);
+		const shallowWrapper = shallow(<PrimaryButton {...TestComponentPropUtils.basicReactProps} />);
 		TestComponentPropUtils.expectsBasicReactProps(shallowWrapper, false);
 	});
 });

--- a/src/components/buttons/PrimaryButton/PrimaryButton.tsx
+++ b/src/components/buttons/PrimaryButton/PrimaryButton.tsx
@@ -19,7 +19,14 @@ interface IProps extends IButtonCommonProps {
 }
 
 export const PrimaryButton = (props: IProps) => {
-	const {className, intent, privateOptions, ...otherProps} = props;
+	const {
+		className,
+		id,
+		intent,
+		privateOptions,
+		style,
+		...otherProps
+	} = props;
 
 	return (
 		<ButtonBase
@@ -28,8 +35,10 @@ export const PrimaryButton = (props: IProps) => {
 				'PrimaryButton',
 			)}
 			color={intent === PrimaryButtonPropIntent.destructive ? ButtonPropColor.red : ButtonPropColor.green}
+			id={id}
 			form={ButtonPropForm.fill}
 			padding={ButtonPropPadding.l}
+			style={style}
 			{...privateOptions}
 			{...otherProps}
 		/>

--- a/src/components/buttons/TextButton/TextButton.test.tsx
+++ b/src/components/buttons/TextButton/TextButton.test.tsx
@@ -1,15 +1,15 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
-import FlyTooltip from './FlyTooltip';
 import TestComponentPropUtils from '../../../utils/TestComponentPropUtils';
+import { TextButton } from './TextButton';
 
-describe('FlyTooltip', () => {
+describe('TextButton', () => {
 	it('renders without crashing', () => {
-		shallow(<FlyTooltip/>);
+		shallow(<TextButton />);
 	});
 
 	it('renders basic react props like id, className, and style as element attributes', () => {
-		const shallowWrapper = shallow(<FlyTooltip {...TestComponentPropUtils.basicReactProps} />);
+		const shallowWrapper = shallow(<TextButton {...TestComponentPropUtils.basicReactProps} />);
 		TestComponentPropUtils.expectsBasicReactProps(shallowWrapper, false);
 	});
 });

--- a/src/components/buttons/TextButton/TextButton.tsx
+++ b/src/components/buttons/TextButton/TextButton.tsx
@@ -26,7 +26,15 @@ interface IProps extends IButtonCommonProps {
 }
 
 export const TextButton = (props: IProps) => {
-	const {className, intent, privateOptions, size, ...otherProps} = props;
+	const {
+		className,
+		id,
+		intent,
+		privateOptions,
+		size,
+		style,
+		...otherProps
+	} = props;
 
 	return (
 		<ButtonBase
@@ -37,6 +45,8 @@ export const TextButton = (props: IProps) => {
 			color={intent === TextButtonPropIntent.destructive ? ButtonPropColor.red : ButtonPropColor.green}
 			fontSize={size === TextButtonPropSize.tiny ? ButtonPropFontSize.xs : ButtonPropFontSize.m}
 			form={ButtonPropForm.text}
+			id={id}
+			style={style}
 			{...privateOptions}
 			{...otherProps}
 		/>

--- a/src/components/buttons/_private/ButtonBase/ButtonBase.test.tsx
+++ b/src/components/buttons/_private/ButtonBase/ButtonBase.test.tsx
@@ -1,0 +1,15 @@
+import * as React from 'react';
+import { shallow } from 'enzyme';
+import TestComponentPropUtils from '../../../../utils/TestComponentPropUtils';
+import { ButtonBase } from './ButtonBase';
+
+describe('ButtonBase', () => {
+	it('renders without crashing', () => {
+		shallow(<ButtonBase />);
+	});
+
+	it('renders basic react props like id, className, and style as element attributes', () => {
+		const shallowWrapper = shallow(<ButtonBase {...TestComponentPropUtils.basicReactProps} />);
+		TestComponentPropUtils.expectsBasicReactProps(shallowWrapper, true);
+	});
+});

--- a/src/components/buttons/_private/ButtonBase/ButtonBase.tsx
+++ b/src/components/buttons/_private/ButtonBase/ButtonBase.tsx
@@ -78,7 +78,6 @@ export interface IButtonBaseProps extends IButtonCommonProps {
 }
 
 export class ButtonBase extends React.Component<IButtonBaseProps> {
-
 	static defaultProps: Partial<IButtonBaseProps> = {
 		color: ButtonPropColor.default,
 		disabled: false,
@@ -100,10 +99,12 @@ export class ButtonBase extends React.Component<IButtonBaseProps> {
 			disabled,
 			fontSize,
 			form,
+			id,
 			innerRef,
 			onClick,
 			padding,
 			fontWeight,
+			style,
 			textTransform,
 			textDecoration,
 			tag,
@@ -144,8 +145,10 @@ export class ButtonBase extends React.Component<IButtonBaseProps> {
 						},
 					)}
 					disabled={disabled}
+					id={id}
 					onClick={onClick}
 					ref={innerRef}
+					style={style}
 					{...otherProps}
 					{...tagProps}
 				>
@@ -154,5 +157,4 @@ export class ButtonBase extends React.Component<IButtonBaseProps> {
 			</Container>
 		);
 	}
-
 }

--- a/src/components/inputs/BasicInput/BasicInput.test.tsx
+++ b/src/components/inputs/BasicInput/BasicInput.test.tsx
@@ -1,14 +1,22 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
 import BasicInput from './BasicInput';
+import TestComponentPropUtils from '../../../utils/TestComponentPropUtils';
 
-it ('renders without crashing', () => {
-	shallow(<BasicInput />);
-});
+describe('BasicInput', () => {
+	it('renders without crashing', () => {
+		shallow(<BasicInput />);
+	});
 
-it ('contains a regular input by default', () => {
-	const component = shallow(<BasicInput />);
+	it('contains a regular input by default', () => {
+		const component = shallow(<BasicInput />);
 
-	expect(component.exists('input[type="text"]')).toBe(true);
-	expect(component.exists('input[type="password"]')).toBe(false);
+		expect(component.exists('input[type="text"]')).toBe(true);
+		expect(component.exists('input[type="password"]')).toBe(false);
+	});
+
+	it('renders basic react props like id, className, and style as element attributes', () => {
+		const shallowWrapper = shallow(<BasicInput {...TestComponentPropUtils.basicReactProps} />);
+		TestComponentPropUtils.expectsBasicReactProps(shallowWrapper, false);
+	});
 });

--- a/src/components/inputs/BasicInput/BasicInput.tsx
+++ b/src/components/inputs/BasicInput/BasicInput.tsx
@@ -9,14 +9,17 @@ interface IProps extends ILocalContainerProps {
 }
 
 export default class BasicInput extends React.Component<IProps> {
-
 	constructor (props: IProps) {
 		super(props);
 	}
 
-
 	render () {
-		const { className, ...props } = this.props;
+		const {
+			className,
+			id,
+			style,
+			...props
+		} = this.props;
 
 		return (
 			<div
@@ -25,6 +28,8 @@ export default class BasicInput extends React.Component<IProps> {
 					styles.BasicInput,
 					this.props.className,
 				)}
+				id={id}
+				style={style}
 			>
 				<input
 					type='text'
@@ -33,5 +38,4 @@ export default class BasicInput extends React.Component<IProps> {
 			</div>
 		);
 	}
-
 }

--- a/src/components/inputs/BrowseInput/BrowseInput.test.tsx
+++ b/src/components/inputs/BrowseInput/BrowseInput.test.tsx
@@ -1,9 +1,15 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
 import BrowseInput from './BrowseInput';
+import TestComponentPropUtils from '../../../utils/TestComponentPropUtils';
 
-jest.mock('electron', () => require('../../../../styleguide/stubs/electron.stub'), { virtual: true });
+describe('BrowseInput', () => {
+	it('renders without crashing', () => {
+		shallow(<BrowseInput />);
+	});
 
-it('renders without crashing', () => {
-	shallow(<BrowseInput />);
+	it('renders basic react props like id, className, and style as element attributes', () => {
+		const shallowWrapper = shallow(<BrowseInput {...TestComponentPropUtils.basicReactProps} />);
+		TestComponentPropUtils.expectsBasicReactProps(shallowWrapper, false);
+	});
 });

--- a/src/components/inputs/BrowseInput/BrowseInput.tsx
+++ b/src/components/inputs/BrowseInput/BrowseInput.tsx
@@ -17,7 +17,6 @@ try {
 }
 
 interface IProps extends IReactComponentProps {
-
 	defaultPath?: string;
 	dialogProperties?: string[];
 	dialogTitle?: string;
@@ -26,17 +25,13 @@ interface IProps extends IReactComponentProps {
 	onChange?: FunctionGeneric;
 	placeholder?: string;
 	value?: string;
-
 }
 
 interface IState {
-
 	value: string | undefined;
-
 }
 
 export default class BrowseInput extends React.Component<IProps, IState> {
-
 	constructor (props: IProps) {
 		super(props);
 
@@ -86,7 +81,10 @@ export default class BrowseInput extends React.Component<IProps, IState> {
 						[styles.BrowseInput__Inline]: this.props.isInline,
 						[styles.BrowseInput__FormInput]: this.props.isFormInput,
 					},
+					this.props.className,
 				)}
+				id={this.props.id}
+				style={this.props.style}
 			>
 				<span
 					className={classnames({
@@ -108,5 +106,4 @@ export default class BrowseInput extends React.Component<IProps, IState> {
 			</div>
 		);
 	}
-
 }

--- a/src/components/inputs/Checkbox/Checkbox.test.tsx
+++ b/src/components/inputs/Checkbox/Checkbox.test.tsx
@@ -1,15 +1,15 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
-import FlyTooltip from './FlyTooltip';
+import Checkbox from './Checkbox';
 import TestComponentPropUtils from '../../../utils/TestComponentPropUtils';
 
-describe('FlyTooltip', () => {
+describe('Checkbox', () => {
 	it('renders without crashing', () => {
-		shallow(<FlyTooltip/>);
+		shallow(<Checkbox />);
 	});
 
 	it('renders basic react props like id, className, and style as element attributes', () => {
-		const shallowWrapper = shallow(<FlyTooltip {...TestComponentPropUtils.basicReactProps} />);
+		const shallowWrapper = shallow(<Checkbox {...TestComponentPropUtils.basicReactProps} />);
 		TestComponentPropUtils.expectsBasicReactProps(shallowWrapper, false);
 	});
 });

--- a/src/components/inputs/Checkbox/Checkbox.tsx
+++ b/src/components/inputs/Checkbox/Checkbox.tsx
@@ -18,7 +18,6 @@ interface IState {
 }
 
 export default class Checkbox extends React.Component<IProps, IState> {
-
 	static defaultProps: Partial<IProps> = {
 		checked: false,
 		disabled: false,
@@ -62,7 +61,10 @@ export default class Checkbox extends React.Component<IProps, IState> {
 						[styles.Checkbox__CheckMixed]: this.state.checked === 'mixed',
 						[styles.Checkbox__Disabled]: this.props.disabled,
 					},
+					this.props.className,
 				)}
+				id={this.props.id}
+				style={this.props.style}
 			>
 				<label className={styles.Checkbox_Label}>
 					<input
@@ -91,5 +93,4 @@ export default class Checkbox extends React.Component<IProps, IState> {
 			</div>
 		);
 	}
-
 }

--- a/src/components/inputs/FlyDropdown/FlyDropdown.test.tsx
+++ b/src/components/inputs/FlyDropdown/FlyDropdown.test.tsx
@@ -1,7 +1,20 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
 import FlyDropdown from './FlyDropdown';
+import TestComponentPropUtils from '../../../utils/TestComponentPropUtils';
 
-it('renders without crashing', () => {
-	shallow(<FlyDropdown items={[]} />);
+describe('FlyDropdown', () => {
+	it('renders without crashing', () => {
+		shallow(<FlyDropdown items={[]} />);
+	});
+
+	it('renders basic react props like id, className, and style as element attributes', () => {
+		const shallowWrapper = shallow(
+			<FlyDropdown
+				items={[]}
+				{...TestComponentPropUtils.basicReactProps}
+			/>
+		);
+		TestComponentPropUtils.expectsBasicReactProps(shallowWrapper, false);
+	});
 });

--- a/src/components/inputs/FlyDropdown/FlyDropdown.tsx
+++ b/src/components/inputs/FlyDropdown/FlyDropdown.tsx
@@ -25,7 +25,6 @@ interface IState {
 }
 
 export default class FlyDropdown extends React.Component<IProps, IState> {
-
 	static defaultProps: Partial<IProps> = {
 		caret: true,
 		items: [],
@@ -71,9 +70,11 @@ export default class FlyDropdown extends React.Component<IProps, IState> {
 					},
 					this.props.className,
 				)}
-				tabIndex={0}
+				id={this.props.id}
 				onClick={this.onClick}
 				onBlur={this.onBlur}
+				style={this.props.style}
+				tabIndex={0}
 			>
 				{this.props.children}
 				{this.props.caret && (
@@ -121,5 +122,4 @@ export default class FlyDropdown extends React.Component<IProps, IState> {
 			</div>
 		);
 	}
-
 }

--- a/src/components/inputs/FlySelect/FlySelect.tsx
+++ b/src/components/inputs/FlySelect/FlySelect.tsx
@@ -56,7 +56,6 @@ interface IState {
 }
 
 export default class FlySelect extends React.Component<IProps, IState> {
-
 	private readonly __containerRef: React.RefObject<any>;
 	private readonly __optionsRef: React.RefObject<any>;
 
@@ -420,14 +419,15 @@ export default class FlySelect extends React.Component<IProps, IState> {
 						[styles.FlySelect__Readonly]: this.props.readonly,
 					},
 				)}
-				onKeyDown={this.onContainerKeyDown}
-				style={this.props.style}
 				data-current-value={this.state.value}
-				tabIndex={0}
-				onClick={this.onClick}
-				onBlur={this.onBlur}
-				ref={this.__containerRef}
 				disabled={this.props.disabled || !Object.keys(optionsFormatted).length}
+				id={this.props.id}
+				onBlur={this.onBlur}
+				onClick={this.onClick}
+				onKeyDown={this.onContainerKeyDown}
+				ref={this.__containerRef}
+				style={this.props.style}
+				tabIndex={0}
 			>
 				<span className="CurrentValue">
 					{

--- a/src/components/inputs/InputPasswordToggle/InputPasswordToggle.test.tsx
+++ b/src/components/inputs/InputPasswordToggle/InputPasswordToggle.test.tsx
@@ -1,23 +1,31 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
 import InputPasswordToggle from './InputPasswordToggle';
+import TestComponentPropUtils from '../../../utils/TestComponentPropUtils';
 
-it ('renders without crashing', () => {
-	shallow(<InputPasswordToggle />);
-});
+describe('InputPasswordToggle', () => {
+	it('renders without crashing', () => {
+		shallow(<InputPasswordToggle />);
+	});
 
-it ('contains a password input by default', () => {
-	const component = shallow(<InputPasswordToggle />);
+	it('contains a password input by default', () => {
+		const component = shallow(<InputPasswordToggle />);
 
-	expect(component.exists('input[type="password"]')).toBe(true);
-	expect(component.exists('input[type="text"]')).toBe(false);
-});
+		expect(component.exists('input[type="password"]')).toBe(true);
+		expect(component.exists('input[type="text"]')).toBe(false);
+	});
 
-it ('contains a text input after clicking the eye', () => {
-	const component = shallow(<InputPasswordToggle />);
+	it('contains a text input after clicking the eye', () => {
+		const component = shallow(<InputPasswordToggle />);
 
-	component.find('.Eye').simulate('click');
+		component.find('.Eye').simulate('click');
 
-	expect(component.exists('input[type="password"]')).toBe(false);
-	expect(component.exists('input[type="text"]')).toBe(true);
+		expect(component.exists('input[type="password"]')).toBe(false);
+		expect(component.exists('input[type="text"]')).toBe(true);
+	});
+
+	it('renders basic react props like id, className, and style as element attributes', () => {
+		const shallowWrapper = shallow(<InputPasswordToggle {...TestComponentPropUtils.basicReactProps} />);
+		TestComponentPropUtils.expectsBasicReactProps(shallowWrapper, false);
+	});
 });

--- a/src/components/inputs/InputPasswordToggle/InputPasswordToggle.tsx
+++ b/src/components/inputs/InputPasswordToggle/InputPasswordToggle.tsx
@@ -13,7 +13,6 @@ interface IState {
 }
 
 export default class InputPasswordToggle extends React.Component<IProps, IState> {
-
 	constructor (props: IProps) {
 		super(props);
 
@@ -47,6 +46,8 @@ export default class InputPasswordToggle extends React.Component<IProps, IState>
 					`PasswordToggle__${this.state.inputType}`,
 					this.props.className,
 				)}
+				id={this.props.id}
+				style={this.props.style}
 			>
 				<input
 					type={this.state.inputType}
@@ -64,5 +65,4 @@ export default class InputPasswordToggle extends React.Component<IProps, IState>
 			</div>
 		);
 	}
-
 }

--- a/src/components/inputs/InputSearch/InputSearch.test.tsx
+++ b/src/components/inputs/InputSearch/InputSearch.test.tsx
@@ -1,15 +1,15 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
-import FlyTooltip from './FlyTooltip';
+import InputSearch from './InputSearch';
 import TestComponentPropUtils from '../../../utils/TestComponentPropUtils';
 
-describe('FlyTooltip', () => {
+describe('InputSearch', () => {
 	it('renders without crashing', () => {
-		shallow(<FlyTooltip/>);
+		shallow(<InputSearch />);
 	});
 
 	it('renders basic react props like id, className, and style as element attributes', () => {
-		const shallowWrapper = shallow(<FlyTooltip {...TestComponentPropUtils.basicReactProps} />);
-		TestComponentPropUtils.expectsBasicReactProps(shallowWrapper, false);
+		const shallowWrapper = shallow(<InputSearch {...TestComponentPropUtils.basicReactProps} />);
+		TestComponentPropUtils.expectsBasicReactProps(shallowWrapper, true, 1);
 	});
 });

--- a/src/components/inputs/InputSearch/InputSearch.tsx
+++ b/src/components/inputs/InputSearch/InputSearch.tsx
@@ -15,7 +15,6 @@ const excludeProps = {
 };
 
 interface IProps extends IReactComponentProps {
-
 	className?: string;
 	containerClassName?: string;
 	onChange?: FunctionGeneric;
@@ -24,7 +23,6 @@ interface IProps extends IReactComponentProps {
 }
 
 export default class InputSearch extends React.Component<IProps> {
-
 	static defaultProps: Partial<IProps> = {
 		value: '',
 	};
@@ -45,6 +43,7 @@ export default class InputSearch extends React.Component<IProps> {
 						styles.InputSearch,
 						this.props.className,
 					)}
+					id={this.props.id}
 					onChange={this.props.onChange}
 					placeholder={this.props.placeholder}
 					type="text"
@@ -54,5 +53,4 @@ export default class InputSearch extends React.Component<IProps> {
 			</div>
 		);
 	}
-
 }

--- a/src/components/inputs/RadioBlock/RadioBlock.test.tsx
+++ b/src/components/inputs/RadioBlock/RadioBlock.test.tsx
@@ -1,20 +1,20 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
-import FlySelect from './FlySelect';
+import RadioBlock from './RadioBlock';
 import TestComponentPropUtils from '../../../utils/TestComponentPropUtils';
 
-describe('FlySelect', () => {
+describe('RadioBlock', () => {
 	it('renders without crashing', () => {
-		shallow(<FlySelect onChange={() => {}} />);
+		shallow(<RadioBlock options={{}} />);
 	});
 
 	it('renders basic react props like id, className, and style as element attributes', () => {
 		const shallowWrapper = shallow(
-			<FlySelect
-				onChange={() => {}}
+			<RadioBlock
+				options={{}}
 				{...TestComponentPropUtils.basicReactProps}
 			/>
 		);
-		TestComponentPropUtils.expectsBasicReactProps(shallowWrapper, false);
+		TestComponentPropUtils.expectsBasicReactProps(shallowWrapper, true);
 	});
 });

--- a/src/components/inputs/RadioBlock/RadioBlock.tsx
+++ b/src/components/inputs/RadioBlock/RadioBlock.tsx
@@ -25,7 +25,6 @@ interface IState {
 }
 
 export default class RadioBlock extends React.Component<IProps, IState> {
-
 	static defaultProps: Partial<IProps> = {
 		direction: 'horiz',
 		disabled: false,
@@ -75,6 +74,8 @@ export default class RadioBlock extends React.Component<IProps, IState> {
 							[styles.RadioBlock__Readonly]: this.props.readonly === true,
 						},
 					)}
+					id={this.props.id}
+					style={this.props.style}
 				>
 					{
 						Object.keys(this.props.options).map((optionValue: string, i: number) => (
@@ -98,7 +99,6 @@ export default class RadioBlock extends React.Component<IProps, IState> {
 			</Container>
 		);
 	}
-
 }
 
 interface IRadioBlockItemProps extends ILocalContainerProps {
@@ -114,7 +114,6 @@ interface IRadioBlockItemProps extends ILocalContainerProps {
 }
 
 class RadioBlockItem extends React.Component<IRadioBlockItemProps> {
-
 	static defaultProps: Partial<IRadioBlockItemProps> = {
 		disabled: false,
 		heightSize: 'l',
@@ -186,5 +185,4 @@ class RadioBlockItem extends React.Component<IRadioBlockItemProps> {
 			</Container>
 		);
 	}
-
 }

--- a/src/components/inputs/Switch/Switch.test.tsx
+++ b/src/components/inputs/Switch/Switch.test.tsx
@@ -1,15 +1,15 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
-import FlyTooltip from './FlyTooltip';
+import Switch from './Switch';
 import TestComponentPropUtils from '../../../utils/TestComponentPropUtils';
 
-describe('FlyTooltip', () => {
+describe('Switch', () => {
 	it('renders without crashing', () => {
-		shallow(<FlyTooltip/>);
+		shallow(<Switch />);
 	});
 
 	it('renders basic react props like id, className, and style as element attributes', () => {
-		const shallowWrapper = shallow(<FlyTooltip {...TestComponentPropUtils.basicReactProps} />);
+		const shallowWrapper = shallow(<Switch {...TestComponentPropUtils.basicReactProps} />);
 		TestComponentPropUtils.expectsBasicReactProps(shallowWrapper, false);
 	});
 });

--- a/src/components/inputs/Switch/Switch.tsx
+++ b/src/components/inputs/Switch/Switch.tsx
@@ -5,7 +5,6 @@ import * as styles from './Switch.sass';
 import { FunctionGeneric } from '../../../common/structures/Generics';
 
 interface IProps extends IReactComponentProps {
-
 	checked?: boolean;
 	disabled?: boolean;
 	flat?: boolean;
@@ -14,17 +13,13 @@ interface IProps extends IReactComponentProps {
 	noValue?: boolean;
 	onChange?: FunctionGeneric;
 	tiny?: boolean;
-
 }
 
 interface IState {
-
 	checked: boolean;
-
 }
 
 export default class Switch extends React.Component<IProps, IState> {
-
 	static defaultProps: Partial<IProps> = {
 		checked: false,
 	};
@@ -64,7 +59,10 @@ export default class Switch extends React.Component<IProps, IState> {
 						[styles.Switch__Tiny]: this.props.tiny,
 						[styles.Switch__Flat]: this.props.flat,
 					},
+					this.props.className,
 				)}
+				id={this.props.id}
+				style={this.props.style}
 			>
 				{
 					this.props.label && (
@@ -81,5 +79,4 @@ export default class Switch extends React.Component<IProps, IState> {
 			</div>
 		);
 	}
-
 }

--- a/src/components/layout/AdvancedToggle/AdvancedToggle.test.tsx
+++ b/src/components/layout/AdvancedToggle/AdvancedToggle.test.tsx
@@ -1,7 +1,15 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
 import AdvancedToggle from './AdvancedToggle';
+import TestComponentPropUtils from '../../../utils/TestComponentPropUtils';
 
-it('renders without crashing', () => {
-	shallow(<AdvancedToggle />);
+describe('AdvancedToggle', () => {
+	it('renders without crashing', () => {
+		shallow(<AdvancedToggle />);
+	});
+
+	it('renders basic react props like id, className, and style as element attributes', () => {
+		const shallowWrapper = shallow(<AdvancedToggle {...TestComponentPropUtils.basicReactProps} />);
+		TestComponentPropUtils.expectsBasicReactProps(shallowWrapper, false);
+	});
 });

--- a/src/components/layout/AdvancedToggle/AdvancedToggle.tsx
+++ b/src/components/layout/AdvancedToggle/AdvancedToggle.tsx
@@ -5,19 +5,14 @@ import * as styles from './AdvancedToggle.sass';
 import CaretSVG from '../../../svg/caret.svg';
 
 interface IProps extends IReactComponentProps {
-
 	headingText?: string;
-
 }
 
 interface IState {
-
 	advancedOpen: boolean;
-
 }
 
 export default class AdvancedToggle extends React.Component<IProps, IState> {
-
 	static defaultProps: Partial<IProps> = {
 		headingText: 'Advanced Options',
 	};
@@ -55,6 +50,8 @@ export default class AdvancedToggle extends React.Component<IProps, IState> {
 						[styles.AdvancedToggle__isOpen]: this.state.advancedOpen,
 					},
 				)}
+				id={this.props.id}
+				style={this.props.style}
 			>
 				<span
 					tabIndex={0}
@@ -74,5 +71,4 @@ export default class AdvancedToggle extends React.Component<IProps, IState> {
 			</div>
 		);
 	}
-
 }

--- a/src/components/layout/Divider/Divider.test.tsx
+++ b/src/components/layout/Divider/Divider.test.tsx
@@ -1,15 +1,15 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
-import FlyTooltip from './FlyTooltip';
+import Divider from './Divider';
 import TestComponentPropUtils from '../../../utils/TestComponentPropUtils';
 
-describe('FlyTooltip', () => {
+describe('Divider', () => {
 	it('renders without crashing', () => {
-		shallow(<FlyTooltip/>);
+		shallow(<Divider />);
 	});
 
 	it('renders basic react props like id, className, and style as element attributes', () => {
-		const shallowWrapper = shallow(<FlyTooltip {...TestComponentPropUtils.basicReactProps} />);
+		const shallowWrapper = shallow(<Divider {...TestComponentPropUtils.basicReactProps} />);
 		TestComponentPropUtils.expectsBasicReactProps(shallowWrapper, false);
 	});
 });

--- a/src/components/layout/Divider/Divider.tsx
+++ b/src/components/layout/Divider/Divider.tsx
@@ -29,6 +29,7 @@ const Divider = (props: IDividerProps) => (
 			props.className,
 			marginsClassMixin(styles, props),
 		)}
+		id={props.id}
 		onClick={props.onClick}
 		style={props.style}
 	>

--- a/src/components/loaders/BigLoader/BigLoader.test.tsx
+++ b/src/components/loaders/BigLoader/BigLoader.test.tsx
@@ -1,7 +1,15 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
 import BigLoader from './BigLoader';
+import TestComponentPropUtils from '../../../utils/TestComponentPropUtils';
 
-it('renders without crashing', () => {
-	shallow(<BigLoader />);
+describe('BigLoader', () => {
+	it('renders without crashing', () => {
+		shallow(<BigLoader />);
+	});
+
+	it('renders basic react props like id, className, and style as element attributes', () => {
+		const shallowWrapper = shallow(<BigLoader {...TestComponentPropUtils.basicReactProps} />);
+		TestComponentPropUtils.expectsBasicReactProps(shallowWrapper, false);
+	});
 });

--- a/src/components/loaders/BigLoader/BigLoader.tsx
+++ b/src/components/loaders/BigLoader/BigLoader.tsx
@@ -6,14 +6,11 @@ import LoadingIndicator from '../LoadingIndicator/LoadingIndicator';
 import { Title } from '../../text/Title/Title';
 
 interface IProps extends IReactComponentProps {
-
 	color?: 'Green' | 'Gray';
 	message?: string;
-
 }
 
 export default class BigLoader extends React.Component<IProps> {
-
 	static defaultProps: Partial<IProps> = {
 		color: 'Green',
 	};
@@ -21,7 +18,12 @@ export default class BigLoader extends React.Component<IProps> {
 	render () {
 		return (
 			<div
-				className={classnames(styles.BigLoader, 'MainPanel', this.props.className)}
+				className={classnames(
+					styles.BigLoader,
+					'MainPanel',
+					this.props.className,
+				)}
+				id={this.props.id}
 				style={this.props.style}
 			>
 				<LoadingIndicator
@@ -42,5 +44,4 @@ export default class BigLoader extends React.Component<IProps> {
 			</div>
 		);
 	}
-
 }

--- a/src/components/loaders/DownloaderItem/DownloaderItem.test.tsx
+++ b/src/components/loaders/DownloaderItem/DownloaderItem.test.tsx
@@ -1,7 +1,27 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
 import DownloaderItem from './DownloaderItem';
+import TestComponentPropUtils from '../../../utils/TestComponentPropUtils';
 
-it('renders without crashing', () => {
-	shallow(<DownloaderItem />);
+jest.mock(
+	'electron',
+	() => {
+		const mockIpcMain = {
+			on: jest.fn().mockReturnThis(),
+			send: jest.fn().mockReturnThis(),
+		};
+		return { ipcRenderer: mockIpcMain };
+	},
+	{ virtual: true },
+);
+
+describe('DownloaderItem', () => {
+	it('renders without crashing', () => {
+		shallow(<DownloaderItem />);
+	});
+
+	it('renders basic react props like id, className, and style as element attributes', () => {
+		const shallowWrapper = shallow(<DownloaderItem {...TestComponentPropUtils.basicReactProps} />);
+		TestComponentPropUtils.expectsBasicReactProps(shallowWrapper, false);
+	});
 });

--- a/src/components/loaders/DownloaderItem/DownloaderItem.tsx
+++ b/src/components/loaders/DownloaderItem/DownloaderItem.tsx
@@ -3,11 +3,11 @@ import IReactComponentProps from '../../../common/structures/IReactComponentProp
 import ProgressBar from '../ProgressBar/ProgressBar';
 import { TextButton } from '../../buttons/TextButton/TextButton';
 import { FunctionGeneric } from '../../../common/structures/Generics';
+import classnames from 'classnames';
 
 const { ipcRenderer } = require('electron');
 
 interface IProps extends IReactComponentProps {
-
 	cancelText?: string;
 	downloaded?: number;
 	itemSize?: number;
@@ -21,11 +21,9 @@ interface IProps extends IReactComponentProps {
 	showCancel?: boolean;
 	showEllipsis?: boolean;
 	stripes?: boolean;
-
 }
 
 export default class DownloaderItem extends React.Component<IProps> {
-
 	static defaultProps: Partial<IProps> = {
 		cancelText: 'Cancel Download',
 		showEllipsis: true,
@@ -49,7 +47,14 @@ export default class DownloaderItem extends React.Component<IProps> {
 
 	render () {
 		return (
-			<li className="DownloaderItem">
+			<li
+				className={classnames(
+					'DownloaderItem',
+					this.props.className,
+				)}
+				id={this.props.id}
+				style={this.props.style}
+			>
 				<span>
 					{this.props.label}
 					{this.props.queueLength && this.props.queueLength > 1 && ` (${(this.props.queueIndex || 0) + 1} of ${this.props.queueLength})`}

--- a/src/components/loaders/InstallerStepStatus/InstallerStepStatus.test.tsx
+++ b/src/components/loaders/InstallerStepStatus/InstallerStepStatus.test.tsx
@@ -1,15 +1,15 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
-import FlyTooltip from './FlyTooltip';
+import InstallerStepStatus from './InstallerStepStatus';
 import TestComponentPropUtils from '../../../utils/TestComponentPropUtils';
 
-describe('FlyTooltip', () => {
+describe('InstallerStepStatus', () => {
 	it('renders without crashing', () => {
-		shallow(<FlyTooltip/>);
+		shallow(<InstallerStepStatus />);
 	});
 
 	it('renders basic react props like id, className, and style as element attributes', () => {
-		const shallowWrapper = shallow(<FlyTooltip {...TestComponentPropUtils.basicReactProps} />);
+		const shallowWrapper = shallow(<InstallerStepStatus {...TestComponentPropUtils.basicReactProps} />);
 		TestComponentPropUtils.expectsBasicReactProps(shallowWrapper, false);
 	});
 });

--- a/src/components/loaders/InstallerStepStatus/InstallerStepStatus.tsx
+++ b/src/components/loaders/InstallerStepStatus/InstallerStepStatus.tsx
@@ -1,20 +1,18 @@
 import * as React from 'react';
-import CircleSVG from '../../../svg/circle.svg';
-import ExclamationSVG from '../../../svg/exclamation.svg';
-import CompleteSVG from '../../../svg/complete.svg';
-import SpinnerSVG from '../../../svg/spinner.svg';
+import classnames from 'classnames';
+import CircleSVG from '../../../svg/circle';
+import ExclamationSVG from '../../../svg/exclamation';
+import CompleteSVG from '../../../svg/complete';
+import SpinnerSVG from '../../../svg/spinner';
 import IReactComponentProps from '../../../common/structures/IReactComponentProps';
 
 interface IProps extends IReactComponentProps {
-
 	inProgress?: boolean;
 	ready?: boolean;
 	requiresAttention?: boolean;
-
 }
 
 export default class InstallerStepStatus extends React.Component<IProps> {
-
 	renderIcon () {
 		if (!this.props.ready && !this.props.inProgress) {
 			return (
@@ -51,10 +49,16 @@ export default class InstallerStepStatus extends React.Component<IProps> {
 
 	render () {
 		return (
-			<span className="InstallerStepStatus">
+			<span
+				className={classnames(
+					'InstallerStepStatus',
+					this.props.className,
+				)}
+				id={this.props.id}
+				style={this.props.style}
+			>
 				{this.renderIcon()}
 			</span>
 		);
 	}
-
 }

--- a/src/components/loaders/InstallerStepStatus/InstallerStepStatus.tsx
+++ b/src/components/loaders/InstallerStepStatus/InstallerStepStatus.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
 import classnames from 'classnames';
-import CircleSVG from '../../../svg/circle';
-import ExclamationSVG from '../../../svg/exclamation';
-import CompleteSVG from '../../../svg/complete';
-import SpinnerSVG from '../../../svg/spinner';
+import CircleSVG from '../../../svg/circle.svg';
+import ExclamationSVG from '../../../svg/exclamation.svg';
+import CompleteSVG from '../../../svg/complete.svg';
+import SpinnerSVG from '../../../svg/spinner.svg';
 import IReactComponentProps from '../../../common/structures/IReactComponentProps';
 
 interface IProps extends IReactComponentProps {

--- a/src/components/loaders/LoadingIndicator/LoadingIndicator.test.tsx
+++ b/src/components/loaders/LoadingIndicator/LoadingIndicator.test.tsx
@@ -1,15 +1,15 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
-import FlyTooltip from './FlyTooltip';
+import LoadingIndicator from './LoadingIndicator';
 import TestComponentPropUtils from '../../../utils/TestComponentPropUtils';
 
-describe('FlyTooltip', () => {
+describe('LoadingIndicator', () => {
 	it('renders without crashing', () => {
-		shallow(<FlyTooltip/>);
+		shallow(<LoadingIndicator />);
 	});
 
 	it('renders basic react props like id, className, and style as element attributes', () => {
-		const shallowWrapper = shallow(<FlyTooltip {...TestComponentPropUtils.basicReactProps} />);
+		const shallowWrapper = shallow(<LoadingIndicator {...TestComponentPropUtils.basicReactProps} />);
 		TestComponentPropUtils.expectsBasicReactProps(shallowWrapper, false);
 	});
 });

--- a/src/components/loaders/LoadingIndicator/LoadingIndicator.tsx
+++ b/src/components/loaders/LoadingIndicator/LoadingIndicator.tsx
@@ -4,15 +4,12 @@ import classnames from 'classnames';
 import * as styles from './LoadingIndicator.sass';
 
 interface IProps extends IReactComponentProps {
-
 	big?: boolean;
 	dots?: 2|3;
 	color?: 'Green' | 'Gray';
-
 }
 
 export default class LoadingIndicator extends React.Component<IProps> {
-
 	static defaultProps: Partial<IProps> = {
 		big: false,
 		dots: 2,
@@ -28,7 +25,10 @@ export default class LoadingIndicator extends React.Component<IProps> {
 						[styles.LoadingIndicator__Gray]: this.props.color === 'Gray',
 						[styles.LoadingIndicator__Big]: this.props.big,
 					},
+					this.props.className
 				)}
+				id={this.props.id}
+				style={this.props.style}
 			>
 				 <div />
 				 <div />
@@ -36,5 +36,4 @@ export default class LoadingIndicator extends React.Component<IProps> {
 			</div>
 		);
 	}
-
 }

--- a/src/components/loaders/ProgressBar/ProgressBar.test.tsx
+++ b/src/components/loaders/ProgressBar/ProgressBar.test.tsx
@@ -1,15 +1,15 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
-import FlyTooltip from './FlyTooltip';
+import ProgressBar from './ProgressBar';
 import TestComponentPropUtils from '../../../utils/TestComponentPropUtils';
 
-describe('FlyTooltip', () => {
+describe('ProgressBar', () => {
 	it('renders without crashing', () => {
-		shallow(<FlyTooltip/>);
+		shallow(<ProgressBar />);
 	});
 
 	it('renders basic react props like id, className, and style as element attributes', () => {
-		const shallowWrapper = shallow(<FlyTooltip {...TestComponentPropUtils.basicReactProps} />);
+		const shallowWrapper = shallow(<ProgressBar {...TestComponentPropUtils.basicReactProps} />);
 		TestComponentPropUtils.expectsBasicReactProps(shallowWrapper, false);
 	});
 });

--- a/src/components/loaders/ProgressBar/ProgressBar.tsx
+++ b/src/components/loaders/ProgressBar/ProgressBar.tsx
@@ -39,7 +39,10 @@ export default class ProgressBar extends React.Component<IProps & IReactComponen
 				className={classnames(
 					styles.ProgressBar,
 					'ProgressBar', // this also needs to be globally accessible so other component styles can reference it
+					this.props.className
 				)}
+				id={this.props.id}
+				style={this.props.style}
 			>
 				{!this.props.stripes ? this.renderRegularBar() : this.renderStripes()}
 			</div>

--- a/src/components/loaders/Spinner/Spinner.test.tsx
+++ b/src/components/loaders/Spinner/Spinner.test.tsx
@@ -1,15 +1,15 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
-import FlyTooltip from './FlyTooltip';
+import Spinner from './Spinner';
 import TestComponentPropUtils from '../../../utils/TestComponentPropUtils';
 
-describe('FlyTooltip', () => {
+describe('Spinner', () => {
 	it('renders without crashing', () => {
-		shallow(<FlyTooltip/>);
+		shallow(<Spinner />);
 	});
 
 	it('renders basic react props like id, className, and style as element attributes', () => {
-		const shallowWrapper = shallow(<FlyTooltip {...TestComponentPropUtils.basicReactProps} />);
+		const shallowWrapper = shallow(<Spinner {...TestComponentPropUtils.basicReactProps} />);
 		TestComponentPropUtils.expectsBasicReactProps(shallowWrapper, false);
 	});
 });

--- a/src/components/loaders/Spinner/Spinner.tsx
+++ b/src/components/loaders/Spinner/Spinner.tsx
@@ -10,7 +10,6 @@ interface IProps extends IReactComponentProps {
 }
 
 export default class Spinner extends React.Component<IProps> {
-
 	static defaultProps: Partial<IProps> = {
 		color: 'Gray25',
 	};
@@ -30,16 +29,18 @@ export default class Spinner extends React.Component<IProps> {
 	}
 
 	render () {
-		if (!this.props.children) {
-			return this.renderSVG();
-		}
-
 		return (
-			<div className={styles.SpinnerContainer}>
+			<div
+				className={classnames(
+					styles.SpinnerContainer,
+					this.props.className,
+				)}
+				id={this.props.id}
+				style={this.props.style}
+			>
 				{this.renderSVG()}
 				{this.props.children}
 			</div>
 		);
 	}
-
 }

--- a/src/components/media/Avatar/Avatar.test.tsx
+++ b/src/components/media/Avatar/Avatar.test.tsx
@@ -1,15 +1,15 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
-import FlyTooltip from './FlyTooltip';
+import Avatar from './Avatar';
 import TestComponentPropUtils from '../../../utils/TestComponentPropUtils';
 
-describe('FlyTooltip', () => {
+describe('Avatar', () => {
 	it('renders without crashing', () => {
-		shallow(<FlyTooltip/>);
+		shallow(<Avatar />);
 	});
 
 	it('renders basic react props like id, className, and style as element attributes', () => {
-		const shallowWrapper = shallow(<FlyTooltip {...TestComponentPropUtils.basicReactProps} />);
+		const shallowWrapper = shallow(<Avatar {...TestComponentPropUtils.basicReactProps} />);
 		TestComponentPropUtils.expectsBasicReactProps(shallowWrapper, false);
 	});
 });

--- a/src/components/media/Avatar/Avatar.tsx
+++ b/src/components/media/Avatar/Avatar.tsx
@@ -6,25 +6,20 @@ import ImageCircle from '../ImageCircle/ImageCircle';
 import ClippedContent from '../../modules/ClippedContent/ClippedContent';
 
 interface IProps extends IReactComponentProps {
-
 	color?: 'blue' | 'green' | 'yellow' | 'orange' | 'red' | 'pink' | 'purple';
 	initials?: string;
 	placeholderSrc?: string;
 	size?: 's' | 'm' | string;
 	src?: string;
 	type: 'user' | 'team';
-
 }
 
 interface IState {
-
 	isImageError: boolean;
 	isImageLoaded: boolean;
-
 }
 
 export default class Avatar extends React.Component<IProps, IState> {
-
 	static defaultProps: Partial<IProps> = {
 		color: 'blue',
 		size: 'm',
@@ -87,6 +82,8 @@ export default class Avatar extends React.Component<IProps, IState> {
 					styles.Avatar,
 					this.props.className,
 				)}
+				id={this.props.id}
+				style={this.props.style}
 			>
 				{
 					this.props.initials && (
@@ -152,5 +149,4 @@ export default class Avatar extends React.Component<IProps, IState> {
 			</div>
 		);
 	}
-
 }

--- a/src/components/media/ImageCircle/ImageCircle.test.tsx
+++ b/src/components/media/ImageCircle/ImageCircle.test.tsx
@@ -1,15 +1,15 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
-import FlyTooltip from './FlyTooltip';
+import ImageCircle from './ImageCircle';
 import TestComponentPropUtils from '../../../utils/TestComponentPropUtils';
 
-describe('FlyTooltip', () => {
+describe('ImageCircle', () => {
 	it('renders without crashing', () => {
-		shallow(<FlyTooltip/>);
+		shallow(<ImageCircle />);
 	});
 
 	it('renders basic react props like id, className, and style as element attributes', () => {
-		const shallowWrapper = shallow(<FlyTooltip {...TestComponentPropUtils.basicReactProps} />);
-		TestComponentPropUtils.expectsBasicReactProps(shallowWrapper, false);
+		const shallowWrapper = shallow(<ImageCircle {...TestComponentPropUtils.basicReactProps} />);
+		TestComponentPropUtils.expectsBasicReactProps(shallowWrapper, true);
 	});
 });

--- a/src/components/media/ImageCircle/ImageCircle.tsx
+++ b/src/components/media/ImageCircle/ImageCircle.tsx
@@ -6,7 +6,6 @@ import ClippedContent from '../../modules/ClippedContent/ClippedContent';
 import { FunctionGeneric } from '../../../common/structures/Generics';
 
 interface IProps extends IReactComponentProps {
-
 	className?: string;
 	containerClassName?: string;
 	onError?: FunctionGeneric;
@@ -15,11 +14,9 @@ interface IProps extends IReactComponentProps {
 	square?: boolean;
 	src: string;
 	tag?: string;
-
 }
 
 export default class ImageCircle extends React.Component<IProps> {
-
 	static defaultProps: Partial<IProps> = {
 		size: 'm',
 		square: false,
@@ -49,6 +46,7 @@ export default class ImageCircle extends React.Component<IProps> {
 						styles.ImageCircle,
 						this.props.className,
 					)}
+					id={this.props.id}
 					onError={this.props.onError}
 					onLoad={this.props.onLoad}
 					src={this.props.src}
@@ -57,5 +55,4 @@ export default class ImageCircle extends React.Component<IProps> {
 			</ClippedContent>
 		);
 	}
-
 }

--- a/src/components/menus/Drawer/Drawer.test.tsx
+++ b/src/components/menus/Drawer/Drawer.test.tsx
@@ -1,15 +1,15 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
-import FlyTooltip from './FlyTooltip';
+import Drawer from './Drawer';
 import TestComponentPropUtils from '../../../utils/TestComponentPropUtils';
 
-describe('FlyTooltip', () => {
+describe('Drawer', () => {
 	it('renders without crashing', () => {
-		shallow(<FlyTooltip/>);
+		shallow(<Drawer>test</Drawer>);
 	});
 
 	it('renders basic react props like id, className, and style as element attributes', () => {
-		const shallowWrapper = shallow(<FlyTooltip {...TestComponentPropUtils.basicReactProps} />);
-		TestComponentPropUtils.expectsBasicReactProps(shallowWrapper, false);
+		const shallowWrapper = shallow(<Drawer {...TestComponentPropUtils.basicReactProps}>test</Drawer>);
+		TestComponentPropUtils.expectsBasicReactProps(shallowWrapper, true);
 	});
 });

--- a/src/components/menus/Drawer/Drawer.tsx
+++ b/src/components/menus/Drawer/Drawer.tsx
@@ -4,21 +4,16 @@ import * as styles from './Drawer.sass';
 import IReactComponentProps from '../../../common/structures/IReactComponentProps';
 
 interface IProps extends IReactComponentProps {
-
 	align?: 'left' | 'center' | 'right';
 	children: React.ReactNode;
 	show?: boolean;
-
 }
 
 interface IState {
-
 	disableAnimation: boolean;
-
 }
 
 export default class Drawer extends React.Component<IProps, IState> {
-
 	constructor (props: IProps) {
 		super(props);
 
@@ -50,11 +45,12 @@ export default class Drawer extends React.Component<IProps, IState> {
 							[styles.Drawer__AlignRight]: this.props.align === 'right',
 						},
 					)}
+					id={this.props.id}
+					style={this.props.style}
 				>
 					{this.props.children}
 				</div>
 			</div>
 		);
 	}
-
 }

--- a/src/components/menus/Stepper/Stepper.test.tsx
+++ b/src/components/menus/Stepper/Stepper.test.tsx
@@ -1,15 +1,19 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
-import FlyTooltip from './FlyTooltip';
 import TestComponentPropUtils from '../../../utils/TestComponentPropUtils';
+import { Stepper, Step } from './Stepper';
 
-describe('FlyTooltip', () => {
+describe('Stepper', () => {
 	it('renders without crashing', () => {
-		shallow(<FlyTooltip/>);
+		shallow(<Stepper><Step number={1} done={false} active={true}>Setup Site</Step></Stepper>);
 	});
 
 	it('renders basic react props like id, className, and style as element attributes', () => {
-		const shallowWrapper = shallow(<FlyTooltip {...TestComponentPropUtils.basicReactProps} />);
+		const shallowWrapper = shallow(
+			<Stepper {...TestComponentPropUtils.basicReactProps}>
+				<Step number={1} done={false} active={true}>Setup Site</Step>
+			</Stepper>
+		);
 		TestComponentPropUtils.expectsBasicReactProps(shallowWrapper, false);
 	});
 });

--- a/src/components/menus/Stepper/Stepper.tsx
+++ b/src/components/menus/Stepper/Stepper.tsx
@@ -4,8 +4,11 @@ import classnames from 'classnames';
 import CompleteSVG from '../../../svg/complete.svg';
 import * as styles from './Stepper.sass';
 
-export class Stepper extends React.Component<IReactComponentProps> {
+interface IProps extends IReactComponentProps {
+	children: React.ReactNode;
+}
 
+export class Stepper extends React.Component<IProps> {
 	render () {
 		return (
 			<div
@@ -15,26 +18,25 @@ export class Stepper extends React.Component<IReactComponentProps> {
 						[styles.__Steps__2]: (this.props.children as React.ReactNode[]).length === 2,
 						[styles.__Steps__3]: (this.props.children as React.ReactNode[]).length === 3,
 					},
+					this.props.className,
 				)}
+				id={this.props.id}
+				style={this.props.style}
 			>
 				{this.props.children}
 			</div>
 		);
 	}
-
 }
 
 interface IStepProps extends IReactComponentProps {
-
-	active: boolean;
-	disabled: boolean;
+	active?: boolean;
+	disabled?: boolean;
 	done: boolean;
 	number: number;
-
 }
 
 export class Step extends React.Component<IStepProps> {
-
 	render () {
 		return (
 			<div

--- a/src/components/menus/TabNav/TabNav.test.tsx
+++ b/src/components/menus/TabNav/TabNav.test.tsx
@@ -1,15 +1,15 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
-import FlyTooltip from './FlyTooltip';
+import TabNav from './TabNav';
 import TestComponentPropUtils from '../../../utils/TestComponentPropUtils';
 
-describe('FlyTooltip', () => {
+describe('TabNav', () => {
 	it('renders without crashing', () => {
-		shallow(<FlyTooltip/>);
+		shallow(<TabNav />);
 	});
 
 	it('renders basic react props like id, className, and style as element attributes', () => {
-		const shallowWrapper = shallow(<FlyTooltip {...TestComponentPropUtils.basicReactProps} />);
+		const shallowWrapper = shallow(<TabNav {...TestComponentPropUtils.basicReactProps} />);
 		TestComponentPropUtils.expectsBasicReactProps(shallowWrapper, false);
 	});
 });

--- a/src/components/menus/TabNav/TabNav.tsx
+++ b/src/components/menus/TabNav/TabNav.tsx
@@ -4,15 +4,12 @@ import classnames from 'classnames';
 import * as styles from './TabNav.sass';
 
 interface IProps extends IReactComponentProps {
-
 	tag?: string;
 	itemsClassName?: string;
 	aux?: React.ReactNode; // Used for adding items in the right-hand side of the TabNav such as Site Info buttons
-
 }
 
 export default class TabNav extends React.Component<IProps> {
-
 	static defaultProps: Partial<IProps> = {
 		tag: 'nav',
 	};
@@ -38,6 +35,8 @@ export default class TabNav extends React.Component<IProps> {
 					styles.TabNav,
 					this.props.className,
 				)}
+				id={this.props.id}
+				style={this.props.style}
 			>
 				<div
 					className={classnames(
@@ -52,5 +51,4 @@ export default class TabNav extends React.Component<IProps> {
 			</NavTag>
 		);
 	}
-
 }

--- a/src/components/menus/TertiaryNav/TertiaryNav.test.tsx
+++ b/src/components/menus/TertiaryNav/TertiaryNav.test.tsx
@@ -1,0 +1,15 @@
+import * as React from 'react';
+import { shallow } from 'enzyme';
+import { TertiaryNav } from './TertiaryNav';
+
+describe('TertiaryNav', () => {
+	it('renders without crashing', () => {
+		shallow(
+			<TertiaryNav
+				match={{} as any}
+				history={{} as any}
+				location={{} as any}
+			/>
+		);
+	});
+});

--- a/src/components/menus/TertiaryNav/TertiaryNav.tsx
+++ b/src/components/menus/TertiaryNav/TertiaryNav.tsx
@@ -39,6 +39,8 @@ export class TertiaryNav extends React.Component<IReactComponentProps & RouteCom
 					styles.TertiaryNavContainer,
 					this.props.className,
 				)}
+				id={this.props.id}
+				style={this.props.style}
 			>
 				<ul className={classnames(styles.TertiaryNav)}>
 					{this.props.children}
@@ -60,15 +62,12 @@ export class TertiaryNav extends React.Component<IReactComponentProps & RouteCom
 			</div>
 		);
 	}
-
 }
 
 interface ITertiaryNavItemProps extends IReactComponentProps {
-
 	path: string;
 	render?: FunctionGeneric;
 	variant?: 'error';
-
 }
 
 // There is a known issue in TypeScript, which doesn't allow decorators to change the signature of the classes
@@ -77,7 +76,6 @@ interface ITertiaryNavItemProps extends IReactComponentProps {
 // https://github.com/DefinitelyTyped/DefinitelyTyped/issues/24077#issuecomment-455487092
 @(withRouter as any)
 export class TertiaryNavItem extends React.Component<ITertiaryNavItemProps & RouteComponentProps> {
-
 	render () {
 		return (
 			<li
@@ -99,5 +97,4 @@ export class TertiaryNavItem extends React.Component<ITertiaryNavItemProps & Rou
 			</li>
 		);
 	}
-
 }

--- a/src/components/modules/Animation/Animation.test.tsx
+++ b/src/components/modules/Animation/Animation.test.tsx
@@ -1,0 +1,9 @@
+import * as React from 'react';
+import { shallow } from 'enzyme';
+import Animation from './Animation';
+
+describe('Animation', () => {
+	it('renders without crashing', () => {
+		shallow(<Animation />);
+	});
+});

--- a/src/components/modules/Card/Card.test.tsx
+++ b/src/components/modules/Card/Card.test.tsx
@@ -1,15 +1,15 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
-import FlyTooltip from './FlyTooltip';
+import Card from './Card';
 import TestComponentPropUtils from '../../../utils/TestComponentPropUtils';
 
-describe('FlyTooltip', () => {
+describe('Card', () => {
 	it('renders without crashing', () => {
-		shallow(<FlyTooltip/>);
+		shallow(<Card />);
 	});
 
 	it('renders basic react props like id, className, and style as element attributes', () => {
-		const shallowWrapper = shallow(<FlyTooltip {...TestComponentPropUtils.basicReactProps} />);
+		const shallowWrapper = shallow(<Card {...TestComponentPropUtils.basicReactProps} />);
 		TestComponentPropUtils.expectsBasicReactProps(shallowWrapper, false);
 	});
 });

--- a/src/components/modules/Card/Card.tsx
+++ b/src/components/modules/Card/Card.tsx
@@ -7,7 +7,6 @@ import { Title } from '../../text/Title/Title';
 import { FunctionGeneric } from '../../../common/structures/Generics';
 
 interface IProps extends IReactComponentProps {
-
 	content?: React.ReactNode;
 	contentClassName?: string;
 	contentDescription?: React.ReactNode;
@@ -40,11 +39,9 @@ interface IProps extends IReactComponentProps {
 	tag?: string;
 	truncateDefaultLines?: number;
 	truncateDefaultEllipsis?: string;
-
 }
 
 export default class Card extends React.Component<IProps> {
-
 	static defaultProps: Partial<IProps> = {
 		overflow: 'hidden',
 		tag: 'article',
@@ -216,8 +213,10 @@ export default class Card extends React.Component<IProps> {
 					styles.Card,
 					this.props.className,
 				)}
+				id={this.props.id}
 				style={{
 					...(this.props.overflow !== 'hidden' && {overflow: this.props.overflow}), // conditionally add style
+					...this.props.style,
 				}}
 			>
 				{this.hasHeader() && this.renderHeader()}
@@ -226,5 +225,4 @@ export default class Card extends React.Component<IProps> {
 			</Tag>
 		);
 	}
-
 }

--- a/src/components/modules/ClippedContent/ClippedContent.test.tsx
+++ b/src/components/modules/ClippedContent/ClippedContent.test.tsx
@@ -1,15 +1,15 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
-import FlyTooltip from './FlyTooltip';
+import ClippedContent from './ClippedContent';
 import TestComponentPropUtils from '../../../utils/TestComponentPropUtils';
 
-describe('FlyTooltip', () => {
+describe('ClippedContent', () => {
 	it('renders without crashing', () => {
-		shallow(<FlyTooltip/>);
+		shallow(<ClippedContent />);
 	});
 
 	it('renders basic react props like id, className, and style as element attributes', () => {
-		const shallowWrapper = shallow(<FlyTooltip {...TestComponentPropUtils.basicReactProps} />);
+		const shallowWrapper = shallow(<ClippedContent {...TestComponentPropUtils.basicReactProps} />);
 		TestComponentPropUtils.expectsBasicReactProps(shallowWrapper, false);
 	});
 });

--- a/src/components/modules/ClippedContent/ClippedContent.tsx
+++ b/src/components/modules/ClippedContent/ClippedContent.tsx
@@ -4,7 +4,6 @@ import * as styles from './ClippedContent.sass';
 import classnames from 'classnames';
 
 interface IProps extends IReactComponentProps {
-
 	alignX?: 'none' | 'center';
 	alignY?: 'none' | 'center';
 	height?: string | 'fit-content';
@@ -13,11 +12,9 @@ interface IProps extends IReactComponentProps {
 	width?: string | 'fit-content';
 	useFullHeight?: boolean;
 	useFullWidth?: boolean;
-
 }
 
 export default class ClippedContent extends React.Component<IProps> {
-
 	static defaultProps: Partial<IProps> = {
 		alignX: 'none',
 		alignY: 'none',
@@ -43,6 +40,7 @@ export default class ClippedContent extends React.Component<IProps> {
 						[styles.ClippedContent__ShapeCircle]: this.props.shape === 'circle',
 					},
 				)}
+				id={this.props.id}
 				style={{
 					...this.props.style,
 					...(this.props.height && {height: this.props.height}),
@@ -53,5 +51,4 @@ export default class ClippedContent extends React.Component<IProps> {
 			</ContainerTag>
 		);
 	}
-
 }

--- a/src/components/modules/Container/Container.test.tsx
+++ b/src/components/modules/Container/Container.test.tsx
@@ -1,15 +1,15 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
-import FlyTooltip from './FlyTooltip';
 import TestComponentPropUtils from '../../../utils/TestComponentPropUtils';
+import { Container } from './Container';
 
-describe('FlyTooltip', () => {
+describe('Container', () => {
 	it('renders without crashing', () => {
-		shallow(<FlyTooltip/>);
+		shallow(<Container />);
 	});
 
 	it('renders basic react props like id, className, and style as element attributes', () => {
-		const shallowWrapper = shallow(<FlyTooltip {...TestComponentPropUtils.basicReactProps} />);
+		const shallowWrapper = shallow(<Container {...TestComponentPropUtils.basicReactProps} />);
 		TestComponentPropUtils.expectsBasicReactProps(shallowWrapper, false);
 	});
 });

--- a/src/components/modules/Container/Container.tsx
+++ b/src/components/modules/Container/Container.tsx
@@ -16,9 +16,7 @@ export interface IContainerProps extends IReactComponentProps {
 	marginTop?: ContainerMarginLookupType;
 }
 
-const defaultProps: Partial<IContainerProps> = {
-
-};
+const defaultProps: Partial<IContainerProps> = {};
 
 export const Container = (props: IContainerProps) => {
 	const Tag: any = props.element || 'div';
@@ -42,6 +40,7 @@ export const Container = (props: IContainerProps) => {
 					className={classnames(
 						props.className,
 					)}
+					id={props.id}
 					style={{
 						...props.style,
 						...ContainerMarginHelper.getContainerMarginStyle(props),

--- a/src/components/modules/DragBar/DragBar.test.tsx
+++ b/src/components/modules/DragBar/DragBar.test.tsx
@@ -1,7 +1,15 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
 import DragBar from './DragBar';
+import TestComponentPropUtils from '../../../utils/TestComponentPropUtils';
 
-it('renders without crashing', () => {
-	shallow(<DragBar />);
+describe('DragBar', () => {
+	it('renders without crashing', () => {
+		shallow(<DragBar/>);
+	});
+
+	it('renders basic react props like id, className, and style as element attributes', () => {
+		const shallowWrapper = shallow(<DragBar {...TestComponentPropUtils.basicReactProps} />);
+		TestComponentPropUtils.expectsBasicReactProps(shallowWrapper, false);
+	});
 });

--- a/src/components/modules/DragBar/DragBar.tsx
+++ b/src/components/modules/DragBar/DragBar.tsx
@@ -1,10 +1,19 @@
 import * as React from 'react';
 import * as styles from './DragBar.sass';
+import classnames from 'classnames';
+import IReactComponentProps from '../../../common/structures/IReactComponentProps';
 
-export default class Toolbar extends React.Component {
+export default class Toolbar extends React.Component<IReactComponentProps> {
 	render () {
 		return (
-			<header className={styles.DragBar} />
+			<header
+				className={classnames(
+					styles.DragBar,
+					this.props.className,
+				)}
+				id={this.props.id}
+				style={this.props.style}
+			/>
 		);
 	}
 }

--- a/src/components/modules/EmptyArea/EmptyArea.tsx
+++ b/src/components/modules/EmptyArea/EmptyArea.tsx
@@ -4,14 +4,11 @@ import classnames from 'classnames';
 import * as styles from './EmptyArea.sass';
 
 interface IProps extends IReactComponentProps {
-
 	border?: boolean;
 	FadeIn?: boolean;
-
 }
 
 export class EmptyArea extends React.Component<IProps> {
-
 	render () {
 		return (
 			<div
@@ -22,11 +19,13 @@ export class EmptyArea extends React.Component<IProps> {
 						'__FadeIn': this.props.FadeIn,
 						'__NoBorder': this.props.border === false,
 					},
+					this.props.className,
 				)}
+				id={this.props.id}
+				style={this.props.style}
 			>
 				{this.props.children}
 			</div>
 		);
 	}
-
 }

--- a/src/components/modules/InnerPaneSidebar/InnerPaneSidebar.test.tsx
+++ b/src/components/modules/InnerPaneSidebar/InnerPaneSidebar.test.tsx
@@ -1,15 +1,15 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
-import FlyTooltip from './FlyTooltip';
+import { InnerPaneSidebar } from './InnerPaneSidebar';
 import TestComponentPropUtils from '../../../utils/TestComponentPropUtils';
 
-describe('FlyTooltip', () => {
+describe('InnerPaneSidebar', () => {
 	it('renders without crashing', () => {
-		shallow(<FlyTooltip/>);
+		shallow(<InnerPaneSidebar />);
 	});
 
 	it('renders basic react props like id, className, and style as element attributes', () => {
-		const shallowWrapper = shallow(<FlyTooltip {...TestComponentPropUtils.basicReactProps} />);
+		const shallowWrapper = shallow(<InnerPaneSidebar {...TestComponentPropUtils.basicReactProps} />);
 		TestComponentPropUtils.expectsBasicReactProps(shallowWrapper, false);
 	});
 });

--- a/src/components/modules/InnerPaneSidebar/InnerPaneSidebar.tsx
+++ b/src/components/modules/InnerPaneSidebar/InnerPaneSidebar.tsx
@@ -5,9 +5,7 @@ import IReactComponentProps from '../../../common/structures/IReactComponentProp
 import { Title } from '../../text/Title/Title';
 
 interface IProps extends IReactComponentProps {
-
 	title: string;
-
 }
 
 export function InnerPaneSidebar (props: IReactComponentProps) {
@@ -17,6 +15,8 @@ export function InnerPaneSidebar (props: IReactComponentProps) {
 				styles.InnerPaneSidebar,
 				props.className,
 			)}
+			style={props.style}
+			id={props.id}
 		>
 			{props.children}
 		</div>

--- a/src/components/modules/Markdown/Markdown.test.tsx
+++ b/src/components/modules/Markdown/Markdown.test.tsx
@@ -1,0 +1,10 @@
+import * as React from 'react';
+import { shallow } from 'enzyme';
+import TestComponentPropUtils from '../../../utils/TestComponentPropUtils';
+import Markdown from './Markdown';
+
+describe('Markdown', () => {
+	it('renders without crashing', () => {
+		shallow(<Markdown />);
+	});
+});

--- a/src/components/modules/Markdown/Markdown.tsx
+++ b/src/components/modules/Markdown/Markdown.tsx
@@ -12,43 +12,40 @@ import * as php from 'highlight.js/lib/languages/php';
 import * as shell from 'highlight.js/lib/languages/shell';
 import * as sql from 'highlight.js/lib/languages/sql';
 import * as typescript from 'highlight.js/lib/languages/typescript';
-import * as xml from 'highlight.js/lib/languages/xml';
+import * as xml from 'highlight.js/lib/languages/xml'
+import classnames from 'classnames';
 import IReactComponentProps from '../../../common/structures/IReactComponentProps';
 
 interface IProps extends IReactComponentProps {
-
 	src?: string;
-
 }
 
 export default class Markdown extends React.Component<IProps> {
-
 	render () {
 		return (
 			<ReactMarkdown
-				className={styles.Markdown}
+				className={classnames(
+					styles.Markdown,
+					this.props.className,
+				)}
 				escapeHtml={true}
-				skipHtml={true}
-				source={this.props.src}
 				renderers={{
 					code: MarkdownCodeBlock,
 				}}
+				skipHtml={true}
+				source={this.props.src}
 			/>
 		);
 	}
-
 }
 
 interface IMarkdownCodeBlockProps extends IReactComponentProps {
-
 	value: string;
 	language: string;
 	inline: boolean;
-
 }
 
 class MarkdownCodeBlock extends React.PureComponent<IMarkdownCodeBlockProps> {
-
 	private readonly __languagesEnabled: {[key: string]: any} = {
 		'apache': apache,
 		'bash': bash,
@@ -85,5 +82,4 @@ class MarkdownCodeBlock extends React.PureComponent<IMarkdownCodeBlockProps> {
 			/>
 		);
 	}
-
 }

--- a/src/components/modules/SiteInfoInnerPane/SiteInfoInnerPane.test.tsx
+++ b/src/components/modules/SiteInfoInnerPane/SiteInfoInnerPane.test.tsx
@@ -1,15 +1,15 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
-import FlyTooltip from './FlyTooltip';
+import SiteInfoInnerPane from './SiteInfoInnerPane';
 import TestComponentPropUtils from '../../../utils/TestComponentPropUtils';
 
-describe('FlyTooltip', () => {
+describe('SiteInfoInnerPane', () => {
 	it('renders without crashing', () => {
-		shallow(<FlyTooltip/>);
+		shallow(<SiteInfoInnerPane />);
 	});
 
 	it('renders basic react props like id, className, and style as element attributes', () => {
-		const shallowWrapper = shallow(<FlyTooltip {...TestComponentPropUtils.basicReactProps} />);
+		const shallowWrapper = shallow(<SiteInfoInnerPane {...TestComponentPropUtils.basicReactProps} />);
 		TestComponentPropUtils.expectsBasicReactProps(shallowWrapper, false);
 	});
 });

--- a/src/components/modules/SiteInfoInnerPane/SiteInfoInnerPane.tsx
+++ b/src/components/modules/SiteInfoInnerPane/SiteInfoInnerPane.tsx
@@ -3,11 +3,18 @@ import IReactComponentProps from '../../../common/structures/IReactComponentProp
 import * as styles from './SiteInfoInnerPane.sass';
 
 export default function SiteInfoInnerPane(props: IReactComponentProps) {
-	const { children, ...propsWithoutChildren } = props;
+	const {
+		children,
+		id,
+		style,
+		...propsWithoutChildren
+	} = props;
 
 	return (
 		<div
 			className={styles.SiteInfoInnerPane}
+			id={id}
+			style={style}
 			{...propsWithoutChildren}
 		>
 			{children}

--- a/src/components/modules/TitleBar/TitleBar.test.tsx
+++ b/src/components/modules/TitleBar/TitleBar.test.tsx
@@ -1,15 +1,15 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
-import FlyTooltip from './FlyTooltip';
+import { TitleBar } from './TitleBar';
 import TestComponentPropUtils from '../../../utils/TestComponentPropUtils';
 
-describe('FlyTooltip', () => {
+describe('TitleBar', () => {
 	it('renders without crashing', () => {
-		shallow(<FlyTooltip/>);
+		shallow(<TitleBar />);
 	});
 
 	it('renders basic react props like id, className, and style as element attributes', () => {
-		const shallowWrapper = shallow(<FlyTooltip {...TestComponentPropUtils.basicReactProps} />);
-		TestComponentPropUtils.expectsBasicReactProps(shallowWrapper, false);
+		const shallowWrapper = shallow(<TitleBar {...TestComponentPropUtils.basicReactProps} />);
+		TestComponentPropUtils.expectsBasicReactProps(shallowWrapper, true);
 	});
 });

--- a/src/components/modules/TitleBar/TitleBar.tsx
+++ b/src/components/modules/TitleBar/TitleBar.tsx
@@ -14,7 +14,10 @@ export const TitleBar = (props: IProps) => (
 			className={classnames(
 				styles.TitleBar,
 				'TitleBar',
+				props.className,
 			)}
+			id={props.id}
+			style={props.style}
 		>
 			<div>
 				{props.title}

--- a/src/components/modules/VerticalNav/VerticalNav.test.tsx
+++ b/src/components/modules/VerticalNav/VerticalNav.test.tsx
@@ -1,15 +1,15 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
-import FlyTooltip from './FlyTooltip';
+import { VerticalNav } from './VerticalNav';
 import TestComponentPropUtils from '../../../utils/TestComponentPropUtils';
 
-describe('FlyTooltip', () => {
+describe('VerticalNav', () => {
 	it('renders without crashing', () => {
-		shallow(<FlyTooltip/>);
+		shallow(<VerticalNav />);
 	});
 
 	it('renders basic react props like id, className, and style as element attributes', () => {
-		const shallowWrapper = shallow(<FlyTooltip {...TestComponentPropUtils.basicReactProps} />);
+		const shallowWrapper = shallow(<VerticalNav {...TestComponentPropUtils.basicReactProps} />);
 		TestComponentPropUtils.expectsBasicReactProps(shallowWrapper, false);
 	});
 });

--- a/src/components/modules/VerticalNav/VerticalNav.tsx
+++ b/src/components/modules/VerticalNav/VerticalNav.tsx
@@ -6,15 +6,20 @@ import * as styles from './VerticalNav.scss';
 import FlyTooltip from '../../overlays/FlyTooltip/FlyTooltip';
 
 export class VerticalNav extends React.Component<IReactComponentProps> {
-
 	render () {
 		return (
-			<div className={styles.VerticalNav}>
+			<div
+				className={classnames(
+					styles.VerticalNav,
+					this.props.className,
+				)}
+				id={this.props.id}
+				style={this.props.style}
+			>
 				{this.props.children}
 			</div>
 		);
 	}
-
 }
 
 interface IProps extends IReactComponentProps {
@@ -29,7 +34,6 @@ interface IProps extends IReactComponentProps {
 }
 
 export class VerticalNavItem extends React.Component<IProps> {
-
 	static defaultProps: Partial<IProps> = {
 		fadeIn: true,
 		type: 'navlink',
@@ -126,5 +130,4 @@ export class VerticalNavItem extends React.Component<IProps> {
 				return null;
 		}
 	}
-
 }

--- a/src/components/modules/VirtualList/VirtualList.test.tsx
+++ b/src/components/modules/VirtualList/VirtualList.test.tsx
@@ -1,0 +1,9 @@
+import * as React from 'react';
+import { shallow } from 'enzyme';
+import { VirtualList } from './VirtualList';
+
+describe('VirtualList', () => {
+	it('renders without crashing', () => {
+		shallow(<VirtualList />);
+	});
+});

--- a/src/components/modules/VirtualList/VirtualList.tsx
+++ b/src/components/modules/VirtualList/VirtualList.tsx
@@ -48,7 +48,6 @@ export interface IVirtualListState {
 }
 
 export class VirtualList extends React.Component<IVirtualListProps, IVirtualListState> {
-
 	static defaultProps: Partial<IVirtualListProps> = {
 		disableResizeObserver: false,
 		disableVirtualization: false,
@@ -240,5 +239,4 @@ export class VirtualList extends React.Component<IVirtualListProps, IVirtualList
 			this._renderWrapper()
 		);
 	}
-
 }

--- a/src/components/modules/VirtualTable/VirtualTable.test.tsx
+++ b/src/components/modules/VirtualTable/VirtualTable.test.tsx
@@ -1,15 +1,15 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
-import FlyTooltip from './FlyTooltip';
+import { VirtualTable } from './VirtualTable';
 import TestComponentPropUtils from '../../../utils/TestComponentPropUtils';
 
-describe('FlyTooltip', () => {
+describe('VirtualTable', () => {
 	it('renders without crashing', () => {
-		shallow(<FlyTooltip/>);
+		shallow(<VirtualTable />);
 	});
 
 	it('renders basic react props like id, className, and style as element attributes', () => {
-		const shallowWrapper = shallow(<FlyTooltip {...TestComponentPropUtils.basicReactProps} />);
-		TestComponentPropUtils.expectsBasicReactProps(shallowWrapper, false);
+		const shallowWrapper = shallow(<VirtualTable {...TestComponentPropUtils.basicReactProps} />);
+		TestComponentPropUtils.expectsBasicReactProps(shallowWrapper, true);
 	});
 });

--- a/src/components/modules/VirtualTable/VirtualTable.tsx
+++ b/src/components/modules/VirtualTable/VirtualTable.tsx
@@ -93,7 +93,6 @@ export interface IVirtualTableState {
 }
 
 export class VirtualTable extends React.Component<IVirtualTableProps, IVirtualTableState> {
-
 	static defaultProps: Partial<IVirtualTableProps> = {
 		headersCapitalize: 'upper',
 		headersWeight: 700,
@@ -177,6 +176,8 @@ export class VirtualTable extends React.Component<IVirtualTableProps, IVirtualTa
 					},
 					this.props.className,
 				)}
+				style={this.props.style}
+				id={this.props.id}
 			>
 				<VirtualTableContext.Provider
 					value={{
@@ -224,5 +225,4 @@ export class VirtualTable extends React.Component<IVirtualTableProps, IVirtualTa
 			</div>
 		);
 	}
-
 }

--- a/src/components/modules/VirtualTable/components/VirtualTableCell.tsx
+++ b/src/components/modules/VirtualTable/components/VirtualTableCell.tsx
@@ -20,7 +20,6 @@ export interface IVirtualTableCellProps extends IReactComponentProps {
 }
 
 export class VirtualTableCell extends React.Component<IVirtualTableCellProps> {
-
 	// the default change event if none is passed in as a prop to VirtualTable
 	protected _changeFn = (newValue: any): void => {
 		this.props.rowData[this.props.colKey] = newValue;
@@ -83,5 +82,4 @@ export class VirtualTableCell extends React.Component<IVirtualTableCellProps> {
 			</VirtualTableContext.Consumer>
 		);
 	}
-
 }

--- a/src/components/modules/VirtualTable/components/VirtualTableRow.tsx
+++ b/src/components/modules/VirtualTable/components/VirtualTableRow.tsx
@@ -20,7 +20,6 @@ export interface IVirtualTableRowProps extends IReactComponentProps {
 }
 
 export class VirtualTableRow extends React.Component<IVirtualTableRowProps> {
-
 	protected _renderRow (context: IVirtualTableContext) {
 		// this is the default rendered cell contents (which can either be used or ignored by a custom renderer)
 		const children: React.ReactNode = this.props.rowDataOrdered && this.props.rowDataOrdered.map((cellData: any, colIndex: number) => (
@@ -69,5 +68,4 @@ export class VirtualTableRow extends React.Component<IVirtualTableRowProps> {
 			</VirtualTableContext.Consumer>
 		);
 	}
-
 }

--- a/src/components/modules/WindowsToolbar/WindowsToolbar.test.tsx
+++ b/src/components/modules/WindowsToolbar/WindowsToolbar.test.tsx
@@ -1,15 +1,28 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
-import { EmptyArea } from './EmptyArea';
+import WindowsToolbar from './WindowsToolbar';
 import TestComponentPropUtils from '../../../utils/TestComponentPropUtils';
 
 describe('EmptyArea', () => {
 	it('renders without crashing', () => {
-		shallow(<EmptyArea />);
+		shallow(
+			<WindowsToolbar
+				title="myTitle"
+				onMinimize={() => {}}
+				onQuit={() => {}}
+			/>
+		);
 	});
 
 	it('renders basic react props like id, className, and style as element attributes', () => {
-		const shallowWrapper = shallow(<EmptyArea {...TestComponentPropUtils.basicReactProps} />);
+		const shallowWrapper = shallow(
+			<WindowsToolbar
+				title="myTitle"
+				onMinimize={() => {}}
+				onQuit={() => {}}
+				{...TestComponentPropUtils.basicReactProps}
+			/>
+		);
 		TestComponentPropUtils.expectsBasicReactProps(shallowWrapper, false);
 	});
 });

--- a/src/components/modules/WindowsToolbar/WindowsToolbar.tsx
+++ b/src/components/modules/WindowsToolbar/WindowsToolbar.tsx
@@ -10,7 +10,6 @@ import WindowsBack from '../../../svg/windows_back.svg';
 import { FunctionGeneric } from '../../../common/structures/Generics';
 
 interface IProps extends IReactComponentProps {
-
 	title: string;
 	resizable?: boolean;
 	onBack?: FunctionGeneric;
@@ -18,14 +17,19 @@ interface IProps extends IReactComponentProps {
 	onMaximize?: FunctionGeneric;
 	onQuit: FunctionGeneric;
 	onShowMenu?: FunctionGeneric;
-
 }
 
 class WindowsToolbar extends React.Component<IProps> {
-
 	render () {
 		return (
-			<header className={styles.WindowsToolbar}>
+			<header
+				className={classnames(
+					styles.WindowsToolbar,
+					this.props.className,
+				)}
+				id={this.props.id}
+				style={this.props.style}
+			>
 				{
 					this.props.onBack && (
 						<span
@@ -77,7 +81,6 @@ class WindowsToolbar extends React.Component<IProps> {
 			</header>
 		);
 	}
-
 }
 
 export default WindowsToolbar;

--- a/src/components/overlays/FlyModal/FlyModal.test.tsx
+++ b/src/components/overlays/FlyModal/FlyModal.test.tsx
@@ -1,15 +1,15 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
-import FlyTooltip from './FlyTooltip';
+import FlyModal from './FlyModal';
 import TestComponentPropUtils from '../../../utils/TestComponentPropUtils';
 
-describe('FlyTooltip', () => {
+describe('FlyModal', () => {
 	it('renders without crashing', () => {
-		shallow(<FlyTooltip/>);
+		shallow(<FlyModal />);
 	});
 
 	it('renders basic react props like id, className, and style as element attributes', () => {
-		const shallowWrapper = shallow(<FlyTooltip {...TestComponentPropUtils.basicReactProps} />);
+		const shallowWrapper = shallow(<FlyModal {...TestComponentPropUtils.basicReactProps} />);
 		TestComponentPropUtils.expectsBasicReactProps(shallowWrapper, false);
 	});
 });

--- a/src/components/overlays/FlyModal/FlyModal.tsx
+++ b/src/components/overlays/FlyModal/FlyModal.tsx
@@ -42,7 +42,6 @@ interface IProps extends IReactComponentProps {
 }
 
 export default class FlyModal extends React.Component<IProps> {
-
 	static defaultProps: Partial<IProps> = {
 		ariaHideApp: true,
 		closeTimeoutMS: 0,
@@ -75,7 +74,10 @@ export default class FlyModal extends React.Component<IProps> {
 				className={classnames(
 					styles.FlyModal,
 					'FlyModal', // in here for tests
+					this.props.className
 				)} // warning: this must be set after {...this.props} to work
+				id={this.props.id}
+				style={this.props.style}
 			>
 				<Close
 					className={classnames({
@@ -87,5 +89,4 @@ export default class FlyModal extends React.Component<IProps> {
 			</ReactModal>
 		);
 	}
-
 }

--- a/src/components/overlays/FlyTooltip/FlyTooltip.tsx
+++ b/src/components/overlays/FlyTooltip/FlyTooltip.tsx
@@ -14,7 +14,6 @@ interface IProps extends IReactComponentProps {
 }
 
 export default class FlyTooltip extends React.Component<IProps> {
-
 	static defaultProps: Partial<IProps> = {
 		exclamation: false,
 		forceHoverState: false,
@@ -34,6 +33,8 @@ export default class FlyTooltip extends React.Component<IProps> {
 					},
 					this.props.className,
 				)}
+				id={this.props.id}
+				style={this.props.style}
 			>
 				<div
 					className={classnames(
@@ -67,5 +68,4 @@ export default class FlyTooltip extends React.Component<IProps> {
 			</div>
 		);
 	}
-
 }

--- a/src/components/overlays/Popup/Popup.test.tsx
+++ b/src/components/overlays/Popup/Popup.test.tsx
@@ -1,15 +1,15 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
-import FlyTooltip from './FlyTooltip';
+import Popup from './Popup';
 import TestComponentPropUtils from '../../../utils/TestComponentPropUtils';
 
-describe('FlyTooltip', () => {
+describe('Popup', () => {
 	it('renders without crashing', () => {
-		shallow(<FlyTooltip/>);
+		shallow(<Popup />);
 	});
 
 	it('renders basic react props like id, className, and style as element attributes', () => {
-		const shallowWrapper = shallow(<FlyTooltip {...TestComponentPropUtils.basicReactProps} />);
+		const shallowWrapper = shallow(<Popup {...TestComponentPropUtils.basicReactProps} />);
 		TestComponentPropUtils.expectsBasicReactProps(shallowWrapper, false);
 	});
 });

--- a/src/components/overlays/Popup/Popup.tsx
+++ b/src/components/overlays/Popup/Popup.tsx
@@ -36,7 +36,6 @@ interface IState {
 }
 
 export default class Popup extends React.Component<IProps, IState> {
-
 	static defaultProps = {
 		items: [],
 		padding: true,
@@ -114,8 +113,10 @@ export default class Popup extends React.Component<IProps, IState> {
 					},
 					this.props.className,
 				)}
-				tabIndex={0}
+				id={this.props.id}
 				onClick={this.onClick}
+				style={this.props.style}
+				tabIndex={0}
 			>
 				<div
 					className={styles.Popup_BubbleWrapper}
@@ -152,5 +153,4 @@ export default class Popup extends React.Component<IProps, IState> {
 			</div>
 		);
 	}
-
 }

--- a/src/components/overlays/Tooltip/Tooltip.test.tsx
+++ b/src/components/overlays/Tooltip/Tooltip.test.tsx
@@ -1,0 +1,9 @@
+import * as React from 'react';
+import { shallow } from 'enzyme';
+import { Tooltip } from './Tooltip';
+
+describe('Tooltip', () => {
+	it('renders without crashing', () => {
+		shallow(<Tooltip />);
+	});
+});

--- a/src/components/overlays/Tooltip/Tooltip.tsx
+++ b/src/components/overlays/Tooltip/Tooltip.tsx
@@ -26,7 +26,6 @@ interface IState {
 }
 
 export class Tooltip extends React.Component<IProps, IState> {
-
 	static defaultProps: Partial<IProps> = {
 		hideDelay: 500,
 		forceHover: false,
@@ -184,5 +183,4 @@ export class Tooltip extends React.Component<IProps, IState> {
 			</Manager>
 		);
 	}
-
 }

--- a/src/components/tables/TableList/TableList.sass
+++ b/src/components/tables/TableList/TableList.sass
@@ -121,7 +121,7 @@ ul.TableList
 				color: $gray25
 
 			&:focus
-				outline: none;
+				outline: none
 				box-shadow: 0 0 0 2px $green !important
 				border-radius: 3px
 

--- a/src/components/tables/TableList/TableList.test.tsx
+++ b/src/components/tables/TableList/TableList.test.tsx
@@ -1,15 +1,15 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
-import FlyTooltip from './FlyTooltip';
+import { TableList } from './TableList';
 import TestComponentPropUtils from '../../../utils/TestComponentPropUtils';
 
-describe('FlyTooltip', () => {
+describe('TableList', () => {
 	it('renders without crashing', () => {
-		shallow(<FlyTooltip/>);
+		shallow(<TableList />);
 	});
 
 	it('renders basic react props like id, className, and style as element attributes', () => {
-		const shallowWrapper = shallow(<FlyTooltip {...TestComponentPropUtils.basicReactProps} />);
+		const shallowWrapper = shallow(<TableList {...TestComponentPropUtils.basicReactProps} />);
 		TestComponentPropUtils.expectsBasicReactProps(shallowWrapper, false);
 	});
 });

--- a/src/components/tables/TableList/TableList.tsx
+++ b/src/components/tables/TableList/TableList.tsx
@@ -4,14 +4,11 @@ import * as styles from './TableList.sass';
 import IReactComponentProps from '../../../common/structures/IReactComponentProps';
 
 interface IProps extends IReactComponentProps {
-
 	form?: boolean;
 	stripes?: boolean;
-
 }
 
 export class TableList extends React.Component<IProps> {
-
 	render () {
 		return (
 			<ul
@@ -24,6 +21,8 @@ export class TableList extends React.Component<IProps> {
 						[styles.TableList__NoStripes]: this.props.stripes === false,
 					},
 				)}
+				id={this.props.id}
+				style={this.props.style}
 			>
 				{this.props.children}
 			</ul>
@@ -32,15 +31,12 @@ export class TableList extends React.Component<IProps> {
 }
 
 interface ITableListRowProps extends IReactComponentProps {
-
 	form?: boolean;
 	label?: string;
 	selectable?: boolean;
-
 }
 
 export class TableListRow extends React.Component<ITableListRowProps> {
-
 	render () {
 		return (
 			<li
@@ -67,5 +63,4 @@ export class TableListRow extends React.Component<ITableListRowProps> {
 			</li>
 		);
 	}
-
 }

--- a/src/components/tables/TableListMultiDisplay/TableListMultiDisplay.tsx
+++ b/src/components/tables/TableListMultiDisplay/TableListMultiDisplay.tsx
@@ -115,7 +115,15 @@ export default class TableListMultiDisplay extends React.Component<
 	render() {
 		return (
 			<div>
-				<TableList form={true} className={styles.TableListMultiDisplay}>
+				<TableList
+					className={classnames(
+						styles.TableListMultiDisplay,
+						this.props.className,
+					)}
+					id={this.props.id}
+					form={true}
+					style={this.props.style}
+				>
 					{this.renderHeader()}
 					{this.state.unsavedData.map((item: any, index: number) => (
 						<li className={styles.TableListRow} key={index}>

--- a/src/components/tables/TableListMultiDisplay/TableListMutliDisplay.test.tsx
+++ b/src/components/tables/TableListMultiDisplay/TableListMutliDisplay.test.tsx
@@ -1,0 +1,15 @@
+import * as React from 'react';
+import { shallow } from 'enzyme';
+import TableListMultiDisplay from './TableListMultiDisplay';
+import TestComponentPropUtils from '../../../utils/TestComponentPropUtils';
+
+describe('TableListMultiDisplay', () => {
+	it('renders without crashing', () => {
+		shallow(<TableListMultiDisplay />);
+	});
+
+	it('renders basic react props like id, className, and style as element attributes', () => {
+		const shallowWrapper = shallow(<TableListMultiDisplay {...TestComponentPropUtils.basicReactProps} />);
+		TestComponentPropUtils.expectsBasicReactProps(shallowWrapper, true);
+	});
+});

--- a/src/components/tables/TableListRepeater/TableListRepeater.test.tsx
+++ b/src/components/tables/TableListRepeater/TableListRepeater.test.tsx
@@ -1,0 +1,15 @@
+import * as React from 'react';
+import { shallow } from 'enzyme';
+import TableListRepeater from './TableListRepeater';
+import TestComponentPropUtils from '../../../utils/TestComponentPropUtils';
+
+describe('TableListRepeater', () => {
+	it('renders without crashing', () => {
+		shallow(<TableListRepeater />);
+	});
+
+	it('renders basic react props like id, className, and style as element attributes', () => {
+		const shallowWrapper = shallow(<TableListRepeater {...TestComponentPropUtils.basicReactProps} />);
+		TestComponentPropUtils.expectsBasicReactProps(shallowWrapper, true);
+	});
+});

--- a/src/components/tables/TableListRepeater/TableListRepeater.tsx
+++ b/src/components/tables/TableListRepeater/TableListRepeater.tsx
@@ -11,7 +11,6 @@ import { Button } from '../../buttons/Button/Button';
 import { FunctionGeneric } from '../../../common/structures/Generics';
 
 interface IProps extends IReactComponentProps {
-
 	data?: any[];
 	header?: React.ReactNode;
 	itemTemplate: any;
@@ -22,19 +21,15 @@ interface IProps extends IReactComponentProps {
 	repeatingContent: FunctionGeneric;
 	submitDisabled?: boolean;
 	submitLabel?: string;
-
 }
 
 interface IState {
-
 	addingItem: boolean;
 	initialData: any;
 	unsavedData: any;
-
 }
 
 export default class TableListRepeater extends React.Component<IProps, IState> {
-
 	static defaultProps: Partial<IProps> = {
 		labelSingular: 'Item',
 		submitDisabled: false,
@@ -186,7 +181,12 @@ export default class TableListRepeater extends React.Component<IProps, IState> {
 			<div>
 				<TableList
 					form={true}
-					className={styles.TableListRepeater}
+					className={classnames(
+						styles.TableListRepeater,
+						this.props.className,
+					)}
+					id={this.props.id}
+					style={this.props.style}
 				>
 					{this.renderHeader()}
 					{this.state.unsavedData.map((item: any, index: number) => (
@@ -222,5 +222,4 @@ export default class TableListRepeater extends React.Component<IProps, IState> {
 			</div>
 		);
 	}
-
 }

--- a/src/components/text/List/List.test.tsx
+++ b/src/components/text/List/List.test.tsx
@@ -1,15 +1,15 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
-import FlyTooltip from './FlyTooltip';
+import List from './List';
 import TestComponentPropUtils from '../../../utils/TestComponentPropUtils';
 
-describe('FlyTooltip', () => {
+describe('List', () => {
 	it('renders without crashing', () => {
-		shallow(<FlyTooltip/>);
+		shallow(<List />);
 	});
 
 	it('renders basic react props like id, className, and style as element attributes', () => {
-		const shallowWrapper = shallow(<FlyTooltip {...TestComponentPropUtils.basicReactProps} />);
+		const shallowWrapper = shallow(<List {...TestComponentPropUtils.basicReactProps} />);
 		TestComponentPropUtils.expectsBasicReactProps(shallowWrapper, false);
 	});
 });

--- a/src/components/text/List/List.tsx
+++ b/src/components/text/List/List.tsx
@@ -21,7 +21,6 @@ const fontWeightClassMixin = (props: {[key: string]: any}) => ({
 });
 
 interface IProps extends IReactComponentProps {
-
 	bullets?: boolean;
 	headerClass?: string;
 	headerHasDivider?: boolean;
@@ -33,11 +32,9 @@ interface IProps extends IReactComponentProps {
 	listItemFontWeight?: '300' | '400' | '500' | '700' | '900';
 	listItemWrapElement?: boolean;
 	tag?: string;
-
 }
 
 export default class List extends React.Component<IProps> {
-
 	static defaultProps: Partial<IProps> = {
 		bullets: true,
 		headerTag: 'div',
@@ -63,6 +60,8 @@ export default class List extends React.Component<IProps> {
 					styles.List_Container,
 					this.props.className,
 				)}
+				id={this.props.id}
+				style={this.props.style}
 			>
 				{this.props.headerText && (
 					<Title
@@ -107,5 +106,4 @@ export default class List extends React.Component<IProps> {
 			</div>
 		);
 	}
-
 }

--- a/src/components/text/Text/Text.test.tsx
+++ b/src/components/text/Text/Text.test.tsx
@@ -1,15 +1,15 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
-import FlyTooltip from './FlyTooltip';
+import { Text } from './Text';
 import TestComponentPropUtils from '../../../utils/TestComponentPropUtils';
 
-describe('FlyTooltip', () => {
+describe('Text', () => {
 	it('renders without crashing', () => {
-		shallow(<FlyTooltip/>);
+		shallow(<Text />);
 	});
 
 	it('renders basic react props like id, className, and style as element attributes', () => {
-		const shallowWrapper = shallow(<FlyTooltip {...TestComponentPropUtils.basicReactProps} />);
+		const shallowWrapper = shallow(<Text {...TestComponentPropUtils.basicReactProps} />);
 		TestComponentPropUtils.expectsBasicReactProps(shallowWrapper, false);
 	});
 });

--- a/src/components/text/Text/Text.tsx
+++ b/src/components/text/Text/Text.tsx
@@ -20,7 +20,14 @@ interface IProps extends ITextCommonProps {
 }
 
 export const Text = (props: IProps) => {
-	const {className, privateOptions, size, ...otherProps} = props;
+	const {
+		className,
+		id,
+		privateOptions,
+		size,
+		style,
+		...otherProps
+	} = props;
 
 	return (
 		<TextBase
@@ -31,6 +38,8 @@ export const Text = (props: IProps) => {
 			color={size === TextPropSize.default ? TextBasePropColor.graydark_gray15_text : TextBasePropColor.gray_gray75_title}
 			fontSize={TextBasePropFontSize.s}
 			fontWeight={TextBasePropFontWeight.normal}
+			id={id}
+			style={style}
 			{...privateOptions}
 			{...otherProps}
 		/>

--- a/src/components/text/Title/Title.test.tsx
+++ b/src/components/text/Title/Title.test.tsx
@@ -1,15 +1,15 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
-import FlyTooltip from './FlyTooltip';
+import { Title } from './Title';
 import TestComponentPropUtils from '../../../utils/TestComponentPropUtils';
 
-describe('FlyTooltip', () => {
+describe('Title', () => {
 	it('renders without crashing', () => {
-		shallow(<FlyTooltip/>);
+		shallow(<Title />);
 	});
 
 	it('renders basic react props like id, className, and style as element attributes', () => {
-		const shallowWrapper = shallow(<FlyTooltip {...TestComponentPropUtils.basicReactProps} />);
+		const shallowWrapper = shallow(<Title {...TestComponentPropUtils.basicReactProps} />);
 		TestComponentPropUtils.expectsBasicReactProps(shallowWrapper, false);
 	});
 });

--- a/src/components/text/Title/Title.tsx
+++ b/src/components/text/Title/Title.tsx
@@ -23,7 +23,14 @@ interface IProps extends ITextCommonProps {
 }
 
 export const Title = (props: IProps) => {
-	const {className, privateOptions, size, ...otherProps} = props;
+	const {
+		className,
+		id,
+		privateOptions,
+		size,
+		style,
+		...otherProps
+	} = props;
 
 	return (
 		<TextBase
@@ -34,6 +41,8 @@ export const Title = (props: IProps) => {
 			color={setColorProp(props, TextBasePropColor.graydark_white_caption)}
 			fontSize={setSizeProp(props, TextBasePropFontSize.m)}
 			fontWeight={TextBasePropFontWeight.bold}
+			id={id}
+			style={style}
 			{...privateOptions}
 			{...otherProps}
 		/>

--- a/src/components/text/Truncate/Truncate.test.tsx
+++ b/src/components/text/Truncate/Truncate.test.tsx
@@ -1,15 +1,15 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
-import FlyTooltip from './FlyTooltip';
+import Truncate from './Truncate';
 import TestComponentPropUtils from '../../../utils/TestComponentPropUtils';
 
-describe('FlyTooltip', () => {
+describe('Truncate', () => {
 	it('renders without crashing', () => {
-		shallow(<FlyTooltip/>);
+		shallow(<Truncate />);
 	});
 
 	it('renders basic react props like id, className, and style as element attributes', () => {
-		const shallowWrapper = shallow(<FlyTooltip {...TestComponentPropUtils.basicReactProps} />);
+		const shallowWrapper = shallow(<Truncate {...TestComponentPropUtils.basicReactProps} />);
 		TestComponentPropUtils.expectsBasicReactProps(shallowWrapper, false);
 	});
 });

--- a/src/components/text/Truncate/Truncate.tsx
+++ b/src/components/text/Truncate/Truncate.tsx
@@ -3,17 +3,12 @@ import IReactComponentProps from '../../../common/structures/IReactComponentProp
 import Omit from '../../../common/structures/Omit';
 import * as TruncateMarkup from 'react-truncate-markup/lib';
 
-interface IProps {
-
+interface IProps extends IReactComponentProps {
 	ellipsis?: React.ReactNode;
 	lines?: number | undefined;
-
 }
 
-type ReactComponentPropsModified = Omit<IReactComponentProps, 'className' | 'style'>;
-
-export default class Truncate extends React.Component<IProps & ReactComponentPropsModified> {
-
+export default class Truncate extends React.Component<IProps> {
 	static defaultProps: Partial<IProps> = {
 		ellipsis: '...',
 		lines: 1,
@@ -22,8 +17,11 @@ export default class Truncate extends React.Component<IProps & ReactComponentPro
 	render () {
 		return (
 			<TruncateMarkup
-				lines={this.props.lines}
+				className={this.props.className}
 				ellipsis={this.props.ellipsis}
+				id={this.props.id}
+				lines={this.props.lines}
+				style={this.props.style}
 			>
 				<div>
 					{this.props.children}
@@ -31,5 +29,4 @@ export default class Truncate extends React.Component<IProps & ReactComponentPro
 			</TruncateMarkup>
 		);
 	}
-
 }

--- a/src/components/text/_private/TextBase/TextBase.test.tsx
+++ b/src/components/text/_private/TextBase/TextBase.test.tsx
@@ -1,0 +1,15 @@
+import * as React from 'react';
+import { shallow } from 'enzyme';
+import { TextBase } from './TextBase';
+import TestComponentPropUtils from '../../../../utils/TestComponentPropUtils';
+
+describe('TextBase', () => {
+	it('renders without crashing', () => {
+		shallow(<TextBase />);
+	});
+
+	it('renders basic react props like id, className, and style as element attributes', () => {
+		const shallowWrapper = shallow(<TextBase {...TestComponentPropUtils.basicReactProps} />);
+		TestComponentPropUtils.expectsBasicReactProps(shallowWrapper, true);
+	});
+});

--- a/src/components/text/_private/TextBase/TextBase.tsx
+++ b/src/components/text/_private/TextBase/TextBase.tsx
@@ -38,7 +38,6 @@ export interface ITextBaseProps extends ITextCommonProps {
 }
 
 export class TextBase extends React.Component<ITextBaseProps> {
-
 	static defaultProps: Partial<ITextBaseProps> = {
 		color: TextBasePropColor.graydark_white_caption,
 		fontSize: TextBasePropFontSize.s,
@@ -47,7 +46,18 @@ export class TextBase extends React.Component<ITextBaseProps> {
 	};
 
 	render () {
-		const {children, color, container, className, fontSize, fontWeight, tag, ...otherProps} = this.props;
+		const {
+			children,
+			color,
+			container,
+			className,
+			fontSize,
+			fontWeight,
+			id,
+			style,
+			tag,
+			...otherProps
+		} = this.props;
 		const Tag: any = tag;
 
 		return (
@@ -71,6 +81,8 @@ export class TextBase extends React.Component<ITextBaseProps> {
 							[styles.TextBase__FontWeight_700]: fontWeight === TextBasePropFontWeight.heavy,
 						},
 					)}
+					id={this.props.id}
+					style={this.props.style}
 					{...otherProps}
 				>
 					{children}
@@ -78,5 +90,4 @@ export class TextBase extends React.Component<ITextBaseProps> {
 			</Container>
 		);
 	}
-
 }

--- a/src/styles/_partials/_variables.scss
+++ b/src/styles/_partials/_variables.scss
@@ -24,6 +24,7 @@ $blue-dark: #01516e;
 $blue-dark25: #296a82;
 $blue-dark50: #338199;
 $blue75: #b0e0ea;
+
 $blue25: #d6eef2;
 $blue5: #8fd6e3;
 

--- a/src/utils/TestComponentPropUtils.tsx
+++ b/src/utils/TestComponentPropUtils.tsx
@@ -1,0 +1,25 @@
+import * as React from 'react';
+import { ShallowWrapper } from 'enzyme';
+
+export default class TestComponentPropUtils {
+	/**
+	 * An object of basic React props that can be destructured and applied to a component for testing purposes.
+	 */
+	static basicReactProps = { id: 'myId', className: 'myClass', style: { cursor: 'pointer' }};
+
+	/**
+	 * Runs through a series of expects that test the attributes of the rendered element.
+	 * @param shallowWrapper The result from calling `shallow(<Component />)`.
+	 * @param usesContainer Whether the component implements the optional `Component` wrapper around its contents.
+	 * @param useChildIndex If `usesContainer` is true, then this can optionally target a specific child (else 0 index).
+	 */
+	static expectsBasicReactProps = (shallowWrapper: ShallowWrapper<any>, usesContainer: boolean, useChildIndex: number = 0) => {
+		if (usesContainer) {
+			shallowWrapper = shallowWrapper.children().at(useChildIndex);
+		}
+
+		expect(shallowWrapper.props().id).toBe('myId');
+		expect(shallowWrapper.props().style.cursor).toBe('pointer');
+		expect(shallowWrapper.props().className).toContain('myClass');
+	}
+}


### PR DESCRIPTION
## Summary

Add support for `id`, `className`, and `style` props for all remaining candidates that can be setup to apply them. This will help provide a firmer and more consistent API for our component set.

## Technical
- added `id` to ReactComponentProps
- configured `id` for 60+ components
- unable to configure `id` for ~5 components because they're either third party and don't expose that property or uses an element that doesn't support `id`
- configured `className` and `style` for 30+ components that had not yet implemented them
- added 40+ test suites for components that didn't have tests previously
- added 60+ component tests to confirm `id`, `className`, and `style` props are being applied correctly

## Reference
[LOC-2034](https://getflywheel.atlassian.net/browse/LOC-2034)