### PR TITLE
fix: move default props to content div, not shadow div

### DIFF
--- a/src/components/overlays/ScrollShadow/ScrollShadow.tsx
+++ b/src/components/overlays/ScrollShadow/ScrollShadow.tsx
@@ -7,6 +7,7 @@ import { FunctionGeneric } from '../../../common/structures/Generics';
 interface IProps extends IReactComponentProps {
 	// Callback for accessing the scrollable content div ref from a parent - element will be passed on change
 	refCallback?: FunctionGeneric;
+	shadowClassName?: string;
 }
 
 export const ScrollShadow = (props: IProps) => {
@@ -49,13 +50,16 @@ export const ScrollShadow = (props: IProps) => {
 
 	return (
 		<>
-			<div className={styles.ScrollableContent} ref={setScrollableContentRef}>
+			<div 
+				className={classnames(styles.ScrollableContent, props.className)} 
+				id={props.id}
+				style={props.style}
+				ref={setScrollableContentRef}
+			>
 				{props.children}
 			</div>
 			<div 
-				className={classnames(styles.ScrollShadow__Container, props.className)}
-				id={props.id}
-				style={props.style}
+				className={classnames(styles.ScrollShadow__Container, props.shadowClassName)}
 			>
 				<div
 					className={classnames(props.className, styles.ScrollShadow, {

--- a/src/components/overlays/ScrollShadow/ScrollShadow.tsx
+++ b/src/components/overlays/ScrollShadow/ScrollShadow.tsx
@@ -58,9 +58,7 @@ export const ScrollShadow = (props: IProps) => {
 			>
 				{props.children}
 			</div>
-			<div 
-				className={classnames(styles.ScrollShadow__Container, props.shadowClassName)}
-			>
+			<div className={classnames(styles.ScrollShadow__Container, props.shadowClassName)}>
 				<div
 					className={classnames(styles.ScrollShadow, {
 						[styles.ScrollShadow__Show]: showScrollShadow,

--- a/src/components/overlays/ScrollShadow/ScrollShadow.tsx
+++ b/src/components/overlays/ScrollShadow/ScrollShadow.tsx
@@ -62,7 +62,7 @@ export const ScrollShadow = (props: IProps) => {
 				className={classnames(styles.ScrollShadow__Container, props.shadowClassName)}
 			>
 				<div
-					className={classnames(props.className, styles.ScrollShadow, {
+					className={classnames(styles.ScrollShadow, {
 						[styles.ScrollShadow__Show]: showScrollShadow,
 					})}
 				/>


### PR DESCRIPTION
Moves the default props to the ScrollableContent, not the shadow overlay div, as we would generally want to target the content, not the shadow. Adds another prop to add a classname to the shadow div specifically.