### PR TITLE
fix(LOC-2202): allow link checker to scroll

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getflywheel/local-components",
-  "version": "15.0.1",
+  "version": "15.0.2",
   "repository": "https://github.com/getflywheel/local-components",
   "homepage": "https://build.localbyflywheel.com",
   "description": "",

--- a/src/components/menus/TertiaryNav/TertiaryNav.sass
+++ b/src/components/menus/TertiaryNav/TertiaryNav.sass
@@ -2,7 +2,6 @@
 
 .TertiaryNavContainer
 	display: flex
-	overflow-y: auto
 	flex-direction: row
 	flex: 1 // this assumes its parent is a flex element
 	@include theme-background-white-else-graydark
@@ -69,5 +68,5 @@
 	.TertiaryContent
 		flex: 1
 		overflow: inherit
-
+		max-height: calc(100vh - 255px)
 

--- a/src/components/menus/TertiaryNav/TertiaryNav.sass
+++ b/src/components/menus/TertiaryNav/TertiaryNav.sass
@@ -4,6 +4,7 @@
 	display: flex
 	flex-direction: row
 	flex: 1 // this assumes its parent is a flex element
+	overflow-y: auto
 	@include theme-background-white-else-graydark
 
 	// needs to be global so any element, outside this library, can use it
@@ -68,5 +69,4 @@
 	.TertiaryContent
 		flex: 1
 		overflow: inherit
-		max-height: calc(100vh - 255px)
 

--- a/src/components/menus/TertiaryNav/TertiaryNav.sass
+++ b/src/components/menus/TertiaryNav/TertiaryNav.sass
@@ -2,6 +2,7 @@
 
 .TertiaryNavContainer
 	display: flex
+	overflow-y: auto
 	flex-direction: row
 	flex: 1 // this assumes its parent is a flex element
 	@include theme-background-white-else-graydark


### PR DESCRIPTION
## Audience

Local Pro Users

## Summary

This is a super small PR that updates the TertiaryContent class that was causing some CSS scrolling issues for Broken Link Checker.

Sister PR for flywheel-local here: https://github.com/getflywheel/flywheel-local/pull/875
Sister PR for Broken Link Checker here: getflywheel/local-addon-broken-link-checker#15

## Technical

Adds a single line of scss that uses the `calc` feature to set max height for the `TertiaryContent` div. This is necessary to inform broken link checker containers what height to use for `max-height: 100%`.

**Pros:** 
- The code works
- It seems to be the most straightforward solution. An alternative would be to undergo a greater style refactor of the parent divs for TertiaryContent,  which could impact more areas of Local than just TertiaryContent and would require caution and testing.

**Cons:**
- It hardcodes a height value, which I don't love. This shouldn't pose a major problem unless we add or subtract fixed height objects to the Local UI, but it could create difficulty with maintaining code down the line.

## Screenshots / Text Samples

New gif that shows other tabs under the PRO menu, including testing for tooltip regressions: https://i.getf.ly/eDuPRrRJ

## Reference
- [LOC-2202](https://getflywheel.atlassian.net/browse/LOC-2202)
