### PR TITLE
fix(LOC-2034): fix critical Truncate render bug

### DIFF
--- a/src/components/text/Truncate/Truncate.test.tsx
+++ b/src/components/text/Truncate/Truncate.test.tsx
@@ -10,6 +10,6 @@ describe('Truncate', () => {
 
 	it('renders basic react props like id, className, and style as element attributes', () => {
 		const shallowWrapper = shallow(<Truncate {...TestComponentPropUtils.basicReactProps} />);
-		TestComponentPropUtils.expectsBasicReactProps(shallowWrapper, false);
+		TestComponentPropUtils.expectsBasicReactProps(shallowWrapper, true);
 	});
 });

--- a/src/components/text/Truncate/Truncate.tsx
+++ b/src/components/text/Truncate/Truncate.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import IReactComponentProps from '../../../common/structures/IReactComponentProps';
-import Omit from '../../../common/structures/Omit';
-import * as TruncateMarkup from 'react-truncate-markup/lib';
+import TruncateMarkup from 'react-truncate-markup';
 
 interface IProps extends IReactComponentProps {
 	ellipsis?: React.ReactNode;
@@ -17,13 +16,14 @@ export default class Truncate extends React.Component<IProps> {
 	render () {
 		return (
 			<TruncateMarkup
-				className={this.props.className}
 				ellipsis={this.props.ellipsis}
-				id={this.props.id}
 				lines={this.props.lines}
-				style={this.props.style}
 			>
-				<div>
+				<div
+					className={this.props.className}
+					id={this.props.id}
+					style={this.props.style}
+				>
 					{this.props.children}
 				</div>
 			</TruncateMarkup>


### PR DESCRIPTION
Summary

The Truncate component was failing to render content. This fix changes the import syntax and moves the id, className, and style props to the div instead of the third-party component.