### PR TITLE
feat(LOC-2618): introduce name attribute for all the various input and button components

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Local component library
+ya# Local component library
 
 [![npm version](https://badge.fury.io/js/%40getflywheel%2Flocal-components.svg)](https://badge.fury.io/js/%40getflywheel%2Flocal-components)
 
@@ -18,20 +18,22 @@ In additional to a quickly growing set of React components, we also have SVGs, S
 
 ## Storybook
 
-The quickest way to work on `local-components` is to leverage [Storybook](https://storybook.js.org/). Storybook is a 
+The quickest way to work on `local-components` is to leverage [Storybook](https://storybook.js.org/). Storybook is a
 local development area that works well with React components and supports hot-module reloading.
 
 To start Storybook, run `yarn storybook`.
 
 ## Developing within Local
 
-If you wish to work on `local-components` and see the changes within Local, you will need to run the following:
+If you wish to work on `local-components` and see the changes within Local, you will need to do the following:
 
-1. `yarn link` in `local-components` (only needed one time or after unlinking)
-2. Run `nps components.link` in `flywheel-local` (only needed one time or after unlinking)
-3. Run `nps build.dev` in `flywheel-local`
-4. Start Local
-5. Make any necessary changes in `local-components`. Note, Local does not support hot-module reloading in all locations
+1. First run `yarn build` in `local-components`
+2. Next run `yarn link` (only needed one time or after unlinking)
+3. Switch to `flywheel-local`
+3. Then run `nps components.link` (only needed one time or after unlinking)
+4. Finally run `nps build.dev`
+5. Start Local
+6. Make any necessary changes in `local-components`. Note, Local does not support hot-module reloading in all locations
 so refreshing the UI in Local (<kbd>Cmd</kbd> + <kbd>R</kbd>) will likely be necessary.
 
 ## Running both Storybook and Watch at the same time

--- a/src/components/buttons/_private/ButtonBase/ButtonBase.test.tsx
+++ b/src/components/buttons/_private/ButtonBase/ButtonBase.test.tsx
@@ -12,4 +12,9 @@ describe('ButtonBase', () => {
 		const shallowWrapper = shallow(<ButtonBase {...TestComponentPropUtils.basicReactProps} />);
 		TestComponentPropUtils.expectsBasicReactProps(shallowWrapper, true);
 	});
+
+	it('renders name attribute correctly', () => {
+		const component = shallow(<ButtonBase name="FormName" />);
+		expect(component.exists('[name="FormName"]')).toBe(true);
+	});
 });

--- a/src/components/buttons/_private/ButtonBase/ButtonBase.tsx
+++ b/src/components/buttons/_private/ButtonBase/ButtonBase.tsx
@@ -55,6 +55,8 @@ enum ButtonLetterSpacing {
 export interface IButtonCommonProps extends ILocalContainerProps {
 	/** Whether the button is disabled. */
 	disabled?: boolean;
+	/** The form name attribute */
+	name?: string;
 	/** The click handler. */
 	onClick?: FunctionGeneric;
 	/** The html element tag used for the button. */
@@ -110,6 +112,7 @@ export class ButtonBase extends React.Component<IButtonBaseProps> {
 			id,
 			innerRef,
 			letterSpacing,
+			name,
 			onClick,
 			padding,
 			fontWeight,
@@ -157,6 +160,7 @@ export class ButtonBase extends React.Component<IButtonBaseProps> {
 					)}
 					disabled={disabled}
 					id={id}
+					name={name}
 					onClick={onClick}
 					ref={innerRef}
 					style={style}

--- a/src/components/inputs/BasicInput/BasicInput.test.tsx
+++ b/src/components/inputs/BasicInput/BasicInput.test.tsx
@@ -19,4 +19,9 @@ describe('BasicInput', () => {
 		const shallowWrapper = shallow(<BasicInput {...TestComponentPropUtils.basicReactProps} />);
 		TestComponentPropUtils.expectsBasicReactProps(shallowWrapper, false);
 	});
+
+	it('renders name attribute correctly', () => {
+		const component = shallow(<BasicInput name="FormName" />);
+		expect(component.exists('[name="FormName"]')).toBe(true);
+	});
 });

--- a/src/components/inputs/BasicInput/BasicInput.tsx
+++ b/src/components/inputs/BasicInput/BasicInput.tsx
@@ -4,6 +4,7 @@ import * as styles from './BasicInput.scss';
 import ILocalContainerProps from '../../../common/structures/ILocalContainerProps';
 
 interface IProps extends ILocalContainerProps {
+	name?: string;
 	onChange?: any;
 	value?: string;
 }
@@ -17,6 +18,7 @@ export default class BasicInput extends React.Component<IProps> {
 		const {
 			className,
 			id,
+			name,
 			style,
 			...props
 		} = this.props;
@@ -32,6 +34,7 @@ export default class BasicInput extends React.Component<IProps> {
 				style={style}
 			>
 				<input
+					name={name}
 					type='text'
 					{...props}
 				/>

--- a/src/components/inputs/Checkbox/Checkbox.test.tsx
+++ b/src/components/inputs/Checkbox/Checkbox.test.tsx
@@ -12,4 +12,9 @@ describe('Checkbox', () => {
 		const shallowWrapper = shallow(<Checkbox {...TestComponentPropUtils.basicReactProps} />);
 		TestComponentPropUtils.expectsBasicReactProps(shallowWrapper, false);
 	});
+
+	it('renders name attribute correctly', () => {
+		const component = shallow(<Checkbox name="FormName" />);
+		expect(component.exists('[name="FormName"]')).toBe(true);
+	});
 });

--- a/src/components/inputs/Checkbox/Checkbox.tsx
+++ b/src/components/inputs/Checkbox/Checkbox.tsx
@@ -10,6 +10,7 @@ interface IProps extends IReactComponentProps {
 	checked?: boolean | 'mixed';
 	disabled?: boolean;
 	label?: string;
+	name?: string;
 	onChange: FunctionGeneric;
 }
 
@@ -72,6 +73,7 @@ export default class Checkbox extends React.Component<IProps, IState> {
 						className={styles.Checkbox_InputHidden}
 						checked={this.state.checked === true}
 						disabled={this.props.disabled}
+						name={this.props.name}
 						onChange={this._handleChange}
 					/>
 					<div

--- a/src/components/inputs/IconCheckbox/IconCheckbox.test.tsx
+++ b/src/components/inputs/IconCheckbox/IconCheckbox.test.tsx
@@ -16,4 +16,9 @@ describe('Checkbox', () => {
 		expect(shallowWrapper.props().style.cursor).toBe('pointer');
 		expect(shallowWrapper.props().className).toContain('myClass');
 	});
+
+	it('renders name attribute correctly', () => {
+		const component = shallow(<IconCheckbox name="FormName" onChange={() => null} Icon={YellowStar} />);
+		expect(component.exists('[name="FormName"]')).toBe(true);
+	});
 });

--- a/src/components/inputs/IconCheckbox/IconCheckbox.tsx
+++ b/src/components/inputs/IconCheckbox/IconCheckbox.tsx
@@ -12,6 +12,7 @@ interface IProps extends IReactComponentProps {
 	checked?: boolean;
 	disabled?: boolean;
 	Icon: React.FC<ISvgProps>;
+	name?: string;
 	onChange: FunctionGeneric;
 	/** Whether to override svg icon path colors **/
 	useIconColorsOnChecked?: boolean;
@@ -24,6 +25,7 @@ export const IconCheckbox: React.FC<IProps> = ({
 	checked,
 	disabled,
 	Icon,
+	name,
 	onChange,
 	useIconColorsOnChecked,
 	useIconColorsOnCheckedHover,
@@ -77,6 +79,7 @@ export const IconCheckbox: React.FC<IProps> = ({
 				className={styles.IconCheckbox_InputHidden}
 				checked={isChecked}
 				disabled={disabled}
+				name={name}
 				onChange={handleChange}
 			/>
 			<Icon className={styles.IconCheckbox_Icon} />

--- a/src/components/inputs/InputPasswordToggle/InputPasswordToggle.test.tsx
+++ b/src/components/inputs/InputPasswordToggle/InputPasswordToggle.test.tsx
@@ -28,4 +28,9 @@ describe('InputPasswordToggle', () => {
 		const shallowWrapper = shallow(<InputPasswordToggle {...TestComponentPropUtils.basicReactProps} />);
 		TestComponentPropUtils.expectsBasicReactProps(shallowWrapper, true);
 	});
+
+	it('renders name attribute correctly', () => {
+		const component = shallow(<InputPasswordToggle name="FormName" />);
+		expect(component.exists('[name="FormName"]')).toBe(true);
+	});
 });

--- a/src/components/inputs/InputPasswordToggle/InputPasswordToggle.tsx
+++ b/src/components/inputs/InputPasswordToggle/InputPasswordToggle.tsx
@@ -4,6 +4,7 @@ import EyeSVG from '../../../svg/eye.svg';
 import ILocalContainerProps from '../../../common/structures/ILocalContainerProps';
 
 interface IProps extends ILocalContainerProps {
+	name?: string;
 	onChange?: any;
 	value?: string;
 }
@@ -50,6 +51,7 @@ export default class InputPasswordToggle extends React.Component<IProps, IState>
 			>
 				<input
 					id={this.props.id}
+					name={this.props.name}
 					type={this.state.inputType}
 					className={className ? `PasswordToggleInput ${className}` : 'PasswordToggleInput'}
 					{...props}

--- a/src/components/inputs/Switch/Switch.test.tsx
+++ b/src/components/inputs/Switch/Switch.test.tsx
@@ -12,4 +12,9 @@ describe('Switch', () => {
 		const shallowWrapper = shallow(<Switch {...TestComponentPropUtils.basicReactProps} />);
 		TestComponentPropUtils.expectsBasicReactProps(shallowWrapper, false);
 	});
+
+	it('renders name attribute correctly', () => {
+		const component = shallow(<Switch name="FormName" />);
+		expect(component.exists('[name="FormName"]')).toBe(true);
+	});
 });

--- a/src/components/inputs/Switch/Switch.tsx
+++ b/src/components/inputs/Switch/Switch.tsx
@@ -73,6 +73,7 @@ export default class Switch extends React.Component<IProps, IState> {
 					type="checkbox"
 					defaultChecked={this.state.checked}
 					disabled={this.props.disabled || this.props.noValue}
+					name={this.props.name}
 					onChange={this.handleChange}
 					data-no-value={this.props.noValue}
 				/>


### PR DESCRIPTION
## Summary

Inputs and button-based components need to support the `name` attribute for forms.

## Technical
* adds a `name` prop to 6 components and applies as attribute to underlying form item
* tests to confirm that `name` is applied correctly to the rendered component

## Out of Scope
* FlySelect doesn't use `select` behind the scenes and so it wasn't touched (though there might come a day when we have to rethink how that component is setup)

## Reference
- [LOC-2618](https://getflywheel.atlassian.net/browse/LOC-2618)
