### PR TITLE
feat: update BasicInput component to accept standard input attributes as props

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getflywheel/local-components",
-  "version": "16.1.0",
+  "version": "16.1.1",
   "repository": "https://github.com/getflywheel/local-components",
   "homepage": "https://build.localbyflywheel.com",
   "description": "",

--- a/src/components/inputs/BasicInput/BasicInput.tsx
+++ b/src/components/inputs/BasicInput/BasicInput.tsx
@@ -7,6 +7,14 @@ interface IProps extends ILocalContainerProps {
 	name?: string;
 	onChange?: any;
 	value?: string;
+	minlength?: number;
+	maxlength?: number;
+	list?: string;
+	pattern?: string;
+	placeholder?: string;
+	readonly?: boolean;
+	size?: number;
+	spellcheck?: boolean;
 }
 
 export default class BasicInput extends React.Component<IProps> {


### PR DESCRIPTION
## Summary

Quick PR that adds the basic input attributes as props to the BasicInput component. Pretty straightforward!

Reference doc: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/text

Also bumps local-components version.

All the props added here are forwarded directly to the underlying "input" component, so no additional work is needed aside from adding the props directly.