### PR TITLE
fix: styling issue in banner component if no icon is present

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getflywheel/local-components",
-  "version": "15.7.1",
+  "version": "15.7.2",
   "repository": "https://github.com/getflywheel/local-components",
   "homepage": "https://build.localbyflywheel.com",
   "description": "",

--- a/src/components/alerts/Banner/Banner.tsx
+++ b/src/components/alerts/Banner/Banner.tsx
@@ -139,9 +139,11 @@ export default class Banner extends React.Component<BannerProps> {
 				style={this.props.style}
 			>
 				{this.renderCarousel()}
-				<div className={styles.renderIcon}>
-					{this.renderIcon()}
-				</div>
+				{this.renderIcon() &&
+					<div className={styles.renderIcon}>
+						{this.renderIcon()}
+					</div>
+				}
 				<span className={styles.Content}>
 					{this.props.children}
 				</span>


### PR DESCRIPTION
## Summary
This tiny PR bumps the local-components version and fixes an issue with Banners that removes an empty div from rendering if no icon is specified.

## Screenshots:

BEFORE: notice how the banner text is indented and not aligned left with the rest of the UI

<img width="851" alt="Screen Shot 2021-04-01 at 1 28 52 PM" src="https://user-images.githubusercontent.com/7596682/113338052-355b9c00-92ee-11eb-9ea9-568479e86a6b.png">

AFTER: fixed!

<img width="851" alt="Screen Shot 2021-04-01 at 1 29 40 PM" src="https://user-images.githubusercontent.com/7596682/113338144-51f7d400-92ee-11eb-8d4c-6eeb1aaecec7.png">

## Reference

Fixed in process of working through LOCAL-194: https://getflywheel.atlassian.net/browse/LOCAL-194