### PR TITLE
fix(LOC-2801): react to changes in extraData prop

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getflywheel/local-components",
-  "version": "16.3.0",
+  "version": "16.3.1",
   "repository": "https://github.com/getflywheel/local-components",
   "homepage": "https://build.localbyflywheel.com",
   "description": "",

--- a/src/components/modules/VirtualList/VirtualList.tsx
+++ b/src/components/modules/VirtualList/VirtualList.tsx
@@ -101,6 +101,7 @@ export class VirtualList extends React.Component<IVirtualListProps, IVirtualList
 			|| nextProps.itemHeight !== this.props.itemHeight
 			|| nextProps.itemRenderer !== this.props.itemRenderer
 			|| nextProps.overscan !== this.props.overscan
+			|| nextProps.itemRendererExtraData !== this.props.itemRendererExtraData
 		) {
 			this._calculateItemsAndRenderIfChanged(nextProps, true);
 		}

--- a/src/components/modules/VirtualTable/VirtualTable.tsx
+++ b/src/components/modules/VirtualTable/VirtualTable.tsx
@@ -12,6 +12,8 @@ export interface VirtualTableCSSProperties extends React.CSSProperties {
 	'--VirtualTable_RowHeight': string;
 }
 
+export type GenericObject = { [key: string]: any };
+
 export interface IVirtualTableCellRendererDataArgs {
 	cellData: any;
 	changeFn: IVirtualTableProps['cellRendererChangeFn'];
@@ -19,7 +21,7 @@ export interface IVirtualTableCellRendererDataArgs {
 	children: React.ReactNode;
 	colKey: string | number;
 	data: IVirtualTableContext['data'] | any;
-	extraData?: any;
+	extraData?: GenericObject;
 	isHeader: boolean;
 	rowData: VirtualTableDataType | any;
 	rowIndex: number;
@@ -29,7 +31,7 @@ export interface IVirtualTableRowRendererDataArgs {
 	/** the default rendered cell contents that can either be rendered within a custom row renderer or ignored all together */
 	children: React.ReactNode;
 	data: IVirtualTableContext['data'] | any;
-	extraData?: any;
+	extraData?: GenericObject;
 	isHeader: boolean;
 	rowData: VirtualTableDataType | any;
 	rowIndex: number;
@@ -37,7 +39,7 @@ export interface IVirtualTableRowRendererDataArgs {
 
 export interface IVirtualTableOnChangeRowDataArgs {
 	colKey: string | number;
-	extraData?: any;
+	extraData?: GenericObject;
 	isHeader: boolean;
 	rowData: VirtualTableDataType | any;
 	rowIndex: number;
@@ -66,7 +68,7 @@ export interface IVirtualTableProps extends IReactComponentProps {
 	 */
 	data: VirtualTableDataType[] | null | undefined;
 	/** */
-	extraData?: any;
+	extraData?: GenericObject;
 	/**
 	 * header data is the order in which is will be displayed
 	 * the header data much match the same type as the data (either array or object-based)
@@ -109,6 +111,7 @@ export class VirtualTable extends React.Component<IVirtualTableProps, IVirtualTa
 		rowHeightSize: 'l',
 		rowHeaderHeightSize: 'auto',
 		striped: true,
+		extraData: {},
 	};
 
 	protected _helper: VirtualTableHelper = new VirtualTableHelper();
@@ -146,14 +149,14 @@ export class VirtualTable extends React.Component<IVirtualTableProps, IVirtualTa
 		}
 	}
 
-	protected _rowRenderer = (rowData: any, rowIndex: number, customRendererStyles: {transform: string}, extraData: {isHeader: boolean}) => {
+	protected _rowRenderer = (rowData: any, rowIndex: number, customRendererStyles: {transform: string}, extraData: GenericObject) => {
 		const key: string = this.props.rowKeyPropName ? rowData[this.props.rowKeyPropName] : `${rowIndex}.${JSON.stringify(rowData)}`;
 
 		return (
 			<VirtualTableRow
 				className={this.props.rowClassName}
-				extraData={this.props.extraData}
-				isHeader={extraData ? extraData.isHeader : false}
+				extraData={extraData}
+				isHeader={extraData.isHeader}
 				key={key}
 				onChangeRowData={this.props.onChangeRowData}
 				rowData={rowData}
@@ -219,7 +222,7 @@ export class VirtualTable extends React.Component<IVirtualTableProps, IVirtualTa
 							styles.VirtualTable_Header,
 							'VirtualTable_Header',
 						)}>
-							{this._rowRenderer(this._helper.getDataCalculationsMemoized(this.props).headersNormalized, -1, {} as any, {isHeader: true})}
+							{this._rowRenderer(this._helper.getDataCalculationsMemoized(this.props).headersNormalized, -1, {} as any, {...this.props.extraData, isHeader: true})}
 						</div>
 					)}
 					<VirtualList
@@ -231,6 +234,7 @@ export class VirtualTable extends React.Component<IVirtualTableProps, IVirtualTa
 						overscan={this.props.overscan}
 						striped={this.props.striped}
 						wrapperRenderer={this._tableBodyRenderer}
+						itemRendererExtraData={this.props.extraData}
 					/>
 				</VirtualTableContext.Provider>
 			</div>


### PR DESCRIPTION
Refactors `VirtualTable.tsx` to make the use of `extraData` more clear and unify the concept across components. Leverages `itemRendererExtraData` from `VirtualList` to prop-drill `extraData`, with a change in that component to react to changes in the `extraData` prop to force a re-render of the table body. 

This was done to make dynamically adjusting a cell's contents possible for a cloud backups ticket, where changes in internet connectivity affect a dropdown menu in a table cell. 