### PR TITLE
feat(LOC-2981): CopyInput and Banner tweaks

### DIFF
--- a/src/components/alerts/Banner/Banner.sass
+++ b/src/components/alerts/Banner/Banner.sass
@@ -10,6 +10,9 @@
 	@include stripes(#f58f30, #f48720)
 	@include selectable
 
+	&.Stripes__None
+			background: #f58f30
+
 	&.Height__Thin
 		min-height: 40px
 
@@ -22,6 +25,9 @@
 		@include theme-border
 		@include theme-stripes-white-else-graydark
 
+		&.Stripes__None
+			@include theme-background-white-else-graydark
+
 		a
 			color: $green
 
@@ -31,11 +37,17 @@
 	&.Banner__Error
 		@include stripes(#f05b6f, #ef4e65)
 
+		&.Stripes__None
+			background: #f05b6f
+
 		a:hover
 			color: $red-dark
 
 	&.Banner__Success
 		@include stripes($green, mix($black, $green, 5%))
+
+		&.Stripes__None
+			background: $green
 
 		a:hover
 			color: $green-dark
@@ -131,6 +143,18 @@
 					fill: $red-dark50
 				@include selectors_ifHostHasModifier('.Banner__Success')
 					fill: $green-dark50
+		
+		&.Dismiss__Large
+			svg
+				width: 18px
+				height: 18px
+				transform: translateY(0);
+				
+				path
+					@include selectors_setAsDefaults()
+						fill: $white
+					@include selectors_ifHostHasModifier('.Banner__Neutral')
+						@include theme-fill-gray-else-white
 
 	.Carousel
 		float: left

--- a/src/components/alerts/Banner/Banner.tsx
+++ b/src/components/alerts/Banner/Banner.tsx
@@ -6,7 +6,9 @@ import WarningSVG from '../../../svg/warning.svg';
 import CloseSVG from '../../../svg/close--small.svg';
 import { ButtonPropColor, ButtonPropForm } from '../../buttons/_private/ButtonBase/ButtonBase';
 import { TextButton, TextButtonPropSize } from '../../buttons/TextButton/TextButton';
+import Close from '../../buttons/Close/Close';
 import { FunctionGeneric } from '../../../common/structures/Generics';
+
 
 interface BannerProps extends IReactComponentProps {
 	buttonText?: string;
@@ -21,6 +23,8 @@ interface BannerProps extends IReactComponentProps {
 	 * Thin height is 40px; default height is 56px
 	 */
 	height: 'thin' | 'default';
+	noStripes: boolean;
+	closeSize: 'sm' | 'l';
 }
 
 export default class Banner extends React.Component<BannerProps> {
@@ -30,6 +34,8 @@ export default class Banner extends React.Component<BannerProps> {
 		icon: 'warning',
 		numBanners: 1,
 		variant: 'neutral',
+		noStripes: false,
+		closeSize: 'sm',
 	};
 
 	constructor (props: BannerProps) {
@@ -118,13 +124,19 @@ export default class Banner extends React.Component<BannerProps> {
 			return null;
 		}
 
-		return (
+		return this.props.closeSize === 'sm' ? (
 			<span
 				className={styles.Dismiss}
 				onClick={this.props.onDismiss}
 			>
 				<CloseSVG />
 			</span>
+		) : (
+			<Close 
+				position="static"
+				className={classnames(styles.Dismiss__Large, styles.Dismiss)}
+				onClick={this.props.onDismiss}
+			/>
 		);
 	}
 
@@ -139,6 +151,7 @@ export default class Banner extends React.Component<BannerProps> {
 						[styles.Banner__Success]: this.props.variant === 'success',
 						[styles.Height__Thin]: this.props.height === 'thin',
 						[styles.Height__Default]: this.props.height === 'default',
+						[styles.Stripes__None]: this.props.noStripes,
 					},
 					this.props.className,
 				)}

--- a/src/components/inputs/CopyInput/CopyInput.scss
+++ b/src/components/inputs/CopyInput/CopyInput.scss
@@ -19,8 +19,8 @@
 		margin-top: 10px;
 		display: block;
 		font-weight: 300;
+		font-size: $font-size-content-s;
 		
-	
 		&.__Invalid {
 			@include theme-color-red-dark50-else-red;
 		}

--- a/src/components/inputs/CopyInput/CopyInput.tsx
+++ b/src/components/inputs/CopyInput/CopyInput.tsx
@@ -75,7 +75,7 @@ export const CopyInput = (props: ICopyInputProps) => {
 					placeholder={placeholder}
 					type="text"
 					value={textToCopy}
-					readOnly={readonly}
+					disabled={readonly}
 					autoComplete="off"
 					spellCheck="false"
 				/>

--- a/src/components/inputs/CopyInput/CopyInput.tsx
+++ b/src/components/inputs/CopyInput/CopyInput.tsx
@@ -16,6 +16,8 @@ export interface ICopyInputProps extends IBasicInputProps {
 	onlyShowMessageWhenInvalid?: boolean;
 	/* Options for CopyButton Tooltip */
 	copyButtonTooltipProps?: TooltipProps;
+	/* Whether or not to disable the input */
+	disabled?: boolean;
 }
 
 export const CopyInput = (props: ICopyInputProps) => {
@@ -24,7 +26,7 @@ export const CopyInput = (props: ICopyInputProps) => {
 		value,
 		onChange,
 		invalid,
-		readonly,
+		disabled,
 		label,
 		message,
 		onlyShowMessageWhenInvalid,
@@ -37,9 +39,9 @@ export const CopyInput = (props: ICopyInputProps) => {
 	}, [value]);
 
 	const showMessage =
-		!readonly &&
+		!disabled &&
 		(onlyShowMessageWhenInvalid ? invalid && message : !!message);
-	const isInvalid = invalid && !readonly;
+	const isInvalid = invalid && !disabled;
 
 	const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
 		const newValue: string = event.target.value;
@@ -63,7 +65,7 @@ export const CopyInput = (props: ICopyInputProps) => {
 			)}
 			<div
 				className={classnames(styles.CopyInput, {
-					[styles.__Disabled]: readonly,
+					[styles.__Disabled]: disabled,
 				})}
 			>
 				<input
@@ -75,7 +77,7 @@ export const CopyInput = (props: ICopyInputProps) => {
 					placeholder={placeholder}
 					type="text"
 					value={textToCopy}
-					disabled={readonly}
+					disabled={disabled}
 					autoComplete="off"
 					spellCheck="false"
 				/>
@@ -112,6 +114,6 @@ export const CopyInput = (props: ICopyInputProps) => {
 
 CopyInput.defaultProps = {
 	invalid: false,
-	readonly: false,
+	disabled: false,
 	onlyShowMessageWhenInvalid: false,
 };

--- a/src/components/inputs/CopyInput/examples/CopyInputPlayground.tsx
+++ b/src/components/inputs/CopyInput/examples/CopyInputPlayground.tsx
@@ -36,7 +36,7 @@ export class CopyInputPlayground extends ComponentExampleBase {
 					type: 'boolean',
 				},
                 {
-					propName: 'readonly',
+					propName: 'disabled',
 					type: 'boolean',
 				},
 			],


### PR DESCRIPTION
This PR tweaks the CopyInput to change the message size and change the "readonly" state from using the "readonly" attribute to the "disabled" attribute. 

Also allows for removing stripes on the banner component and using the large close button instead of the smaller close icon.