### PR TITLE
fix: sync outline button SVG color with text color when disabled

### DIFF
--- a/src/components/buttons/_private/ButtonBase/ButtonBase.scss
+++ b/src/components/buttons/_private/ButtonBase/ButtonBase.scss
@@ -133,6 +133,7 @@ $disabled-text-dark: $gray-dark50;
 	}
 
 	&[disabled] {
+		@include setThemeVar('--Button_SvgPathFillColor', $disabled-text-light-alt-soft, $disabled-background-dark);
 		@include setThemeVar('--Button_Background', $disabled-background-light-alt-soft, $disabled-background-dark-alt-hard);
 		@include setThemeVar('--Button_BorderColor', $disabled-background-light, $disabled-background-dark);
 		@include setThemeVar('--Button_TextColor', $disabled-text-light-alt-soft, $disabled-background-dark);


### PR DESCRIPTION
# Summary

Sync SVG color with text color in disabled outline buttons.

## Screenshots

![image](https://user-images.githubusercontent.com/375381/98593364-ac898880-2298-11eb-933c-abee05121407.png)

<img width="781" alt="Screen Shot 2020-11-09 at 2 34 07 PM" src="https://user-images.githubusercontent.com/375381/98593375-b01d0f80-2298-11eb-82ef-e50241aa0cf5.png">
