### PR TITLE
fix(LOC-2130): fix cap issue with exported reference to TitleBar path

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -63,7 +63,7 @@ export {
 } from './components/modules/InnerPaneSidebar/InnerPaneSidebar';
 export { default as Markdown } from './components/modules/Markdown/Markdown';
 export { default as SiteInfoInnerPane } from './components/modules/SiteInfoInnerPane/SiteInfoInnerPane';
-export { TitleBar } from './components/modules/Titlebar/TitleBar';
+export { TitleBar } from './components/modules/TitleBar/TitleBar';
 export {
 	VerticalNav,
 	VerticalNavItem


### PR DESCRIPTION
## Summary

Linux build is failing because the TitleBar path is wrong in the module export.

## Technical

Capitalize `TitleBar` directory correctly (was `Titlebar` 🙄)

## Screenshots

### Azure Error

<img width="1533" alt="image" src="https://user-images.githubusercontent.com/41925404/92020612-09f3dd00-ed1e-11ea-87c6-8628a55372e6.png">

### References
- [Azure Build](https://dev.azure.com/localbyflywheel/Local%20by%20Flywheel/_build/results?buildId=4870&view=logs&j=641e4c04-9698-5c27-19e6-14023c1c3b0a&t=b59f18d2-c258-5720-387a-0cae1d6879fe)
- [LOC-2130](https://getflywheel.atlassian.net/browse/LOC-2130)