### PR TITLE
chore: update ProgressRing styles

### DIFF
--- a/src/components/loaders/ProgressRing/ProgressRing.scss
+++ b/src/components/loaders/ProgressRing/ProgressRing.scss
@@ -75,7 +75,11 @@
 }
 
 .ProgressRing_SvgForeground_Circle__strokeLight {
-	@include overrideStrokeLightAndDark($green);
+	@include overrideStrokeLightAndDark($white, $white);
+}
+
+.ProgressRing_SvgBackground_Circle__strokeLight {
+	@include overrideStrokeLightAndDark($gray75, $gray15);
 }
 
 // Text

--- a/src/components/loaders/ProgressRing/ProgressRing.scss
+++ b/src/components/loaders/ProgressRing/ProgressRing.scss
@@ -29,6 +29,10 @@
 // SVG
 
 .ProgressRing_Svg {
+	// maintain ring shape regardless of inherited svg styles
+	width: auto !important;
+	height: auto !important;
+	margin: auto !important;
 	// position at "12 o'clock" by shifting -90 degrees and nudging to offset 'stroke-linecap: round' overhang
 	transform: rotate(-88deg);
 	transform-origin: 50% 50%;
@@ -81,6 +85,7 @@
 .ProgressRing_SvgBackground_Circle__strokeLight {
 	@include overrideStrokeLightAndDark($gray75, $gray15);
 }
+
 
 // Text
 

--- a/src/components/loaders/ProgressRing/ProgressRing.stories.mdx
+++ b/src/components/loaders/ProgressRing/ProgressRing.stories.mdx
@@ -9,17 +9,17 @@ import { useEffect, useState } from 'react';
 <Canvas>
 	<Story name="large (default)">
         <ProgressRing progress={0} />
-        <ProgressRing progress={25} />
-        <ProgressRing progress={50} />
-        <ProgressRing progress={75} />
-        <ProgressRing progress={100} />
+        <ProgressRing progress={.25} />
+        <ProgressRing progress={.5} />
+        <ProgressRing progress={.75} />
+        <ProgressRing progress={1} />
 	</Story>
     <Story name="small">
         <ProgressRing size="small" progress={0} />
-        <ProgressRing size="small" progress={25} />
-        <ProgressRing size="small" progress={50} />
-        <ProgressRing size="small" progress={75} />
-        <ProgressRing size="small" progress={100} />
+        <ProgressRing size="small" progress={.25} />
+        <ProgressRing size="small" progress={.5} />
+        <ProgressRing size="small" progress={.75} />
+        <ProgressRing size="small" progress={1} />
     </Story>
 </Canvas>
 
@@ -54,22 +54,22 @@ import { useEffect, useState } from 'react';
         <div className="Theme__Light" style={{ padding: '10px' }}>
             <h1 style={{ padding: '10px 0' }}>Light theme</h1>
             <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
-                <ProgressRing progress={25} size="large">Installing..</ProgressRing>
-                <ProgressRing progress={25} size="small">Installing..</ProgressRing>
+                <ProgressRing progress={.25} size="large">Installing..</ProgressRing>
+                <ProgressRing progress={.25} size="small">Installing..</ProgressRing>
             </div>
         </div>
         <div className="Theme__Dark" style={{ background: '#262727', padding: '10px' }}>
             <h1 style={{ color: '#FFFFFF', padding: '10px 0' }}>Dark theme</h1>
             <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
-                <ProgressRing progress={25} size="large">Installing..</ProgressRing>
-                <ProgressRing progress={25} size="small">Installing..</ProgressRing>
+                <ProgressRing progress={.25} size="large">Installing..</ProgressRing>
+                <ProgressRing progress={.25} size="small">Installing..</ProgressRing>
             </div>
         </div>
         <div className="Theme__Dark" style={{ background: '#f47820', padding: '10px' }}>
             <h1 style={{ color: '#FFFFFF', padding: '10px 0' }}>Dark theme / orange bg</h1>
             <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
-                <ProgressRing progress={25} size="large">Installing..</ProgressRing>
-                <ProgressRing progress={25} size="small">Installing..</ProgressRing>
+                <ProgressRing progress={.25} size="large">Installing..</ProgressRing>
+                <ProgressRing progress={.25} size="small">Installing..</ProgressRing>
             </div>
         </div>
     </Story>

--- a/src/components/loaders/ProgressRing/ProgressRing.tsx
+++ b/src/components/loaders/ProgressRing/ProgressRing.tsx
@@ -79,6 +79,9 @@ const ProgressRing = (props: IProps) => {
 					className={classnames(
 						styles.ProgressRing_SvgBackground_Circle,
 						'ProgressRing_SvgBackground_Circle',
+						{
+							[styles.ProgressRing_SvgBackground_Circle__strokeLight]: progressColor === 'light',
+						},
 					)}
 					cx={center}
 					cy={center}
@@ -123,7 +126,7 @@ const ProgressRing = (props: IProps) => {
 					},
 				)}
 			>
-				{ children }
+				{children}
 			</span>
 		</div>
 	);


### PR DESCRIPTION
This PR accomplishes a few things: 
- Update the `ProgressRing` circle colors in 'light' mode to match the design spec
- Pass decimals to `ProgressRing` stories instead of whole numbers
- Add ```width: auto !important;
	height: auto !important;
	margin: auto !important;``` to `ProgressRing_Svg` styles to overwrite the inherited styles from `ButtonBase`. Don't worry, this did not ruin styles for the existing `ProgressRing` in the app.

<img width="1340" alt="Screen Shot 2021-06-09 at 9 28 59 AM" src="https://user-images.githubusercontent.com/10208759/121374011-26ecba80-c905-11eb-81ab-ac3f98407580.png">
