### PR TITLE
Warning icon not displayed properly when trying to push WP 5.4.2 version

### DIFF
--- a/src/components/overlays/FlyModal/FlyModal.sass
+++ b/src/components/overlays/FlyModal/FlyModal.sass
@@ -29,9 +29,6 @@
 		max-height: 93vh
 		padding: 60px
 
-		> div
-			margin-top: 0 !important
-
 	&.FlyModal__HasIcon
 		overflow: visible
 

--- a/src/components/overlays/FlyModal/FlyModal.tsx
+++ b/src/components/overlays/FlyModal/FlyModal.tsx
@@ -74,7 +74,7 @@ export default class FlyModal extends React.Component<IProps> {
 				className={classnames(
 					styles.FlyModal,
 					'FlyModal', // in here for tests
-					this.props.className
+					this.props.className,
 				)} // warning: this must be set after {...this.props} to work
 				id={this.props.id}
 				style={this.props.style}


### PR DESCRIPTION
## The Problem

The warning icon was not displaying properly when trying to push changes to Flywheel with an incompatible WP version.

## Technical

Remove top margin style from `FlyModal.sass` that was preventing the `topIcon` from displaying right. 

## Screenshot

Before: 
![image-20210426-191451](https://user-images.githubusercontent.com/10208759/116907383-19a62700-ac07-11eb-91e1-00dd5da215e0.png)

After: 
<img width="1112" alt="Screen Shot 2021-05-03 at 11 46 23 AM" src="https://user-images.githubusercontent.com/10208759/116907238-f11e2d00-ac06-11eb-939f-55253998be29.png">
