### PR TITLE
feat: add onKeyUp event handler to BasicInput

### DIFF
--- a/src/components/inputs/BasicInput/BasicInput.tsx
+++ b/src/components/inputs/BasicInput/BasicInput.tsx
@@ -15,6 +15,7 @@ export interface IBasicInputProps extends ILocalContainerProps {
 	readonly?: boolean;
 	size?: number;
 	spellcheck?: boolean;
+	onKeyUp?: any;
 }
 
 export default class BasicInput extends React.Component<IBasicInputProps> {


### PR DESCRIPTION
Adds onKeyUp event handler to BasicInput (to allow for actions on certain keys, such as opening a link on hitting enter in an input)