### PR TITLE
fix(LOC-2112): fix IconCheckbox hover color and add alternative prop

### DIFF
--- a/src/components/inputs/IconCheckbox/IconCheckbox.scss
+++ b/src/components/inputs/IconCheckbox/IconCheckbox.scss
@@ -10,8 +10,12 @@
 	justify-content: center;
 
 	&:hover {
-		@include theme-background-gray5-else-black;
+		@include theme-background-gray5-else-gray-dark50;
 		border-radius: 100%;
+	}
+
+	&.IconCheckbox__AltHoverColor:hover {
+		@include theme-background-gray5-else-graydarkalt;
 	}
 }
 

--- a/src/components/inputs/IconCheckbox/IconCheckbox.stories.mdx
+++ b/src/components/inputs/IconCheckbox/IconCheckbox.stories.mdx
@@ -64,3 +64,18 @@ Disabled & Checked
         </div>
 	</Story>
 </Canvas>
+
+Use alt hover color
+
+<Canvas>
+    <Story name="Use alt hover color">
+        <div>
+            <IconCheckbox
+                svgCheckedIcon={YellowStarIcon}
+                svgUncheckedIcon={GrayStarIcon}
+                checked={true}
+                useAltHoverColor
+            />
+        </div>
+    </Story>
+</Canvas>

--- a/src/components/inputs/IconCheckbox/IconCheckbox.tsx
+++ b/src/components/inputs/IconCheckbox/IconCheckbox.tsx
@@ -14,6 +14,7 @@ interface IProps extends IReactComponentProps {
 	onChange: FunctionGeneric;
 	svgCheckedIcon: React.FC<ISvgProps>;
 	svgUncheckedIcon: React.FC<ISvgProps>;
+	useAltHoverColor?: boolean;
 }
 
 export const IconCheckbox: React.FC<IProps> = ({
@@ -22,6 +23,7 @@ export const IconCheckbox: React.FC<IProps> = ({
 	onChange,
 	svgCheckedIcon,
 	svgUncheckedIcon,
+	useAltHoverColor,
 	...props
 }) => {
 	const [ isChecked, updateCheckedState ] = useState(checked === undefined ? false : checked);
@@ -43,6 +45,7 @@ export const IconCheckbox: React.FC<IProps> = ({
 				{
 					[styles.IconCheckbox__Checked]: isChecked === true,
 					[styles.IconCheckbox__Disabled]: disabled,
+					[styles.IconCheckbox__AltHoverColor]: useAltHoverColor === true,
 				},
 				props.className,
 			)}

--- a/src/styles/_partials/_theme.scss
+++ b/src/styles/_partials/_theme.scss
@@ -68,10 +68,6 @@
 	@include __theme-background($gray2, $gray-dark50);
 }
 
-@mixin theme-background-gray5-else-black {
-	@include __theme-background($gray5, $black);
-}
-
 @mixin theme-background-gray5-else-graydarkalt {
 	@include __theme-background($gray5, $gray-dark-alt);
 }


### PR DESCRIPTION
## Audience

Local Engineers and Add-on Developers

## Summary

IconCheckbox hover background color works on some backgrounds and not others for dark mode.

## Technical
- change hover for dark mode to most commonly needed background color and add prop to use alternative for edge cases

## Screenshots / Text Samples

## Reference
- [LOC-2112](https://getflywheel.atlassian.net/browse/LOC-2112)