### PR TITLE
Rearrange ID's for input click tracking

### DIFF
--- a/src/components/inputs/FlySelect/FlySelect.tsx
+++ b/src/components/inputs/FlySelect/FlySelect.tsx
@@ -337,6 +337,7 @@ export default class FlySelect extends React.Component<IProps, IState> {
 
 		return (
 			<div
+				id={`${this.props.id}_Option`}
 				tabIndex={0}
 				key={i}
 				data-value={option.value}

--- a/src/components/inputs/IconCheckbox/IconCheckbox.test.tsx
+++ b/src/components/inputs/IconCheckbox/IconCheckbox.test.tsx
@@ -12,6 +12,8 @@ describe('Checkbox', () => {
 
 	it('renders basic react props like id, className, and style as element attributes', () => {
 		const shallowWrapper = shallow(<IconCheckbox onChange={() => null} Icon={YellowStar} {...TestComponentPropUtils.basicReactProps} />);
-		TestComponentPropUtils.expectsBasicReactProps(shallowWrapper, false);
+
+		expect(shallowWrapper.props().style.cursor).toBe('pointer');
+		expect(shallowWrapper.props().className).toContain('myClass');
 	});
 });

--- a/src/components/inputs/IconCheckbox/IconCheckbox.tsx
+++ b/src/components/inputs/IconCheckbox/IconCheckbox.tsx
@@ -37,7 +37,7 @@ export const IconCheckbox: React.FC<IProps> = ({
 	const [ disableHoverStyles, setDisableHoverStyles ] = useState(isCheckedProp);
 
 	// to allow updates to the state via prop changes, an effect much be used
-	useEffect(() => { updateCheckedState(isCheckedProp)}, [checked] )
+	useEffect(() => { updateCheckedState(isCheckedProp)}, [checked] );
 
 	const handleChange = () => {
 		const checkedUpdate: boolean = !isChecked;
@@ -68,11 +68,11 @@ export const IconCheckbox: React.FC<IProps> = ({
 				},
 				props.className,
 			)}
-			id={props.id}
 			onMouseLeave={onMouseLeave}
 			style={props.style}
 		>
 			<input
+				id={props.id}
 				type="checkbox"
 				className={styles.IconCheckbox_InputHidden}
 				checked={isChecked}

--- a/src/components/inputs/InputPasswordToggle/InputPasswordToggle.test.tsx
+++ b/src/components/inputs/InputPasswordToggle/InputPasswordToggle.test.tsx
@@ -26,6 +26,6 @@ describe('InputPasswordToggle', () => {
 
 	it('renders basic react props like id, className, and style as element attributes', () => {
 		const shallowWrapper = shallow(<InputPasswordToggle {...TestComponentPropUtils.basicReactProps} />);
-		TestComponentPropUtils.expectsBasicReactProps(shallowWrapper, false);
+		TestComponentPropUtils.expectsBasicReactProps(shallowWrapper, true);
 	});
 });

--- a/src/components/inputs/InputPasswordToggle/InputPasswordToggle.tsx
+++ b/src/components/inputs/InputPasswordToggle/InputPasswordToggle.tsx
@@ -46,10 +46,10 @@ export default class InputPasswordToggle extends React.Component<IProps, IState>
 					`PasswordToggle__${this.state.inputType}`,
 					this.props.className,
 				)}
-				id={this.props.id}
 				style={this.props.style}
 			>
 				<input
+					id={this.props.id}
 					type={this.state.inputType}
 					className={className ? `PasswordToggleInput ${className}` : 'PasswordToggleInput'}
 					{...props}


### PR DESCRIPTION
Move id to input elements for `IconCheckbox` & `InputPasswordToggle` components so global click tracking will recognize it as an 'input' for analytics.

Add an id to the option in `FlySelect` to track when a user clicks the option for analytics.

Accompanies: [PR for LOC-2307]( https://github.com/getflywheel/flywheel-local/pull/903)