### PR TITLE
feat(LOC-2671): create new Accordion component

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -12,4 +12,7 @@
 		left: 0;
 		overflow: hidden;
 	}
+	.Story__Padding {
+		padding: 10px;
+	}
 </style>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getflywheel/local-components",
-  "version": "15.6.1",
+  "version": "15.7.0",
   "repository": "https://github.com/getflywheel/local-components",
   "homepage": "https://build.localbyflywheel.com",
   "description": "",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "clipboard-copy": "^3.1.0",
     "highlight.js": "^9.13.1",
     "lodash.isequal": "^4.5.0",
+    "react-animate-height": "^2.0.23",
     "react-lowlight": "^2.0.0",
     "react-markdown": "^4.0.3",
     "react-modal": "^3.5.1",

--- a/src/components/icons/helpers/withIconSvg.tsx
+++ b/src/components/icons/helpers/withIconSvg.tsx
@@ -8,8 +8,10 @@ import * as styles from './withIconSvg.scss';
 export interface IconSvgProps {
 	className?: string;
 	key?: string | number;
+	height?: number;
 	id?: string;
 	style?: object;
+	width?: number;
 }
 
 export interface IconSvgStoryMetaAdditionalProps {

--- a/src/components/icons/svgs/CheckmarkMixedIcon.tsx
+++ b/src/components/icons/svgs/CheckmarkMixedIcon.tsx
@@ -18,6 +18,9 @@ export default withIconSvg(
 	{
 		tags: [
 			'checkbox',
+			'minus',
+			'mixed',
+			'subtract',
 		],
 	},
 );

--- a/src/components/layout/Accordion/Accordion.scss
+++ b/src/components/layout/Accordion/Accordion.scss
@@ -1,0 +1,3 @@
+@import '../../../styles/_partials/index';
+
+.Accordion {}

--- a/src/components/layout/Accordion/Accordion.scss
+++ b/src/components/layout/Accordion/Accordion.scss
@@ -1,3 +1,0 @@
-@import '../../../styles/_partials/index';
-
-.Accordion {}

--- a/src/components/layout/Accordion/Accordion.stories.mdx
+++ b/src/components/layout/Accordion/Accordion.stories.mdx
@@ -1,16 +1,168 @@
-import Accordion from "./Accordion";
 import { Meta, Story, Canvas } from "@storybook/addon-docs/blocks";
+import Accordion from "./Accordion";
+import { Title } from '../../text/Title/Title';
+import { Text } from '../../text/Text/Text';
+import { ConnectBothIcon, ConnectPullIcon, ConnectPushIcon } from '../../icons/Icons';
 
 <Meta title="Layout/Accordion" component={Accordion} />
 
+# Basic
+
+Barebones example of multiple Accordion items with the default functionality of only one item being open at a time.
+
 <Canvas>
 	<Story name="Accordion">
-		<div>
-			<div>Some text</div>
+		<div className="Story__Padding">
 			<Accordion>
-				<div>
-					According to me
+				<div style={{paddingBottom: '10px', borderBottom: '1px solid #9f9c9c', marginBottom: '10px'}}>
+					<Title>
+						Connect
+					</Title>
+					<Text>
+						We've built a workflow where you can push local sites to Flywheel and WP Engine in a few quick clicks, easily pull down live sites for offline editing, and sync up your tools for a simplified process!
+					</Text>
 				</div>
+				<div style={{paddingBottom: '10px', borderBottom: '1px solid #9f9c9c', marginBottom: '10px'}}>
+					<Title>
+						Pull
+					</Title>
+					<Text>
+						As long as the Local site is running the “Preferred” environment with PHP 7.3, you can push it straight to Flywheel. And if it’s running a different environment, don’t fret. Simply export the local site and re-import with the “Preferred” environment.
+					</Text>
+				</div>
+				<div>
+					<Title>
+						Push
+					</Title>
+					<Text>
+						If you Connect to multiple hosts, so it’s totally up to you which one your site goes to when it’s time to go live!
+					</Text>
+				</div>
+			</Accordion>
+		</div>
+	</Story>
+</Canvas>
+
+# Stylized Example
+
+An example with plenty of styling combined with basic functionality.
+
+<Canvas>
+	<Story name="Accordion Custom">
+		<div className="Story__Padding">
+			<Accordion>
+				<div style={{paddingBottom: '10px', borderBottom: '1px solid #9f9c9c', marginBottom: '10px'}}>
+					<div style={{display: 'flex', alignItems: 'center'}}>
+						<div style={{textAlign: 'center', width: '24px'}}>
+							<ConnectBothIcon />
+						</div>
+						<div style={{display: 'flex', flexDirection: 'column', marginLeft: '10px'}}>
+							<Title>
+								Connect
+							</Title>
+							<Text>
+								What can Connect do for me?
+							</Text>
+						</div>
+					</div>
+					<div style={{margin: '10px 0 0 34px', padding: '10px 0', borderTop: '1px solid #9f9c9c'}}>
+						<Text>
+							We've built a workflow where you can push local sites to Flywheel and WP Engine in a few quick clicks, easily pull down live sites for offline editing, and sync up your tools for a simplified process!
+						</Text>
+					</div>
+				</div>
+				<div style={{paddingBottom: '10px', borderBottom: '1px solid #9f9c9c', marginBottom: '10px'}}>
+					<div style={{display: 'flex', alignItems: 'center'}}>
+						<div style={{textAlign: 'center', width: '24px'}}>
+							<ConnectPullIcon />
+						</div>
+						<div style={{display: 'flex', flexDirection: 'column', marginLeft: '10px'}}>
+							<Title>
+								Pull
+							</Title>
+							<Text>
+								Can I push existing Local Sites to Flywheel?
+							</Text>
+						</div>
+					</div>
+					<div style={{margin: '10px 0 0 34px', padding: '10px 0', borderTop: '1px solid #9f9c9c'}}>
+						<Text>
+							Yup! As long as the Local site is running the “Preferred” environment with PHP 7.3, you can push it straight to Flywheel. And if it’s running a different environment, don’t fret. Simply export the local site and re-import with the “Preferred” environment.
+						</Text>
+					</div>
+				</div>
+				<div>
+					<div style={{display: 'flex', alignItems: 'center'}}>
+						<div style={{textAlign: 'center', width: '24px'}}>
+							<ConnectPushIcon />
+						</div>
+						<div style={{display: 'flex', flexDirection: 'column', marginLeft: '10px'}}>
+							<Title>
+								Push
+							</Title>
+							<Text>
+								If I connect to Flywheel, do I have to host all my sites there?
+							</Text>
+						</div>
+					</div>
+					<div style={{margin: '10px 0 0 34px', padding: '10px 0', borderTop: '1px solid #9f9c9c'}}>
+						<Text>
+							Nope! In fact, you can Connect to multiple hosts, so it’s totally up to you which one your site goes to when it’s time to go live!
+						</Text>
+					</div>
+				</div>
+			</Accordion>
+		</div>
+	</Story>
+</Canvas>
+
+# FAQ
+
+FAQ example that allows multiple items to be open at the same time via `allowMultipleOpenItems` and enables the entire question area to be clicked via `clickArea` prop.
+
+<Canvas>
+	<Story name="Accordion Multi-Open">
+		<div className="Story__Padding">
+			<Accordion allowMultipleOpenItems clickArea="all">
+				<div
+					className="testClass"
+					onClick={(itemId) => console.log('item clicked: ', itemId)}
+					style={{paddingBottom: '10px', borderBottom: '1px solid #9f9c9c', marginBottom: '10px'}}
+				>
+					<Title>How to export a WordPress site from Local</Title>
+					<Text>
+						<p>
+							Start by opening “Local” and ensure that the site you want to export is running. Next, right-click on the site and select “Export.” Follow the prompts to save the website in a place that you can find it like the Desktop!
+						</p>
+						<p>
+							The zip file that is created contains everything you need for the site, including Media, Plugins, Themes, and an export of the database! The export is the entire /wp-content folder and the database.
+						</p>
+					</Text>
+				</div>
+				<div style={{paddingBottom: '10px', borderBottom: '1px solid #9f9c9c', marginBottom: '10px'}}>
+					<Title>Do you have to be a Flywheel customer to use Local?</Title>
+					<Text>
+						<p>
+							Not at all! While Local will likely work, look, and feel best if you’re using it with Flywheel, it is a standalone local development application. Enjoy! 🙂
+						</p>
+					</Text>
+				</div>
+				<div style={{paddingBottom: '10px', borderBottom: '1px solid #9f9c9c', marginBottom: '10px'}}>
+					<Title>Have another question?</Title>
+					<Text>
+						<p>
+							Visit our <a href="https://localwp.com/community/">community forums</a> for Local at localwp.com/community. Chances are we’ve answered your question already!
+						</p>
+					</Text>
+				</div>
+				<>
+					<Title>Can I use a React Fragment to contain an Accordion item instead of an html element?</Title>
+					<Text>
+						<p>
+							Why yes! In fact, this example does exactly that 😃
+						</p>
+					</Text>
+				</>
 			</Accordion>
 		</div>
 	</Story>

--- a/src/components/layout/Accordion/Accordion.stories.mdx
+++ b/src/components/layout/Accordion/Accordion.stories.mdx
@@ -1,0 +1,17 @@
+import Accordion from "./Accordion";
+import { Meta, Story, Canvas } from "@storybook/addon-docs/blocks";
+
+<Meta title="Layout/Accordion" component={Accordion} />
+
+<Canvas>
+	<Story name="Accordion">
+		<div>
+			<div>Some text</div>
+			<Accordion>
+				<div>
+					According to me
+				</div>
+			</Accordion>
+		</div>
+	</Story>
+</Canvas>

--- a/src/components/layout/Accordion/Accordion.test.tsx
+++ b/src/components/layout/Accordion/Accordion.test.tsx
@@ -1,0 +1,15 @@
+import * as React from 'react';
+import { shallow } from 'enzyme';
+import Accordion from './Accordion';
+import TestComponentPropUtils from '../../../utils/TestComponentPropUtils';
+
+describe('Accordion', () => {
+	it('renders without crashing', () => {
+		shallow(<Accordion />);
+	});
+
+	it('renders basic react props like id, className, and style as element attributes', () => {
+		const shallowWrapper = shallow(<Accordion {...TestComponentPropUtils.basicReactProps} />);
+		TestComponentPropUtils.expectsBasicReactProps(shallowWrapper, true);
+	});
+});

--- a/src/components/layout/Accordion/Accordion.test.tsx
+++ b/src/components/layout/Accordion/Accordion.test.tsx
@@ -5,11 +5,11 @@ import TestComponentPropUtils from '../../../utils/TestComponentPropUtils';
 
 describe('Accordion', () => {
 	it('renders without crashing', () => {
-		shallow(<Accordion />);
+		shallow(<Accordion><div /></Accordion>);
 	});
 
 	it('renders basic react props like id, className, and style as element attributes', () => {
-		const shallowWrapper = shallow(<Accordion {...TestComponentPropUtils.basicReactProps} />);
+		const shallowWrapper = shallow(<Accordion {...TestComponentPropUtils.basicReactProps}><div /></Accordion>);
 		TestComponentPropUtils.expectsBasicReactProps(shallowWrapper, true);
 	});
 });

--- a/src/components/layout/Accordion/Accordion.tsx
+++ b/src/components/layout/Accordion/Accordion.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import classnames from 'classnames';
-import * as styles from './Accordion.scss';
 import { Container } from '../../modules/Container/Container';
 import ILocalContainerProps from '../../../common/structures/ILocalContainerProps';
 import AccordionItem from './AccordionItem';
@@ -44,7 +43,6 @@ const Accordion: React.FC<Props> = ({
 		<Container {...container}>
 			<div
 				className={classnames(
-					styles.Accordion,
 					'Accordion',
 					className,
 				)}

--- a/src/components/layout/Accordion/Accordion.tsx
+++ b/src/components/layout/Accordion/Accordion.tsx
@@ -1,0 +1,37 @@
+import * as React from 'react';
+import classnames from 'classnames';
+import * as styles from './Accordion.scss';
+import { Container } from '../../modules/Container/Container';
+import ILocalContainerProps from '../../../common/structures/ILocalContainerProps';
+
+export interface Props extends ILocalContainerProps {
+
+}
+
+const Accordion: React.FC<Props> = ({
+	children,
+	className,
+	container,
+	id,
+	style,
+}) => (
+	<Container {...container}>
+		<div
+			className={classnames(
+				styles.Accordion,
+				'Accordion',
+				className,
+			)}
+			id={id}
+			style={style}
+		>
+			{ children && (
+				<div>
+					{children}
+				</div>
+			)}
+		</div>
+	</Container>
+);
+
+export default Accordion;

--- a/src/components/layout/Accordion/Accordion.tsx
+++ b/src/components/layout/Accordion/Accordion.tsx
@@ -3,35 +3,79 @@ import classnames from 'classnames';
 import * as styles from './Accordion.scss';
 import { Container } from '../../modules/Container/Container';
 import ILocalContainerProps from '../../../common/structures/ILocalContainerProps';
+import AccordionItem from './AccordionItem';
 
 export interface Props extends ILocalContainerProps {
-
+	allowMultipleOpenItems?: boolean;
+	clickArea?: 'icon' | 'all';
 }
 
 const Accordion: React.FC<Props> = ({
+	allowMultipleOpenItems,
 	children,
 	className,
+	clickArea = 'icon',
 	container,
 	id,
 	style,
-}) => (
-	<Container {...container}>
-		<div
-			className={classnames(
-				styles.Accordion,
-				'Accordion',
-				className,
-			)}
-			id={id}
-			style={style}
-		>
-			{ children && (
-				<div>
-					{children}
-				</div>
-			)}
-		</div>
-	</Container>
-);
+}) => {
+	const [lastOpenedItemId, setLastOpenedItemId] = React.useState<string | undefined>();
+	const [openedItemsLookup, setOpenedItemsLookup] = React.useState<{[key: string]: boolean}>({});
+
+	const onToggle = (itemId: string | undefined) => {
+		// toggle if already open otherwise set new item to open
+		setLastOpenedItemId((lastOpenedItemId) => itemId === lastOpenedItemId ? undefined : itemId);
+
+		if (itemId) {
+			setOpenedItemsLookup((openedItemsLookup) => ({
+				...openedItemsLookup,
+				[itemId]: !openedItemsLookup[itemId],
+			}));
+		}
+	};
+
+	const isItemOpen = (itemId: string | undefined) => {
+		return allowMultipleOpenItems
+			? itemId && !!openedItemsLookup[itemId]
+			: itemId === lastOpenedItemId;
+	}
+
+	return (
+		<Container {...container}>
+			<div
+				className={classnames(
+					styles.Accordion,
+					'Accordion',
+					className,
+				)}
+				id={id}
+				style={style}
+			>
+				{ React.Children.map(children, (child: React.ReactNode, index: number) => {
+					if (!child) {
+						return;
+					}
+
+					const childPlus: React.ReactNode & {props?: any[]} = child;
+
+					return (
+						<AccordionItem
+							itemId={`item-${index}`}
+							clickArea={clickArea}
+							onToggle={onToggle}
+							opened={isItemOpen(`item-${index}`)}
+							{...childPlus.props}
+						>
+							<>
+								{/* directly render children, if possible, thereby removing the wrapper (aka 'child') */}
+								{childPlus?.props?.children || child}
+							</>
+						</AccordionItem>
+					);
+				})}
+			</div>
+		</Container>
+	);
+};
 
 export default Accordion;

--- a/src/components/layout/Accordion/AccordionItem.scss
+++ b/src/components/layout/Accordion/AccordionItem.scss
@@ -1,0 +1,56 @@
+@import '../../../styles/_partials/index';
+
+.AccordionItem {
+	display: flex;
+	flex-direction: column;
+}
+
+.AccordionItem_Summary {
+	display: flex;
+	flex-direction: row;
+	align-items: center;
+}
+
+button.AccordionItem_Summary {
+	// hide button default styles
+	background: none;
+	color: inherit;
+	border: none;
+	padding: 0;
+	text-align: inherit;
+}
+
+.AccordionItem_Summary__ClickAreaAll {
+	&,
+	& * {
+		cursor: pointer;
+	}
+}
+
+.AccordionItem_Summary > * {
+	flex: 1;
+}
+
+.AccordionItem_Summary > *:last-child {
+	flex: initial;
+}
+
+.AccordionItem_Summary_Action {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	align-self: stretch; // increase vertical hit area
+	max-height: 44px;
+	margin-left: 20px;
+
+	// hide button styles
+	background: none;
+	color: inherit;
+	border: none;
+	padding: 0;
+
+	&,
+	& * {
+		cursor: pointer;
+	}
+}

--- a/src/components/layout/Accordion/AccordionItem.stories.mdx
+++ b/src/components/layout/Accordion/AccordionItem.stories.mdx
@@ -1,0 +1,99 @@
+import { Meta, Story, Canvas } from "@storybook/addon-docs/blocks";
+import AccordionItem from "./AccordionItem";
+import { Title } from '../../text/Title/Title';
+import { Text } from '../../text/Text/Text';
+import { CircleInfoIcon } from '../../icons/Icons';
+
+<Meta title="Layout/AccordionItem" component={AccordionItem} />
+
+# Basic
+
+Default single Accordion item.
+
+<Canvas>
+	<Story name="AccordionItem">
+		<div className="Story__Padding">
+			<AccordionItem>
+				<Title>
+					Click me to reveal a secret!
+				</Title>
+				<Text>
+					<p>
+						But then it wouldn't be a secret, would it?! 😉
+					</p>
+				</Text>
+			</AccordionItem>
+		</div>
+	</Story>
+</Canvas>
+
+# Open by Default
+
+An Accordion item that ruins the joke by showing the punchline via `openedDefault` prop 😂
+
+<Canvas>
+	<Story name="AccordionItem Opened">
+		<div className="Story__Padding">
+			<AccordionItem openedDefault>
+				<Title>
+					What did the pirate say when he turned 80?
+				</Title>
+				<Text>
+					<p>
+						Aye Matey
+					</p>
+				</Text>
+			</AccordionItem>
+		</div>
+	</Story>
+</Canvas>
+
+# Hide Icon
+
+Disable `icon` prop and allow the entire summary row to be clicked to open and close.
+
+<Canvas>
+	<Story name="AccordionItem No Icon">
+		<div className="Story__Padding">
+			<AccordionItem
+				icon={false}
+				clickArea="all"
+			>
+				<Title>
+					Look, no icon! Click anywhere on this row.
+				</Title>
+				<Text>
+					<p>
+						Please use this wisely as the icon is used to indicate the intended behavior of an Accordion item.
+					</p>
+				</Text>
+			</AccordionItem>
+		</div>
+	</Story>
+</Canvas>
+
+# Custom Icon
+
+Customize the `icon` used to open and close the item.
+
+<Canvas>
+	<Story name="AccordionItem New Icon">
+		<div className="Story__Padding">
+			<AccordionItem
+				icon={<CircleInfoIcon />}
+			>
+				<Title>
+					Is the default icon not your jam?
+				</Title>
+				<Text>
+					<p>
+						No problem, we've got you covered!
+					</p>
+					<p>
+						In addition to adding a different icon, you can tap into the CSS selector for the open state and add styles like `transform: rotate(90deg)`.
+					</p>
+				</Text>
+			</AccordionItem>
+		</div>
+	</Story>
+</Canvas>

--- a/src/components/layout/Accordion/AccordionItem.test.tsx
+++ b/src/components/layout/Accordion/AccordionItem.test.tsx
@@ -1,0 +1,15 @@
+import * as React from 'react';
+import { shallow } from 'enzyme';
+import AccordionItem from './AccordionItem';
+import TestComponentPropUtils from '../../../utils/TestComponentPropUtils';
+
+describe('AccordionItem', () => {
+	it('renders without crashing', () => {
+		shallow(<AccordionItem><div /></AccordionItem>);
+	});
+
+	it('renders basic react props like id, className, and style as element attributes', () => {
+		const shallowWrapper = shallow(<AccordionItem {...TestComponentPropUtils.basicReactProps}><div /></AccordionItem>);
+		TestComponentPropUtils.expectsBasicReactProps(shallowWrapper, false);
+	});
+});

--- a/src/components/layout/Accordion/AccordionItem.tsx
+++ b/src/components/layout/Accordion/AccordionItem.tsx
@@ -1,0 +1,184 @@
+import * as React from 'react';
+import classnames from 'classnames';
+import * as styles from './AccordionItem.scss';
+import { Container } from '../../modules/Container/Container';
+import ILocalContainerProps from '../../../common/structures/ILocalContainerProps';
+import AnimateHeight from 'react-animate-height';
+import { CaretIcon, CheckmarkMixedIcon } from '../../icons/Icons';
+
+const animationStateClasses = {
+	animating: 'AccordionItem_Content__animating',
+	animatingUp: 'AccordionItem_Content__animatingUp',
+	animatingDown: 'AccordionItem_Content__animatingDown',
+	animatingToHeightZero: 'AccordionItem_Content__animatingToHeightZero',
+	animatingToHeightAuto: 'AccordionItem_Content__animatingToHeightAuto',
+	animatingToHeightSpecific: 'AccordionItem_Content__animatingToHeightSpecific',
+	static: 'AccordionItem_Content__static',
+	staticHeightZero: 'AccordionItem_Content__staticHeightZero',
+	staticHeightAuto: 'AccordionItem_Content__staticHeightAuto',
+	staticHeightSpecific: 'AccordionItem_Content__staticHeightSpecific',
+}
+
+interface PropsBase extends ILocalContainerProps {
+	children: React.ReactNode & {props?: any[]} | null;
+	clickArea?: 'icon' | 'all';
+	icon?: boolean | React.ReactNode;
+	itemId?: string;
+	onToggle?: (id: PropsControlled['itemId'] | undefined) => void;
+}
+
+interface PropsControlled extends PropsBase {
+	opened: boolean;
+}
+
+const AccordionItemControlled: React.FC<PropsControlled> = ({
+	children,
+	className,
+	clickArea = 'icon',
+	container,
+	icon = true,
+	id,
+	itemId,
+	onToggle,
+	opened,
+	style,
+}) => {
+	const onClick = (_: React.MouseEvent<HTMLElement>) => {
+		if (clickArea !== 'all') {
+			// accordion callback
+			onToggle?.(itemId);
+		}
+	};
+	const onClickSummary = (event: React.MouseEvent<HTMLElement>) => {
+		if (clickArea === 'all') {
+			// accordion callback
+			onToggle?.(itemId);
+		}
+	};
+
+	const TagSummary: any = clickArea === 'all' ? 'button' : 'div';
+
+	return (
+		<Container {...container}>
+			<div
+				className={classnames(
+					styles.AccordionItem,
+					'AccordionItem',
+					className,
+				)}
+				id={id}
+				style={style}
+			>
+				<>
+					{/* need to unwrap children because of potential extra 'child' wrapper (plus this works with fragments) */}
+					{ React.Children.map(children?.props?.children || children, (child: React.ReactNode, index: number) => {
+						switch(index) {
+							case 0:
+								return (
+									<TagSummary
+										className={classnames(
+											styles.AccordionItem_Summary,
+											'AccordionItem_Summary',
+											{
+												[styles.AccordionItem_Summary__ClickAreaAll]: clickArea === 'all',
+												['AccordionItem_Summary__ClickAreaAll']: clickArea === 'all',
+											}
+										)}
+										onClick={onClickSummary}
+									>
+										{React.cloneElement(child as React.ReactElement, {})}
+										{/* don't render if icon is disabled otherwise this can be tabbed to */}
+										{icon !== false && (
+											<button
+												className={classnames(
+													styles.AccordionItem_Summary_Action,
+													'AccordionItem_Summary_Action',
+													{
+														// allow developers to override for custom open/close styles
+														['AccordionItem_Summary_Action__Opened']: opened,
+													}
+												)}
+												onClick={onClick}
+												type="button"
+											>
+												{!opened && icon === true && (
+													<CaretIcon />
+												)}
+												{opened && icon === true && (
+													<CheckmarkMixedIcon width={14} height={3} />
+												)}
+												{typeof icon === "object" && (
+													<>
+														{icon}
+													</>
+												)}
+											</button>
+										)}
+									</TagSummary>
+								);
+							case 1:
+								return (
+									<AnimateHeight
+										animationStateClasses={animationStateClasses}
+										className={classnames(
+											'AccordionItem_Content',
+										)}
+										duration={ 200 }
+										height={ opened ? 'auto' : 0 }
+									>
+										{child}
+									</AnimateHeight>
+								);
+							default:
+								return React.cloneElement(child as React.ReactElement, {});
+						}
+					})}
+				</>
+			</div>
+		</Container>
+	);
+};
+
+interface PropsUncontrolled extends PropsBase {
+	openedDefault?: boolean,
+}
+
+const AccordionItemUncontrolled: React.FC<PropsUncontrolled> = ({
+	openedDefault,
+	onToggle,
+	...otherProps
+}) => {
+	const [isOpen, setIsOpen] = React.useState(openedDefault ?? false);
+
+	const onClick = (itemId: PropsBase['itemId']) => {
+		// toggle open state
+		setIsOpen((isOpen) => !isOpen);
+
+		// call optional callback
+		onToggle?.(itemId);
+	};
+
+	return <AccordionItemControlled opened={isOpen} onToggle={onClick} {...otherProps} />;
+};
+
+function instanceOfPropsControlled(object: any): object is PropsControlled {
+    return 'opened' in object;
+}
+
+/**
+ * This is a factory of sorts that determines whether to use the controlled or uncontrolled variation.
+ * Uses controlled-specific prop(s) to determine whether the parent is trying to "control" state or not.
+ */
+const AccordionItem : React.FC<PropsControlled | PropsUncontrolled> = (props) => {
+	return instanceOfPropsControlled(props) ? (
+		<AccordionItemControlled
+			{...props}
+		/>
+	) : (
+		<AccordionItemUncontrolled
+			{...(props)}
+		/>
+	);
+};
+
+export default AccordionItem;

--- a/src/components/layout/Accordion/AccordionItem.tsx
+++ b/src/components/layout/Accordion/AccordionItem.tsx
@@ -176,7 +176,7 @@ const AccordionItem : React.FC<PropsControlled | PropsUncontrolled> = (props) =>
 		/>
 	) : (
 		<AccordionItemUncontrolled
-			{...(props)}
+			{...props}
 		/>
 	);
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,7 @@ export { default as InputSearch } from './components/inputs/InputSearch/InputSea
 export { default as RadioBlock } from './components/inputs/RadioBlock/RadioBlock';
 export { default as Switch } from './components/inputs/Switch/Switch';
 // Layout
+export { default as Accordion } from './components/layout/Accordion/Accordion';
 export { default as AdvancedToggle } from './components/layout/AdvancedToggle/AdvancedToggle';
 export { default as Divider } from './components/layout/Divider/Divider';
 // Loaders

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,7 @@ export { default as RadioBlock } from './components/inputs/RadioBlock/RadioBlock
 export { default as Switch } from './components/inputs/Switch/Switch';
 // Layout
 export { default as Accordion } from './components/layout/Accordion/Accordion';
+export { default as AccordionItem } from './components/layout/Accordion/AccordionItem';
 export { default as AdvancedToggle } from './components/layout/AdvancedToggle/AdvancedToggle';
 export { default as Divider } from './components/layout/Divider/Divider';
 // Loaders

--- a/yarn.lock
+++ b/yarn.lock
@@ -11053,6 +11053,14 @@ raw-loader@^4.0.1:
     loader-utils "^2.0.0"
     schema-utils "^2.6.5"
 
+react-animate-height@^2.0.23:
+  version "2.0.23"
+  resolved "https://registry.yarnpkg.com/react-animate-height/-/react-animate-height-2.0.23.tgz#2e14ac707b20ae67b87766ccfd581e693e0e7ec7"
+  integrity sha512-DucSC/1QuxWEFzR9IsHMzrf2nrcZ6qAmLIFoENa2kLK7h72XybcMA9o073z7aHccFzdMEW0/fhAdnQG7a4rDow==
+  dependencies:
+    classnames "^2.2.5"
+    prop-types "^15.6.1"
+
 react-color@^2.17.0:
   version "2.18.1"
   resolved "https://registry.yarnpkg.com/react-color/-/react-color-2.18.1.tgz#2cda8cc8e06a9e2c52ad391a30ddad31972472f4"


### PR DESCRIPTION
# Summary

Create an Accordion component with:
- open/close action
- animation
- auto close any other items (optionally)
- default chevron
- stories
- tests

# Technical
- created 2 new components `Accordion` which is made up of a group of `AccordionItem` components.
- the `Accordion` component simply controls the state of each `AccordionItem` and auto-closes others if `allowMultipleOpenItems` is set to `false` (default)
- the `AccordionItem` does all the heavy lifting and can be used independent of the parent `Accordion` component
- a mixed control approach was used for `AccordionItem` that allows it to be dumb (controlled) or manage its own state (uncontrolled) and these two modes are auto-determined based on whether the `opened` prop is utilized or not
- both components can set the prop `clickArea` to determine whether the chevron (`icon`) is the lone button that opens/closes the content or if the entire summary area is clickable
- these components are keyboard accessible as this will continue to be a point of emphasis 🎉
- both components utilize the `Container` wrapper (which is now standard for most new components)
- added `react-animate-height` package to once and for all have non-janky height animation that's true to the actual content's height (all non-JavaScript approaches have well known limitations)
- lots of stories to cover a bunch of use cases
- basic tests
- added global storybook style `Story__Padding` that can be used on any story to apply a more aesthetically pleasing padding around story examples
- enhance standard SVG icon component props to allow for height and width overrides (if needed, rare)

# Screenshots

## Accordion stories

<img width="935" alt="image" src="https://user-images.githubusercontent.com/41925404/108534137-68e2e980-729f-11eb-8483-c712d399096c.png">

## AccordionItem stories

<img width="936" alt="image" src="https://user-images.githubusercontent.com/41925404/108534247-887a1200-729f-11eb-8e3c-7eeaee42f273.png">

<img width="930" alt="image" src="https://user-images.githubusercontent.com/41925404/108534305-9def3c00-729f-11eb-9466-14e309a38cc6.png">

## Accordion Accessibility demo

https://user-images.githubusercontent.com/41925404/108534610-f45c7a80-729f-11eb-894f-03cdd9894218.mov

## AccordionItem Accessibility demo

https://user-images.githubusercontent.com/41925404/108534867-3f768d80-72a0-11eb-84b0-4a4ed6a7864b.mov

