### PR TITLE
feat(LOC-2981): changes for editing LiveLinks

### DIFF
--- a/src/components/inputs/CopyInput/CopyInput.scss
+++ b/src/components/inputs/CopyInput/CopyInput.scss
@@ -1,74 +1,75 @@
 @import '../../../styles/_partials/index.scss';
 @import '../../../common/styles/themeUtils';
 
-.CopyInput__Container {
+// .TableList and .TableListRow are globally scoped - overriding styles for use in TableLists 
+.CopyInput__Container, :global(.TableList .TableListRow) .CopyInput__Container {
 	display: flex;
 	flex-direction: column;
-}
 
-.CopyInput {
-	position: relative;
-	display: flex;
-	align-items: center;
-	width: 100%;
-}
-
-input.CopyInput__Input {
-	outline: none;
-	border: 1px solid;
-	border-radius: 2px;
-	@include theme-border-color;
-	background-color: inherit;
+	.CopyInput__Label {
+		@include theme-color-gray-else-gray15;
+		line-height: 21px;
+		margin-bottom: 10px;
+		display: block;
+	}
 	
-	padding: 4px 42px 4px 10px;
-	width: 100%;
-
-	line-height: 20px;
-	font-weight: 300;
-	@include theme-color-gray-else-gray15;
-	cursor: text;
-
-	transition: box-shadow .1s, border .1s;
-	&:focus {
-		box-shadow: inset 0 0 0 1px $green;
-		border: 1px solid $green;
-	}
- 
-	&.__Invalid,
-	&.__Invalid:focus {
-		box-shadow: inset 0 0 0 1px $red;
-		border: 1px solid $red;
-	}
-}
-
-.CopyInput.__Disabled {
-	input.CopyInput__Input {
-		border-color: transparent;
-		text-align: right;
-	}
-}
-
-.CopyInput__CopyButton {
-	position: absolute;
-	right: 10px;
-}
-
-.CopyInput__Label {
-	@include theme-color-gray-else-gray15;
-	line-height: 21px;
-	margin-bottom: 10px;
-	display: block;
-}
-
-.CopyInput__Message {
-	@include theme-color-gray-else-gray15;
-	line-height: 21px;
-	margin-top: 10px;
-	display: block;
-	font-weight: 300;
+	.CopyInput__Message {
+		@include theme-color-gray-else-gray15;
+		line-height: 21px;
+		margin-top: 10px;
+		display: block;
+		font-weight: 300;
+		
 	
+		&.__Invalid {
+			@include theme-color-red-dark50-else-red;
+		}
+	}
 
-	&.__Invalid {
-		@include theme-color-red-dark50-else-red;
+	.CopyInput {
+		position: relative;
+		display: flex;
+		align-items: center;
+		width: 100%;
+
+		input.CopyInput__Input {
+			outline: none;
+			border: 1px solid;
+			border-radius: 2px;
+			@include theme-border-color;
+			background-color: inherit;
+			
+			padding: 4px 42px 4px 10px;
+			width: 100%;
+		
+			line-height: 20px;
+			font-weight: 300;
+			@include theme-color-gray-else-gray15;
+			cursor: text;
+		
+			transition: box-shadow .1s, border .1s;
+			&:focus {
+				box-shadow: inset 0 0 0 1px $green;
+				border: 1px solid $green;
+			}
+		 
+			&.__Invalid,
+			&.__Invalid:focus {
+				box-shadow: inset 0 0 0 1px $red;
+				border: 1px solid $red;
+			}
+		}
+
+		&.__Disabled {
+			input.CopyInput__Input {
+				border-color: transparent;
+				text-align: right;
+			}
+		}
+
+		.CopyInput__CopyButton {
+			position: absolute;
+			right: 10px;
+		}
 	}
 }

--- a/src/components/inputs/CopyInput/CopyInput.tsx
+++ b/src/components/inputs/CopyInput/CopyInput.tsx
@@ -11,7 +11,7 @@ export interface ICopyInputProps extends IBasicInputProps {
 	/* Label to be shown above text input */
 	label?: string;
 	/* Message to be shown underneath an enabled input e.g. length requirement, example input, etc. */
-	message?: string;
+	message?: React.ReactNode;
 	/* Only show message when invalid is true - useful for only displaying error/validity CTAs */
 	onlyShowMessageWhenInvalid?: boolean;
 	/* Options for CopyButton Tooltip */
@@ -77,6 +77,7 @@ export const CopyInput = (props: ICopyInputProps) => {
 					value={textToCopy}
 					readOnly={readonly}
 					autoComplete="off"
+					spellCheck="false"
 				/>
 				<Tooltip 
 					className={styles.CopyInput__CopyButton} 

--- a/src/components/menus/Drawer/Drawer.scss
+++ b/src/components/menus/Drawer/Drawer.scss
@@ -20,14 +20,17 @@
 		@include theme-border-top;
 		box-shadow: none;
 		transform: translateY(100%);
-		transition: box-shadow 0.25s ease-in, transform 0.35s cubic-bezier(.4,-0.24,.6,-0.12) 0s; // hide/out transition
+		transition: box-shadow 0.25s ease-in, transform 0.35s cubic-bezier(.4,-0.24,.6,-0.05) 0s, visibility 0s 0.35s; // hide/out transition
 		pointer-events: initial;
+		visibility: hidden;
+		@include theme-background-white-else-graydark;
 
 		&.Drawer__DisableAnimation {
 			transition: none;
 		}
 
 		&.Drawer__Show {
+			visibility: visible;
 			transform: translateY(10px);
 			transition: box-shadow 0.15s ease, transform 0.35s cubic-bezier(0.4, 1.65, 0.6, 0.9) 0s; // show/in transition
 

--- a/src/components/menus/TertiaryNav/TertiaryNav.scss
+++ b/src/components/menus/TertiaryNav/TertiaryNav.scss
@@ -79,5 +79,6 @@
 	.TertiaryContent {
 		flex: 1;
 		overflow: inherit;
+		position: relative;
 	}
 }


### PR DESCRIPTION
This PR contains a few changes to some components that were necessary while completing [LOC-2981](https://wpengine.atlassian.net/browse/LOC-2981). The ugliest change here is nesting the scss in `CopyInput.scss` to allow for overriding the `TableList` styles, which is possible due to the global scoping of those classes.

Otherwise the git commits describe the changes - allowing for a drawer component in `TertiaryNav`, setting `visibility: hidden` when not showing the drawer to prevent a tabbing bug, and, most frustratingly, adding a background color to the drawer component. I spent forever wondering why that component was sitting behind the content, when actually it just didn't have a background 🥴 