### PR TITLE
fix(LOC-2150): Up the min-height of Banner component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getflywheel/local-components",
-  "version": "15.0.2",
+  "version": "15.0.3",
   "repository": "https://github.com/getflywheel/local-components",
   "homepage": "https://build.localbyflywheel.com",
   "description": "",

--- a/src/components/alerts/Banner/Banner.sass
+++ b/src/components/alerts/Banner/Banner.sass
@@ -6,7 +6,7 @@
 	position: relative
 	display: flex
 	align-items: center
-	min-height: 48px
+	min-height: 56px
 	font-weight: 300;
 	@include stripes(#f58f30, #f48720)
 	@include selectable

--- a/src/components/alerts/Banner/Banner.sass
+++ b/src/components/alerts/Banner/Banner.sass
@@ -37,6 +37,7 @@
 
 	.Content
 		line-height: 18px
+		margin-right: 60px
 
 	@at-root :global(.SettingsPane_Content) &
 		margin: -34px 0 20px

--- a/src/components/alerts/Banner/Banner.sass
+++ b/src/components/alerts/Banner/Banner.sass
@@ -43,8 +43,8 @@
 		margin: -34px 0 20px
 
 	.renderIcon
-		min-width: 18px
-		min-height: 18px
+		width: 18px
+		height: 18px
 		margin-right: 10px
 
 		> svg

--- a/src/components/alerts/Banner/Banner.sass
+++ b/src/components/alerts/Banner/Banner.sass
@@ -42,6 +42,24 @@
 	@at-root :global(.SettingsPane_Content) &
 		margin: -34px 0 20px
 
+	.renderIcon
+		min-width: 18px
+		min-height: 18px
+		margin-right: 10px
+
+		> svg
+			width: 18px
+			height: 18px
+			margin-right: 10px
+			vertical-align: middle
+
+			path, circle, rect
+				fill: $white
+
+			@include selectors_ifHostHasModifier('.Banner__Neutral')
+				path
+					fill: $yellow
+
 	> svg
 		width: 18px
 		height: 18px

--- a/src/components/alerts/Banner/Banner.tsx
+++ b/src/components/alerts/Banner/Banner.tsx
@@ -133,14 +133,15 @@ export default class Banner extends React.Component<BannerProps> {
 						[styles.Banner__Error]: this.props.variant === 'error',
 						[styles.Banner__Success]: this.props.variant === 'success',
 					},
-					this.props.className
+					this.props.className,
 				)}
 				id={this.props.id}
 				style={this.props.style}
 			>
 				{this.renderCarousel()}
-				{this.renderIcon()}
-
+				<div className={styles.renderIcon}>
+					{this.renderIcon()}
+				</div>
 				<span className={styles.Content}>
 					{this.props.children}
 				</span>


### PR DESCRIPTION
**Summary:**

Per LOC-2150, when there are multiple banners within a carousel sometimes the banners were not the same height. Particularly if one banner had a button and the other did not have a button.

This change should make banners height more consistent regardless if the banner has a button or not.

<img width="1167" alt="Screen Shot 2020-10-23 at 11 46 45 AM" src="https://user-images.githubusercontent.com/62450648/97033106-6b6b4780-1528-11eb-8f75-091f4b87a790.png">
<img width="1169" alt="Screen Shot 2020-10-23 at 11 46 58 AM" src="https://user-images.githubusercontent.com/62450648/97033109-6c9c7480-1528-11eb-9534-e2cb32439643.png">

For testing purposes you can yarn link this to Local and slap down some Banners -- I put the following within the SiteInfo index.

```
// import { BannerCarousel, Banner } from '@getflywheel/local-components'

<div>
	<BannerCarousel>
		<Banner variant="success" icon="warning" buttonText="Click Me!" buttonOnClick={() => console.log('buttonOnClick')}>
			<strong>Typewriter!</strong> Poke selvage fam retro pug, offal butcher occupy banh mi artisan tousled. Poke selvage fam retro pug, offal
		</Banner>
		<Banner variant="warning" icon="warning">
			<strong>Typewriter!</strong> Poke selvage fam retro pug, offal butcher occupy banh mi artisan tousled.
		</Banner>
	</BannerCarousel>
</div>
```