### PR TITLE
fix(PRO-291): fix LiveLinksPro popup styling bugs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getflywheel/local-components",
-  "version": "14.1.5",
+  "version": "14.1.4",
   "repository": "https://github.com/getflywheel/local-components",
   "homepage": "https://build.localbyflywheel.com",
   "description": "",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getflywheel/local-components",
-  "version": "14.1.4",
+  "version": "14.1.5",
   "repository": "https://github.com/getflywheel/local-components",
   "homepage": "https://build.localbyflywheel.com",
   "description": "",

--- a/src/components/buttons/CopyButton/CopyButton.scss
+++ b/src/components/buttons/CopyButton/CopyButton.scss
@@ -8,8 +8,6 @@
 	padding: 5px;
 	font-weight: 700;
 	background: transparent;
-	border: none;
-	border-radius: 5px;
 	@include defaultFontSettings;
 	@include tracking(40);
 	@include setupThemeVars(
@@ -17,16 +15,21 @@
 		'--Button_Background_Hover',
 		'--Button_Text_Color',
 		'--Button_Text_Color_Hover',
-		'--Button_Padding'
+		'--Button_Padding',
+		'--Button_Border',
+		'--Button_Border_Hover',
 	);
 
 	color: var(--Button_Text_Color);
 	background: var(--Button_Background);
 	padding: var(--Button_Padding);
+	border: var(--Button_Border);
+	border-radius: 5px;
 
 	&:hover {
 		color: var(--Button_Text_Color_Hover);
 		background: var(--Button_Background_Hover);
+		border: var(--Button_Border_Hover);
 	}
 
 	&:active {
@@ -36,20 +39,32 @@
 	span, svg, g, path, circle {
 		cursor: pointer;
 	}
+
+	svg path {
+		fill: var(--Button_Text_Color);
+	}
+
+	&:hover svg path {
+		fill: var(--Button_Text_Color_Hover);
+	}
 }
 
 .CopyButton__Color_Gray {
-	@include setThemeVar('--Button_Background', $gray5);
-	@include setThemeVar('--Button_Background_Hover', $gray15);
-	@include setThemeVar('--Button_Text_Color', $gray-dark50);
-	@include setThemeVar('--Button_Text_Color_Hover', $gray-dark50);
+	@include setThemeVar('--Button_Background', $gray5, none);
+	@include setThemeVar('--Button_Background_Hover', $gray15, none);
+	@include setThemeVar('--Button_Text_Color', $gray-dark50, $gray25);
+	@include setThemeVar('--Button_Text_Color_Hover', $gray-dark50, $white);
+	@include setThemeVar('--Button_Border', none, 1px solid $gray25);
+	@include setThemeVar('--Button_Border_Hover', none, 1px solid $white);
 }
 
 .CopyButton__Color_Gray_Padding_Small {
-	@include setThemeVar('--Button_Padding', 5px 10px);
+	@include setThemeVar('--Button_Padding', 5px 10px, 4px 10px);
+	@include setThemeVar('--Button_Border_Width', none, 1px);
 }
 .CopyButton__Color_Gray_Padding_Medium {
 	@include setThemeVar('--Button_Padding', 10px);
+	@include setThemeVar('--Button_Border_Width', none, 1.5px);
 }
 
 .CopyButton__Color_Green {
@@ -60,7 +75,7 @@
 }
 
 .CopyButton__Color_Green_Padding_Small {
-	@include setThemeVar('--Button_Padding', 5px 10px);
+	@include setThemeVar('--Button_Padding', 5px 10px, 4px 10px);
 }
 
 .CopyButton__Color_Green_Padding_Medium {
@@ -84,6 +99,7 @@
 
 .CopyButton__Text {
 	font-size: 12px;
+	letter-spacing: 0.24px;
 }
 
 .CopyButton__Text_Margin {

--- a/src/components/buttons/_private/ButtonBase/ButtonBase.scss
+++ b/src/components/buttons/_private/ButtonBase/ButtonBase.scss
@@ -21,7 +21,6 @@ $disabled-text-dark: $gray-dark50;
 	flex-shrink: 0;
 	border-radius: 500px;
 	@include defaultFontSettings;
-	@include tracking(40);
 	// setup a light and dark css variable for each css prop name so we can effortlessly toggle between them based on the current theme
 	@include setupThemeVars(
 		'--Button_Background',
@@ -204,6 +203,14 @@ $disabled-text-dark: $gray-dark50;
 
 .ButtonBase__TextDecoration_Underline {
 	@include setThemeVar('--Button__TextDecoration', underline);
+}
+
+.ButtonBase__LetterSpacing_Normal {
+	letter-spacing: normal;
+}
+
+.ButtonBase__LetterSpacing_Tracked {
+	@include tracking(40);
 }
 
 .ButtonBase__FontSize_XSmall {

--- a/src/components/buttons/_private/ButtonBase/ButtonBase.tsx
+++ b/src/components/buttons/_private/ButtonBase/ButtonBase.tsx
@@ -47,6 +47,11 @@ enum ButtonPropTextDecoration {
 	underline = 'underline',
 }
 
+enum ButtonLetterSpacing {
+	normal = 'normal',
+	tracked = 'tracked',
+}
+
 export interface IButtonCommonProps extends ILocalContainerProps {
 	/** Whether the button is disabled. */
 	disabled?: boolean;
@@ -75,6 +80,8 @@ export interface IButtonBaseProps extends IButtonCommonProps {
 	textTransform?: ButtonPropTextTransform | keyof typeof ButtonPropTextTransform;
 	/** The text decoration applied to the button */
 	textDecoration?: ButtonPropTextDecoration | keyof typeof ButtonPropTextDecoration;
+	/** The letter spacing applied to the button */
+	letterSpacing?: ButtonLetterSpacing | keyof typeof ButtonLetterSpacing;
 }
 
 export class ButtonBase extends React.Component<IButtonBaseProps> {
@@ -88,6 +95,7 @@ export class ButtonBase extends React.Component<IButtonBaseProps> {
 		fontWeight: ButtonPropFontWeight.heavy,
 		textTransform: ButtonPropTextTransform.upper,
 		textDecoration: ButtonPropTextDecoration.none,
+		letterSpacing: ButtonLetterSpacing.tracked,
 	};
 
 	render () {
@@ -101,6 +109,7 @@ export class ButtonBase extends React.Component<IButtonBaseProps> {
 			form,
 			id,
 			innerRef,
+			letterSpacing,
 			onClick,
 			padding,
 			fontWeight,
@@ -133,6 +142,8 @@ export class ButtonBase extends React.Component<IButtonBaseProps> {
 							[styles.ButtonBase__Form_Outline]: form === ButtonPropForm.outline,
 							[styles.ButtonBase__Form_Reversed]: form === ButtonPropForm.reversed,
 							[styles.ButtonBase__Form_Text]: form === ButtonPropForm.text,
+							[styles.ButtonBase__LetterSpacing_Normal]: letterSpacing === ButtonLetterSpacing.normal,
+							[styles.ButtonBase__LetterSpacing_Tracked]: letterSpacing === ButtonLetterSpacing.tracked,
 							[styles.ButtonBase__Padding_Small]: padding === ButtonPropPadding.s,
 							[styles.ButtonBase__Padding_Medium]: padding === ButtonPropPadding.m,
 							[styles.ButtonBase__Padding_Large]: padding === ButtonPropPadding.l,


### PR DESCRIPTION
## Audience

Local Pro Users

## Summary

Fixes a handful of styling issues found on the LiveLinksPro pop up:
- Letter spacing on a number of buttons
- Adds better dark mode support for "CopyText" buttons
- Removes the HTTP auth username and password from the copy text on one of the buttons.

## Technical

- Updates the .scss file for the "CopyButton" component to accommodate dark mode
- Adds a border to CopyButton component when dark mode is active
- Updates the ButtonBase component so it accepts a new privateOption "letterSpacing" and translates it to a CSS property.
- A few additional changes can be found in the corresponding PR for `flywheel-local`: https://github.com/getflywheel/flywheel-local/pull/807 

## Screenshots / Text Samples
**Before updates**
<img width="999" alt="pro-291-dark-mode-before" src="https://user-images.githubusercontent.com/7596682/92962673-e83dd880-f436-11ea-8be0-3e4e2828b634.png">

**After updates**
<img width="1147" alt="pro-291-after-dark" src="https://user-images.githubusercontent.com/7596682/92962700-f4299a80-f436-11ea-9de9-a4155dcf6e63.png">

Short gif recording to show hover states: https://i.getf.ly/lluYlW82

## Reference

- [PRO-219](https://getflywheel.atlassian.net/browse/PRO-219)
