### PR TITLE
fix(LOC-2127): fix flytooltip props

### DIFF
--- a/src/components/overlays/FlyTooltip/FlyTooltip.test.tsx
+++ b/src/components/overlays/FlyTooltip/FlyTooltip.test.tsx
@@ -10,6 +10,6 @@ describe('FlyTooltip', () => {
 
 	it('renders basic react props like id, className, and style as element attributes', () => {
 		const shallowWrapper = shallow(<FlyTooltip {...TestComponentPropUtils.basicReactProps} />);
-		TestComponentPropUtils.expectsBasicReactProps(shallowWrapper, false);
+		TestComponentPropUtils.expectsBasicReactProps(shallowWrapper, true);
 	});
 });

--- a/src/components/overlays/FlyTooltip/FlyTooltip.tsx
+++ b/src/components/overlays/FlyTooltip/FlyTooltip.tsx
@@ -31,10 +31,7 @@ export default class FlyTooltip extends React.Component<IProps> {
 						[styles.FlyTooltip_Container__HoverIntent]: this.props.hoverIntent,
 						[styles.FlyTooltip_Container__ForceHoverState]: this.props.forceHoverState,
 					},
-					this.props.className,
 				)}
-				id={this.props.id}
-				style={this.props.style}
 			>
 				<div
 					className={classnames(
@@ -49,6 +46,7 @@ export default class FlyTooltip extends React.Component<IProps> {
 						},
 						this.props.className,
 					)}
+					id={this.props.id}
 					style={this.props.style}
 				>
 					{


### PR DESCRIPTION
## Summary

Site push/pull icon buttons width applied incorrectly to container.

## Technical

Incorrectly applied `style` in [this PR](https://github.com/getflywheel/local-components/pull/134/files#diff-fc41e316a42ae3086c7dc5fa5b3f1f04R36). Need to move all of these out of the container and onto the primary component element. In addition, there were duplicate `className` props being applied (which is a problem waiting to happen) so the one on the container has been removed. If it's needed later, the `Container` component can be used or a `containerClassName` prop could be added as a quick fix.

## Risks

Moving `className` always presents some risk. I ran through implementations to confirm there were no visual side effects, but it needs to be tested thoroughly for regressions.

## Screenshots / Text Samples

### Bug:
<img width="290" alt="image" src="https://user-images.githubusercontent.com/41925404/91899141-57ab0f80-ec62-11ea-9b78-fbe77b1577b8.png">

### Fixed:
<img width="367" alt="image" src="https://user-images.githubusercontent.com/41925404/91899286-888b4480-ec62-11ea-9ee7-ca2981aeb550.png">

## Reference
- [LOC-2127](https://getflywheel.atlassian.net/browse/LOC-2127)
