### PR TITLE
feat(LOC-3181): remove uppercase styles and dont default to optional uppercase

### DIFF
--- a/src/components/buttons/CopyButton/CopyButton.tsx
+++ b/src/components/buttons/CopyButton/CopyButton.tsx
@@ -146,8 +146,8 @@ export const CopyButton = (props: ICopyButtonProps) => {
 CopyButton.defaultProps = {
 	tag: 'button',
 	copiedTimeout: 1000,
-	uncopiedStateText: 'COPY',
-	copiedStateText: 'COPIED',
+	uncopiedStateText: 'Copy',
+	copiedStateText: 'Copied',
 	uncopiedStateIconVariant: null,
 	copiedStateIconVariant: CopiedStateIconVariants.checkmark,
 	copiedStateBGStyleVariant: CopiedStateBGStyleVariants.green,

--- a/src/components/buttons/_private/ButtonBase/ButtonBase.tsx
+++ b/src/components/buttons/_private/ButtonBase/ButtonBase.tsx
@@ -95,7 +95,7 @@ export class ButtonBase extends React.Component<IButtonBaseProps> {
 		padding: ButtonPropPadding.m,
 		tag: 'button',
 		fontWeight: ButtonPropFontWeight.heavy,
-		textTransform: ButtonPropTextTransform.upper,
+		textTransform: ButtonPropTextTransform.none,
 		textDecoration: ButtonPropTextDecoration.none,
 		letterSpacing: ButtonLetterSpacing.tracked,
 	};

--- a/src/components/inputs/Switch/Switch.scss
+++ b/src/components/inputs/Switch/Switch.scss
@@ -18,7 +18,6 @@
 		font-size: 11px;
 		color: $gray25;
 		@include tracking(20);
-		text-transform: uppercase;
 		margin: 0 5px 0 0;
 	}
 

--- a/src/components/inputs/Switch/Switch.scss
+++ b/src/components/inputs/Switch/Switch.scss
@@ -82,7 +82,7 @@
 		}
 
 		&::after {
-			content: "OFF";
+			content: "Off";
 			display: block;
 			position: absolute;
 			top: 0;
@@ -106,7 +106,7 @@
 		}
 
 		&[aria-pressed="true"]::after {
-			content: "ON";
+			content: "On";
 			left: 1em;
 			color: $white;
 		}

--- a/src/components/layout/AdvancedToggle/AdvancedToggle.sass
+++ b/src/components/layout/AdvancedToggle/AdvancedToggle.sass
@@ -30,7 +30,6 @@
 		line-height: 34px
 		font-size: 14px
 		font-weight: 700
-		text-transform: uppercase
 		@include tracking(20)
 		color: $gray25
 

--- a/src/components/layout/AdvancedToggle/AdvancedToggle.tsx
+++ b/src/components/layout/AdvancedToggle/AdvancedToggle.tsx
@@ -14,7 +14,7 @@ interface IState {
 
 export default class AdvancedToggle extends React.Component<IProps, IState> {
 	static defaultProps: Partial<IProps> = {
-		headingText: 'Advanced Options',
+		headingText: 'Advanced options',
 	};
 
 	constructor (props: IProps) {

--- a/src/components/loaders/DownloaderItem/DownloaderItem.tsx
+++ b/src/components/loaders/DownloaderItem/DownloaderItem.tsx
@@ -25,7 +25,7 @@ interface IProps extends IReactComponentProps {
 
 export default class DownloaderItem extends React.Component<IProps> {
 	static defaultProps: Partial<IProps> = {
-		cancelText: 'Cancel Download',
+		cancelText: 'Cancel download',
 		showEllipsis: true,
 	};
 

--- a/src/components/menus/TabNav/TabNav.sass
+++ b/src/components/menus/TabNav/TabNav.sass
@@ -20,7 +20,6 @@
 			font-weight: 700
 			color: $gray25
 			text-decoration: none
-			text-transform: uppercase
 			border-bottom: 4px solid transparent
 			transition: .1s color ease 0s, .1s border-bottom-color ease 0s
 

--- a/src/components/modules/Markdown/Markdown.sass
+++ b/src/components/modules/Markdown/Markdown.sass
@@ -81,7 +81,6 @@
 
 		thead
 			tr
-				text-transform: uppercase
 				font-weight: 700
 				letter-spacing: 0.02em
 				@include theme-background-gray15-else-gray

--- a/src/components/modules/VirtualTable/VirtualTable.tsx
+++ b/src/components/modules/VirtualTable/VirtualTable.tsx
@@ -106,7 +106,7 @@ export interface IVirtualTableState {
 
 export class VirtualTable extends React.Component<IVirtualTableProps, IVirtualTableState> {
 	static defaultProps: Partial<IVirtualTableProps> = {
-		headersCapitalize: 'upper',
+		headersCapitalize: 'none',
 		headersWeight: 700,
 		rowHeightSize: 'l',
 		rowHeaderHeightSize: 'auto',

--- a/src/components/overlays/FlyTooltip/FlyTooltip.scss
+++ b/src/components/overlays/FlyTooltip/FlyTooltip.scss
@@ -264,7 +264,6 @@
 
 	a {
 		font-weight: 700;
-		text-transform: uppercase;
 		@include tracking(20);
 	}
 

--- a/src/components/tables/TableList/TableList.sass
+++ b/src/components/tables/TableList/TableList.sass
@@ -14,7 +14,6 @@
 			background: none !important
 
 	.TableListRowHeader
-		text-transform: uppercase
 		font-weight: 700
 		@include tracking(20)
 		@include theme-background-gray15-else-graydark50

--- a/src/styles/components/SettingsSidebar.scss
+++ b/src/styles/components/SettingsSidebar.scss
@@ -20,7 +20,6 @@
 			text-decoration: none;
 			margin: 0 -20px;
 			padding: 0 17px;
-			text-transform: uppercase;
 			font-weight: 700;
 			color: $gray75;
 			@include tracking(40);

--- a/src/styles/components/TabNav.scss
+++ b/src/styles/components/TabNav.scss
@@ -22,7 +22,6 @@
 			font-weight: 700;
 			color: $gray25;
 			text-decoration: none;
-			text-transform: uppercase;
 			padding: 6px 10px 14px;
 			transition: .1s color ease 0s, .1s border-bottom-color ease 0s;
 			border-bottom: 4px solid transparent;

--- a/src/styles/components/Tag.scss
+++ b/src/styles/components/Tag.scss
@@ -5,7 +5,6 @@
 		border-radius: 4px;
 		display: inline-block;
 		padding: 6px 12px;
-		text-transform: uppercase;
 		line-height: 1;
 		white-space: nowrap;
 		color: $white;

--- a/src/styles/containers/SiteInfo.scss
+++ b/src/styles/containers/SiteInfo.scss
@@ -139,7 +139,6 @@
 			line-height: 20px;
 			margin-left: 10px;
 			font-weight: 700;
-			text-transform: uppercase;
 			font-size: 11px;
 			margin-top: 1px;
 			min-width: 100px;

--- a/src/styles/forms.scss
+++ b/src/styles/forms.scss
@@ -136,7 +136,6 @@
 			text-align: left;
 			@include theme-color-gray-else-gray25;
 			@include theme-background-gray15-else-graydark50;
-			text-transform: uppercase;
 			@include tracking(5);
 			font-weight: 700;
 			padding: 0 20px;
@@ -234,7 +233,6 @@
 			height: 57px;
 			line-height: 57px;
 			text-align: center;
-			text-transform: uppercase;
 			font-weight: bold;
 
 			svg {


### PR DESCRIPTION
This pr removes hard-coded uppercase styles in Local Components and defaults components with optional text-transforms to `none` where applicable (usually the default would be `upper`).