### PR TITLE
feat(LOC-2652): allow site overview pane to scroll

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getflywheel/local-components",
-  "version": "15.7.0",
+  "version": "15.7.1",
   "repository": "https://github.com/getflywheel/local-components",
   "homepage": "https://build.localbyflywheel.com",
   "description": "",

--- a/src/components/modules/SiteInfoInnerPane/SiteInfoInnerPane.sass
+++ b/src/components/modules/SiteInfoInnerPane/SiteInfoInnerPane.sass
@@ -3,4 +3,4 @@
 .SiteInfoInnerPane
 	flex: 1
 	display: flex
-	overflow: inherit
+	overflow: auto


### PR DESCRIPTION
## Summary

This is a single line change that allows the "Site Overview" pane to scroll properly if there's too much content.

We used to need this to 'inherit' the overflow property, but thanks to Crum's work refactoring the tooltip, this is no longer an issue.

Also bumps version to `15.7.1`

## Screenshare

Demonstrates scrolling and that tooltips still appear as expected

https://user-images.githubusercontent.com/7596682/108873353-abb70100-75c0-11eb-9ad8-077eadd4da27.mov

