### PR TITLE
feat(LOC-2380): add ProgressRing component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getflywheel/local-components",
-  "version": "15.2.0",
+  "version": "15.3.0",
   "repository": "https://github.com/getflywheel/local-components",
   "homepage": "https://build.localbyflywheel.com",
   "description": "",

--- a/src/components/loaders/ProgressRing/ProgressRing.scss
+++ b/src/components/loaders/ProgressRing/ProgressRing.scss
@@ -1,0 +1,98 @@
+@import '../../../styles/_partials/index';
+
+@mixin overrideColorLightAndDark($color) {
+	@include if-theme-light() {
+		color: $color;
+	}
+	@include if-theme-dark() {
+		color: $color;
+	}
+}
+
+@mixin overrideStrokeLightAndDark($stroke1, $stroke2: $stroke1) {
+	@include if-theme-light() {
+		stroke: $stroke1;
+	}
+	@include if-theme-dark() {
+		stroke: $stroke2;
+	}
+}
+
+// Base Component
+
+.ProgressRing {
+	position: relative;
+	display: inline-flex;
+	align-items: center;
+}
+
+// SVG
+
+.ProgressRing_Svg {
+	// position at "12 o'clock" by shifting -90 degrees and nudging to offset 'stroke-linecap: round' overhang
+	transform: rotate(-88deg);
+	transform-origin: 50% 50%;
+}
+
+.ProgressRing_SvgBackground {
+	@include if-theme-dark() {
+		mix-blend-mode: luminosity;
+	}
+}
+
+.ProgressRing_SvgForeground {
+	position: absolute;
+	top: 0;
+	left: 0;
+}
+
+// SVG Circle "Ring" Background
+
+.ProgressRing_SvgBackground_Circle {
+	fill: none;
+	stroke: $gray15;
+	stroke-linecap: round;
+
+	@include if-theme-dark() {
+		stroke: $gray;
+		opacity: 0.5;
+	}
+}
+
+// SVG Circle "Ring" Foreground Fill
+
+.ProgressRing_SvgForeground_Circle {
+	fill: none;
+	stroke-linecap: round;
+	transition: stroke-dashoffset 500ms ease-in-out;
+	@include overrideStrokeLightAndDark($green, $white);
+}
+
+// SVG Circle "Ring" Foreground Fill Modifiers
+
+.ProgressRing_SvgForeground_Circle__disabledTransition {
+	transition: stroke-dashoffset 0ms;
+}
+
+.ProgressRing_SvgForeground_Circle__strokeLight {
+	@include overrideStrokeLightAndDark($green);
+}
+
+// Text
+
+.ProgressRing_Text {
+	margin-left: 10px;
+	@include theme-color-gray-else-white;
+	font-weight: 500;
+	letter-spacing: 0.005em;
+}
+
+// Text Modifiers
+
+.ProgressRing_Text__Dark {
+	@include overrideColorLightAndDark($gray);
+}
+
+.ProgressRing_Text__Light {
+	@include overrideColorLightAndDark($white);
+}

--- a/src/components/loaders/ProgressRing/ProgressRing.stories.mdx
+++ b/src/components/loaders/ProgressRing/ProgressRing.stories.mdx
@@ -1,0 +1,76 @@
+import ProgressRing from "./ProgressRing";
+import { Meta, Story, Canvas } from "@storybook/addon-docs/blocks";
+import { useEffect, useState } from 'react';
+
+<Meta title="Loaders/ProgressRing" component={ProgressRing} />
+
+# Non-updating progress state both large (default) and small
+
+<Canvas>
+	<Story name="large (default)">
+        <ProgressRing progress={0} />
+        <ProgressRing progress={25} />
+        <ProgressRing progress={50} />
+        <ProgressRing progress={75} />
+        <ProgressRing progress={100} />
+	</Story>
+    <Story name="small">
+        <ProgressRing size="small" progress={0} />
+        <ProgressRing size="small" progress={25} />
+        <ProgressRing size="small" progress={50} />
+        <ProgressRing size="small" progress={75} />
+        <ProgressRing size="small" progress={100} />
+    </Story>
+</Canvas>
+
+# Updating progress
+
+<Canvas>
+    <Story name="updating progress">
+        {() => {
+            const [counter, setCounter] = useState(0);
+            useEffect(() => {
+                const interval = setInterval(() => { setCounter(num => num + 1) }, 1000);
+                return () => clearInterval(interval);
+            }, []);
+            return (
+                <>
+                    <ProgressRing progress={counter * 0.75} />
+                    <ProgressRing progress={counter * 1.5} />
+                    <ProgressRing progress={counter * 3} />
+                    <ProgressRing progress={counter * 5} />
+                    <ProgressRing progress={counter * 10} />
+                    <ProgressRing progress={counter * 20} />
+                </>
+            );
+        }}
+    </Story>
+</Canvas>
+
+# Text and progress color
+
+<Canvas>
+    <Story name="auto theme colors">
+        <div className="Theme__Light" style={{ padding: '10px' }}>
+            <h1 style={{ padding: '10px 0' }}>Light theme</h1>
+            <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
+                <ProgressRing progress={25} size="large">Installing..</ProgressRing>
+                <ProgressRing progress={25} size="small">Installing..</ProgressRing>
+            </div>
+        </div>
+        <div className="Theme__Dark" style={{ background: '#262727', padding: '10px' }}>
+            <h1 style={{ color: '#FFFFFF', padding: '10px 0' }}>Dark theme</h1>
+            <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
+                <ProgressRing progress={25} size="large">Installing..</ProgressRing>
+                <ProgressRing progress={25} size="small">Installing..</ProgressRing>
+            </div>
+        </div>
+        <div className="Theme__Dark" style={{ background: '#f47820', padding: '10px' }}>
+            <h1 style={{ color: '#FFFFFF', padding: '10px 0' }}>Dark theme / orange bg</h1>
+            <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
+                <ProgressRing progress={25} size="large">Installing..</ProgressRing>
+                <ProgressRing progress={25} size="small">Installing..</ProgressRing>
+            </div>
+        </div>
+    </Story>
+</Canvas>

--- a/src/components/loaders/ProgressRing/ProgressRing.test.tsx
+++ b/src/components/loaders/ProgressRing/ProgressRing.test.tsx
@@ -1,0 +1,15 @@
+import * as React from 'react';
+import { shallow } from 'enzyme';
+import ProgressRing from './ProgressRing';
+import TestComponentPropUtils from '../../../utils/TestComponentPropUtils';
+
+describe('ProgressRing', () => {
+	it('renders without crashing', () => {
+		shallow(<ProgressRing progress={0} />);
+	});
+
+	it('renders basic react props like id, className, and style as element attributes', () => {
+		const shallowWrapper = shallow(<ProgressRing progress={0} {...TestComponentPropUtils.basicReactProps} />);
+		TestComponentPropUtils.expectsBasicReactProps(shallowWrapper, false);
+	});
+});

--- a/src/components/loaders/ProgressRing/ProgressRing.tsx
+++ b/src/components/loaders/ProgressRing/ProgressRing.tsx
@@ -1,0 +1,134 @@
+import React, { useEffect, useState } from 'react';
+import classnames from 'classnames';
+import * as styles from './ProgressRing.scss';
+import IReactComponentProps from '../../../common/structures/IReactComponentProps';
+
+interface IProps extends IReactComponentProps {
+	/** Progress as a decimal number (0 to 1.0) **/
+	progress: number;
+	progressColor?: 'auto' | 'light';
+	size?: 'large' | 'small';
+	textColor?: 'auto' | 'light' | 'dark';
+}
+
+const defaultProps: Partial<IProps> = {
+	progressColor: 'auto',
+	size: 'large',
+	textColor: 'auto',
+};
+
+const ProgressRing = (props: IProps) => {
+	const [offset, setOffset] = useState(0);
+	const [isAfterInit, setIsAfterInit] = useState(false);
+	const {
+		children,
+		className,
+		id,
+		progress,
+		progressColor,
+		size,
+		style,
+		textColor,
+	} = props;
+	const sizeNum = size === 'large' ? 28 : 18;
+	const strokeWidth = size === 'large' ? 4 : 2;
+	const center = sizeNum / 2;
+	const radius = sizeNum / 2 - strokeWidth / 2;
+	const circumference = 2 * Math.PI * radius;
+
+	useEffect(() => {
+		const interval = setTimeout(() => {
+			setIsAfterInit(true);
+		});
+
+		return () => clearInterval(interval);
+	}, []);
+
+	useEffect(() => {
+		// clamp progress value to 0-100
+		const progressNum = Math.max(0, Math.min(progress * 100, 100));
+		// incrementally decrease the overall % by using a tail reduction value
+		// this is necessary because rounded stroke cap will otherwise make 95% visually look like 100%
+		// the divisor here is completely arbitrary and whatever makes the ring look "full" at 100%
+		const gradualRadialTailReduction = progressNum / 25;
+		// calculate the svg offset value based on progress and circumference
+		const progressOffset = ((100 - progressNum + gradualRadialTailReduction) / 100) * circumference;
+		setOffset(progressOffset);
+	}, [setOffset, progress, circumference, offset]);
+
+	return (
+		<div
+			className={classnames(
+				styles.ProgressRing,
+				'ProgressRing', // this needs to be globally accessible so other component styles can reference it
+				className,
+			)}
+			id={id}
+			style={style}
+		>
+			<svg
+				className={classnames(
+					styles.ProgressRing_Svg,
+					styles.ProgressRing_SvgBackground,
+					'ProgressRing_SvgBackground',
+				)}
+				width={sizeNum}
+				height={sizeNum}
+			>
+				<circle
+					className={classnames(
+						styles.ProgressRing_SvgBackground_Circle,
+						'ProgressRing_SvgBackground_Circle',
+					)}
+					cx={center}
+					cy={center}
+					r={radius}
+					strokeWidth={strokeWidth}
+				/>
+			</svg>
+			<svg
+				className={classnames(
+					styles.ProgressRing_Svg,
+					styles.ProgressRing_SvgForeground,
+					'ProgressRing_SvgForeground',
+				)}
+				width={sizeNum}
+				height={sizeNum}
+			>
+				<circle
+					className={classnames(
+						styles.ProgressRing_SvgForeground_Circle,
+						'ProgressRing_SvgForeground_Circle',
+						{
+							[styles.ProgressRing_SvgForeground_Circle__disabledTransition]: !isAfterInit,
+							[styles.ProgressRing_SvgForeground_Circle__strokeLight]: progressColor === 'light',
+						}
+					)}
+					cx={center}
+					cy={center}
+					r={radius}
+					strokeWidth={strokeWidth}
+					strokeDasharray={circumference}
+					strokeDashoffset={offset}
+				/>
+			</svg>
+			<span
+				className={classnames(
+					styles.ProgressRing_Text,
+					'ProgressRing_Text',
+					{
+						[styles.ProgressRing_Text__Auto]: textColor === 'auto',
+						[styles.ProgressRing_Text__Dark]: textColor === 'dark',
+						[styles.ProgressRing_Text__Light]: textColor === 'light',
+					},
+				)}
+			>
+				{ children }
+			</span>
+		</div>
+	);
+}
+
+ProgressRing.defaultProps = defaultProps;
+
+export default ProgressRing;

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,6 +36,7 @@ export { default as DownloaderItem } from './components/loaders/DownloaderItem/D
 export { default as InstallerStepStatus } from './components/loaders/InstallerStepStatus/InstallerStepStatus';
 export { default as LoadingIndicator } from './components/loaders/LoadingIndicator/LoadingIndicator';
 export { default as ProgressBar } from './components/loaders/ProgressBar/ProgressBar';
+export { default as ProgressRing } from './components/loaders/ProgressRing/ProgressRing';
 export { default as Spinner } from './components/loaders/Spinner/Spinner';
 // Media
 export { default as Avatar } from './components/media/Avatar/Avatar';


### PR DESCRIPTION
## Summary

Create a new progress component that's circular (aka ring).

## Technical
- create new `ProgressRing` component within the `progress` section of storybook
- use programmatic svgs to efficiently render circle instead of outdated css hacks like 360 separate lines, clip-path, etc
- document with several story examples
- add basic tests
- flatten all CSS to make it easier to override when consuming
- add non-hashed class names (in addition to locally scoped names used for styling) for easier selector access later on
- clamp progress so it must always resolve to 0-100
- little tweaks to rotation of circle and progress fill math to make it "look full" at 100% while taking into account the extra size adding by `stroke-linecap: round`
- some of the colors used are automatically changed depending on theme light/dark when using default props values
- `mix-blend-mode` used for dark mode to get background circle colors just right for both dark gray and orange background colors

## Screenshots (as seen in Storybook)

<img width="1041" alt="image" src="https://user-images.githubusercontent.com/41925404/101823940-2196ea80-3af1-11eb-8841-ae75de06f931.png">
