### PR TITLE
feat(LOC-3183): update global anchor styles for accessibility

### DIFF
--- a/src/styles/text.scss
+++ b/src/styles/text.scss
@@ -38,11 +38,12 @@
 	}
 
 	a {
-		color: $green;
+		@include __theme-color($green-dark, $green);
 		text-decoration: none;
 
 		&:hover {
-			color: $green-dark;
+			text-decoration: underline;
+			@include __theme-color($green, $green-dark50);
 		}
 	}
 }


### PR DESCRIPTION
This PR adjusts the global styles for anchor tags - in some places we have just raw HTML that renders (for example, the add-on descriptions or credits page). The only styles those can use are global styles, no React components. This PR brings the global styles in line with other efforts (accessible colors and unerline on hover by default).