### PR TITLE
feat(LOC-2986): add optional tooltip to CopyInput input field

### DIFF
--- a/src/components/buttons/RefreshButton/RefreshButton.scss
+++ b/src/components/buttons/RefreshButton/RefreshButton.scss
@@ -28,7 +28,7 @@
 
 	&.spin {
 		transform: rotate(360deg);
-		transition: transform 0.55s cubic-bezier(0.5, 1.8, 0.6, 0.75) 0s;
+		transition: transform 0.55s cubic-bezier(.42,1.56,.61,.83) 0s; 
 	}
 
 	&.disabled {

--- a/src/components/inputs/CopyInput/CopyInput.scss
+++ b/src/components/inputs/CopyInput/CopyInput.scss
@@ -32,37 +32,43 @@
 		align-items: center;
 		width: 100%;
 
-		input.CopyInput__Input {
-			outline: none;
-			border: 1px solid;
-			border-radius: 2px;
-			@include theme-border-color;
-			background-color: inherit;
-			
-			padding: 4px 42px 4px 10px;
-			width: 100%;
+		outline: none;
+		border: 1px solid;
+		border-radius: 2px;
+		@include theme-border-color;
+		background-color: inherit;
 		
+		padding: 4px 42px 4px 10px;
+		width: 100%;
+
+		transition: box-shadow .1s, border .1s;
+		&:focus-within {
+			box-shadow: inset 0 0 0 1px $green;
+			border: 1px solid $green;
+		}
+
+		&.__Invalid,
+		&.__Invalid:focus-within {
+			box-shadow: inset 0 0 0 1px $red;
+			border: 1px solid $red;
+		}
+
+		input.CopyInput__Input {
 			line-height: 20px;
 			font-weight: 300;
 			@include theme-color-gray-else-gray15;
 			cursor: text;
-		
-			transition: box-shadow .1s, border .1s;
-			&:focus {
-				box-shadow: inset 0 0 0 1px $green;
-				border: 1px solid $green;
-			}
-		 
-			&.__Invalid,
-			&.__Invalid:focus {
-				box-shadow: inset 0 0 0 1px $red;
-				border: 1px solid $red;
-			}
+			width: 100%;
+		}
+
+		> :global(.Tooltip_Target_Container):first-of-type {
+			width: 100%;
 		}
 
 		&.__Disabled {
+			border-color: transparent;
+
 			input.CopyInput__Input {
-				border-color: transparent;
 				text-align: right;
 			}
 		}

--- a/src/components/inputs/CopyInput/CopyInput.tsx
+++ b/src/components/inputs/CopyInput/CopyInput.tsx
@@ -74,7 +74,7 @@ export const CopyInput = (props: ICopyInputProps) => {
 			>
 				<Tooltip
 					{...inputTooltipProps}
-					hideTooltip={inputTooltipProps ? inputTooltipProps.hideTooltip : true}
+					hideTooltip={inputTooltipProps ? inputTooltipProps?.hideTooltip : true}
 				>
 					<input
 						className={styles.CopyInput__Input}
@@ -91,7 +91,7 @@ export const CopyInput = (props: ICopyInputProps) => {
 				<Tooltip 
 					className={styles.CopyInput__CopyButton} 
 					{...copyButtonTooltipProps}
-					hideTooltip={copyButtonTooltipProps ? copyButtonTooltipProps.hideTooltip : true}
+					hideTooltip={copyButtonTooltipProps ? copyButtonTooltipProps?.hideTooltip : true}
 				>
 					<CopyButton
 						copiedStateIconVariant="checkmarkStroke"

--- a/src/components/inputs/CopyInput/CopyInput.tsx
+++ b/src/components/inputs/CopyInput/CopyInput.tsx
@@ -18,6 +18,8 @@ export interface ICopyInputProps extends IBasicInputProps {
 	copyButtonTooltipProps?: TooltipProps;
 	/* Whether or not to disable the input */
 	disabled?: boolean;
+	/* Options for disabled input Tooltip */
+	inputTooltipProps?: TooltipProps;
 }
 
 export const CopyInput = (props: ICopyInputProps) => {
@@ -31,6 +33,7 @@ export const CopyInput = (props: ICopyInputProps) => {
 		message,
 		onlyShowMessageWhenInvalid,
 		copyButtonTooltipProps,
+		inputTooltipProps
 	} = props;
 
 	const [textToCopy, setTextToCopy] = React.useState(value);
@@ -66,26 +69,30 @@ export const CopyInput = (props: ICopyInputProps) => {
 			<div
 				className={classnames(styles.CopyInput, {
 					[styles.__Disabled]: disabled,
+					[styles.__Invalid]: isInvalid,
 				})}
 			>
-				<input
-					className={classnames(styles.CopyInput__Input, {
-						[styles.__Invalid]: isInvalid,
-					})}
-					id={styles.CopyInput__Input}
-					onChange={handleChange}
-					placeholder={placeholder}
-					type="text"
-					value={textToCopy}
-					disabled={disabled}
-					autoComplete="off"
-					spellCheck="false"
-				/>
+				<Tooltip
+					{...inputTooltipProps}
+					hideTooltip={inputTooltipProps ? inputTooltipProps.hideTooltip : true}
+				>
+					<input
+						className={styles.CopyInput__Input}
+						id={styles.CopyInput__Input}
+						onChange={handleChange}
+						placeholder={placeholder}
+						type="text"
+						value={textToCopy}
+						disabled={disabled}
+						autoComplete="off"
+						spellCheck="false"
+					/>
+				</Tooltip>
 				<Tooltip 
 					className={styles.CopyInput__CopyButton} 
 					{...copyButtonTooltipProps}
 					hideTooltip={copyButtonTooltipProps ? copyButtonTooltipProps.hideTooltip : true}
-					>
+				>
 					<CopyButton
 						copiedStateIconVariant="checkmarkStroke"
 						copiedStateBGStyleVariant="transparentGrayText"

--- a/src/components/menus/TertiaryNav/TertiaryNav.tsx
+++ b/src/components/menus/TertiaryNav/TertiaryNav.tsx
@@ -45,7 +45,9 @@ export class TertiaryNav extends React.Component<IReactComponentProps & RouteCom
 				<ul className={classnames(styles.TertiaryNav)}>
 					{this.props.children}
 				</ul>
-				<div className={classnames(styles.TertiaryContent)}>
+				{/* globally scoping TertiaryContent so overflow can be hijacked
+				to make Drawer components work with overflowing content */}
+				<div className={classnames(styles.TertiaryContent, "TertiaryContent")}>
 					<Switch>
 						{tertiaryNavRoutes}
 						{firstRoute! &&


### PR DESCRIPTION
This PR wraps the input field of `CopyInput` in an optional Tooltip and adds the `inputTooltipProps` prop, much like how the tooltip around the `CopyButton` component works.

This required applying much of the input CSS to the wrapping div, as it surrounds both the input field and the CopyButton component, which are now both surrounded by a ToolTipTargetContainer. 