### PR TITLE
feat: update colors - mostly grays - for contrast compliance

### DIFF
--- a/src/components/buttons/CopyButton/CopyButton.scss
+++ b/src/components/buttons/CopyButton/CopyButton.scss
@@ -52,9 +52,9 @@
 .CopyButton__Color_Gray {
 	@include setThemeVar('--Button_Background', $gray5, none);
 	@include setThemeVar('--Button_Background_Hover', $gray15, none);
-	@include setThemeVar('--Button_Text_Color', $gray-dark50, $gray25);
+	@include setThemeVar('--Button_Text_Color', $gray-dark50, $gray15);
 	@include setThemeVar('--Button_Text_Color_Hover', $gray-dark50, $white);
-	@include setThemeVar('--Button_Border', none, 1px solid $gray25);
+	@include setThemeVar('--Button_Border', none, 1px solid $gray15);
 	@include setThemeVar('--Button_Border_Hover', none, 1px solid $white);
 }
 
@@ -98,8 +98,8 @@
 }
 
 .CopyButton__Text_Gray {
-	@include setThemeVar('--Button_Text_Color', $gray-dark50, $gray25);
-	@include setThemeVar('--Button_Text_Color_Hover', $gray-dark50, $gray25);
+	@include setThemeVar('--Button_Text_Color', $gray-dark50, $gray15);
+	@include setThemeVar('--Button_Text_Color_Hover', $gray-dark50, $gray15);
 }
 
 .CopyButton__Text {

--- a/src/components/buttons/_private/ButtonBase/ButtonBase.scss
+++ b/src/components/buttons/_private/ButtonBase/ButtonBase.scss
@@ -2,12 +2,11 @@
 @import '../../../../common/styles/themeUtils';
 
 $disabled-background-light: $gray25;
-$disabled-background-light-alt-soft: $gray5;
 $disabled-background-dark: $gray25;
-$disabled-background-dark-alt-hard: $gray-dark50;
-$disabled-text-light: $gray75;
-$disabled-text-light-alt-soft: $gray25;
-$disabled-text-dark: $gray75;
+$disabled-text-light: $gray25;
+$disabled-text-light-alt-hard: $gray75;
+$disabled-text-dark: $gray;
+$disabled-text-dark-alt-hard: $gray75;
 
 .ButtonBase {
 	// base styles
@@ -144,8 +143,8 @@ $disabled-text-dark: $gray75;
 
 	&[disabled] {
 		@include setThemeVar('--Button_Background', $disabled-background-light, $disabled-background-dark);
-		@include setThemeVar('--Button_TextColor', $disabled-text-light, $disabled-text-dark);
-		@include setThemeVar('--Button_SvgPathFillColor', $disabled-text-light, $disabled-text-dark);
+		@include setThemeVar('--Button_TextColor', $disabled-text-light-alt-hard, $disabled-text-dark-alt-hard);
+		@include setThemeVar('--Button_SvgPathFillColor', $disabled-text-light-alt-hard, $disabled-text-dark-alt-hard);
 	}
 }
 
@@ -170,7 +169,8 @@ $disabled-text-dark: $gray75;
 
 	&[disabled] {
 		@include setThemeVar('--Button_Background', $disabled-background-light, $disabled-background-dark);
-		@include setThemeVar('--Button_TextColor', $disabled-text-light, $disabled-text-dark);
+		@include setThemeVar('--Button_TextColor', $disabled-text-light-alt-hard, $disabled-text-dark-alt-hard);
+		@include setThemeVar('--Button_SvgPathFillColor', $disabled-text-light-alt-hard, $disabled-text-dark-alt-hard);
 	}
 }
 
@@ -197,9 +197,9 @@ $disabled-text-dark: $gray75;
 
 	&[disabled] {
 		@include setThemeVar('--Button_Background', transparent);
-		@include setThemeVar('--Button_SvgPathFillColor', $gray25, $gray75);
-		@include setThemeVar('--Button_BorderColor', $gray25, $gray75);
-		@include setThemeVar('--Button_TextColor', $gray25, $gray75);
+		@include setThemeVar('--Button_SvgPathFillColor', $disabled-text-light, $disabled-text-dark);
+		@include setThemeVar('--Button_BorderColor', $disabled-text-light, $disabled-text-dark);
+		@include setThemeVar('--Button_TextColor', $disabled-text-light, $disabled-text-dark);
 	}
 }
 
@@ -220,8 +220,8 @@ $disabled-text-dark: $gray75;
 	}
 
 	&[disabled] {
-		@include setThemeVar('--Button_SvgPathFillColor', $gray25, $gray75);
-		@include setThemeVar('--Button_TextColor', $gray25, $gray75);
+		@include setThemeVar('--Button_SvgPathFillColor', $disabled-text-light, $disabled-text-dark);
+		@include setThemeVar('--Button_TextColor', $disabled-text-light, $disabled-text-dark);
 	}
 }
 

--- a/src/components/inputs/FlyDropdown/FlyDropdown.scss
+++ b/src/components/inputs/FlyDropdown/FlyDropdown.scss
@@ -10,7 +10,7 @@
 		padding: 6px 4px 11px;
 
 		button {
-			color: $gray25;
+			@include theme-color-gray-else-gray25
 		}
 
 		&.FlyDropdown__NavItemActive {
@@ -40,7 +40,7 @@
 	&:global(.Popper__Showing) {
 		.FlyDropdown_Caret {
 			height: 2px;
-			background: $gray25;
+			@include __theme-background($gray, $gray25);
 			margin-top: -2px;
 
 			* {

--- a/src/components/inputs/InputPasswordToggle/InputPasswordToggle.scss
+++ b/src/components/inputs/InputPasswordToggle/InputPasswordToggle.scss
@@ -20,7 +20,7 @@
             }
 
             &:hover svg path {
-                fill: $gray75;
+                @include __theme-fill($gray, $gray25);
             }
         }
     }
@@ -48,7 +48,7 @@
             height: $height;
 
             path {
-                fill: $gray25;
+                @include __theme-fill($gray, $gray25);
                 transition: fill .1s ease 0ms;
             }
         }

--- a/src/components/inputs/Switch/Switch.scss
+++ b/src/components/inputs/Switch/Switch.scss
@@ -16,7 +16,7 @@
 		display: inline-block;
 		font-weight: 700;
 		font-size: 11px;
-		color: $gray25;
+		@include theme-color-gray-else-gray15;
 		@include tracking(20);
 		margin: 0 5px 0 0;
 	}
@@ -76,7 +76,7 @@
 			transition: left 200ms ease 0ms;
 			border-radius: 50%;
 			box-shadow: 0 2px 0 $gray75;
-			@include theme-background-white-else-gray25;
+			@include __theme-background($white, $gray15);
 			width: 2.2em;
 			height: 2.2em;
 		}
@@ -89,7 +89,7 @@
 			left: 2.6em;
 			transition: left 200ms ease 0ms;
 			line-height: 2.4;
-			@include theme-color-white-else-gray25;
+			@include __theme-color($white, $gray15);
 			font-size: 1.4em;
 			font-weight: 700;
 		}

--- a/src/components/layout/AdvancedToggle/AdvancedToggle.sass
+++ b/src/components/layout/AdvancedToggle/AdvancedToggle.sass
@@ -31,7 +31,7 @@
 		font-size: 14px
 		font-weight: 700
 		@include tracking(20)
-		color: $gray25
+		@include theme-color-gray-else-gray25
 
 		&:before,
 		&:after
@@ -59,4 +59,4 @@
 				transform: rotate(180deg)
 
 			path
-				fill: $gray25
+				@include __theme-fill($gray, $gray25)

--- a/src/components/loaders/Spinner/Spinner.sass
+++ b/src/components/loaders/Spinner/Spinner.sass
@@ -2,6 +2,7 @@
 
 .SpinnerContainer
 	font-weight: 300
+	@include theme-color-gray75-else-gray25
 	color: $gray75
 	letter-spacing: 0
 	text-transform: none

--- a/src/components/menus/ContextMenu/ContextMenu.scss
+++ b/src/components/menus/ContextMenu/ContextMenu.scss
@@ -11,7 +11,7 @@
 		padding: 6px 4px 11px;
 
 		button {
-			color: $gray25;
+			@include theme-color-gray-else-gray25;
 		}
 	}
 

--- a/src/components/menus/TabNav/TabNav.sass
+++ b/src/components/menus/TabNav/TabNav.sass
@@ -18,7 +18,7 @@
 			padding: 6px 10px 14px
 			@include tracking(40)
 			font-weight: 700
-			color: $gray25
+			@include theme-color-gray-else-gray25
 			text-decoration: none
 			border-bottom: 4px solid transparent
 			transition: .1s color ease 0s, .1s border-bottom-color ease 0s

--- a/src/components/menus/TertiaryNav/TertiaryNav.scss
+++ b/src/components/menus/TertiaryNav/TertiaryNav.scss
@@ -38,7 +38,7 @@
 			line-height: 36px;
 			padding: 1px 20px 0;
 			border-radius: 4px;
-			@include theme-color-gray-else-gray15;
+			@include theme-color-gray-else-gray25;
 			font-weight: 500;
 			font-size: 14px;
 			@include tracking(40);

--- a/src/components/menus/TertiaryNav/TertiaryNav.scss
+++ b/src/components/menus/TertiaryNav/TertiaryNav.scss
@@ -42,6 +42,10 @@
 			font-weight: 500;
 			font-size: 14px;
 			@include tracking(40);
+			
+			&:hover {
+				@include theme-color-graydark-else-white;
+			}
 		}
 
 		a.TertiaryNavItem__Active {

--- a/src/components/menus/TertiaryNav/TertiaryNav.scss
+++ b/src/components/menus/TertiaryNav/TertiaryNav.scss
@@ -9,7 +9,7 @@
 
 	// needs to be global so any element, outside this library, can use it
 	:global(.TertiaryNavChild__Error) {
-		color: $red;
+		@include theme-color-red-dark50-else-red;
 	}
 
 	// reset unordered lists
@@ -38,7 +38,7 @@
 			line-height: 36px;
 			padding: 1px 20px 0;
 			border-radius: 4px;
-			color: $gray75;
+			@include theme-color-gray-else-gray15;
 			font-weight: 500;
 			font-size: 14px;
 			@include tracking(40);
@@ -59,7 +59,7 @@
 		}
 
 		&.TertiaryNavItem__Error a {
-			color: $red;
+			@include __theme-color($red-darker, $white);
 			padding-left: 34px;
 		}
 
@@ -72,7 +72,7 @@
 			height: 100%;
 			-webkit-mask: url(../../../svg/warning.svg) no-repeat 50% 50%;
 			mask: url(../../../svg/warning.svg) no-repeat 50% 50%;
-			background-color: $red;
+			@include __theme-background($red-darker, $red);
 		}
 	}
 

--- a/src/components/modules/Card/Card.sass
+++ b/src/components/modules/Card/Card.sass
@@ -41,13 +41,13 @@
 
 	.Card_Content_Sub
 		margin-bottom: 10px
-		color: $gray75
+		@include theme-color-gray-else-gray25
 
 		&:last-child
 			margin-bottom: 0
 
 	.Card_Content_Description
-		@include theme-color-gray-else-gray75
+		@include theme-color-gray-else-gray25
 		font-weight: 300
 
 	.Card_Footer

--- a/src/components/modules/EmptyArea/EmptyArea.sass
+++ b/src/components/modules/EmptyArea/EmptyArea.sass
@@ -10,14 +10,14 @@
 	justify-content: center
 	margin: 50px
 	flex-grow: 1
-	@include theme-color-gray25-else-white
+	@include theme-color-gray75-else-gray25
 
 	@at-root .VerticalNav + .EmptyArea
 		margin: 0
 
 		@include if-theme-dark()
 			background: $gray-dark-alt
-			@include theme-color-gray25-else-gray75
+			@include theme-color-gray75-else-gray25
 
 	.Title
 		line-height: 140%
@@ -30,7 +30,7 @@
 
 	> svg
 		width: 50px
-		fill: $gray25
+		@include theme-fill-gray75-else-gray25
 		margin: 0 auto -20px
 
 		&:global(.MultipleSitesSelected)

--- a/src/components/modules/Markdown/Markdown.sass
+++ b/src/components/modules/Markdown/Markdown.sass
@@ -103,7 +103,7 @@
 		padding-left: 10px + $lineWidth
 
 		> p
-			@include theme-color-gray75-else-gray25
+			@include theme-color-gray-else-gray25
 
 		> blockquote
 			margin-left: 20px

--- a/src/components/text/Text/Text.tsx
+++ b/src/components/text/Text/Text.tsx
@@ -35,7 +35,7 @@ export const Text = (props: IProps) => {
 				'Text',
 				className,
 			)}
-			color={size === TextPropSize.default ? TextBasePropColor.graydark_gray15_text : TextBasePropColor.gray_gray75_title}
+			color={size === TextPropSize.default ? TextBasePropColor.graydark_gray15_text : TextBasePropColor.gray_gray25_title}
 			fontSize={TextBasePropFontSize.s}
 			fontWeight={TextBasePropFontWeight.normal}
 			id={id}

--- a/src/components/text/Title/Title.tsx
+++ b/src/components/text/Title/Title.tsx
@@ -73,7 +73,7 @@ function setSizeProp (props: IProps, defaultValue: TextBasePropFontSize): TextBa
 function setColorProp (props: IProps, defaultColor: TextBasePropColor): TextBasePropColor {
 	switch (props.size) {
 		case TitlePropSize.caption:
-			return TextBasePropColor.gray_gray75_title;
+			return TextBasePropColor.gray_gray25_title;
 	}
 
 	return defaultColor;

--- a/src/components/text/_private/TextBase/TextBase.scss
+++ b/src/components/text/_private/TextBase/TextBase.scss
@@ -12,8 +12,8 @@
 	color: var(--TextBase_TextColor);
 }
 
-.TextBase__Color_Gray_Gray75 {
-	@include setThemeVar('--TextBase_TextColor', $gray, $gray75);
+.TextBase__Color_Gray_Gray25 {
+	@include setThemeVar('--TextBase_TextColor', $gray, $gray25);
 }
 
 .TextBase__Color_GrayDark_Gray15 {

--- a/src/components/text/_private/TextBase/TextBase.tsx
+++ b/src/components/text/_private/TextBase/TextBase.tsx
@@ -5,7 +5,7 @@ import ILocalContainerProps from '../../../../common/structures/ILocalContainerP
 import { Container } from '../../../modules/Container/Container';
 
 export enum TextBasePropColor {
-	gray_gray75_title = 'gray_gray75_title',
+	gray_gray25_title = 'gray_gray25_title',
 	gray25_text = 'gray25_text',
 	graydark_gray15_text = 'graydark_gray15_text',
 	graydark_white_caption = 'graydark_white_caption',
@@ -68,7 +68,7 @@ export class TextBase extends React.Component<ITextBaseProps> {
 						'TextBase',
 						className,
 						{
-							[styles.TextBase__Color_Gray_Gray75]: color === TextBasePropColor.gray_gray75_title,
+							[styles.TextBase__Color_Gray_Gray25]: color === TextBasePropColor.gray_gray25_title,
 							[styles.TextBase__Color_GrayDark_Gray15]: color === TextBasePropColor.graydark_gray15_text,
 							[styles.TextBase__Color_Gray25]: color === TextBasePropColor.gray25_text,
 							[styles.TextBase__Color_GrayDark_White]: color === TextBasePropColor.graydark_white_caption,

--- a/src/styles/_partials/_theme.scss
+++ b/src/styles/_partials/_theme.scss
@@ -286,6 +286,10 @@
 	@include __theme-fill($gray25, $gray75);
 }
 
+@mixin theme-fill-gray75-else-gray25 {
+	@include __theme-fill($gray75, $gray25)
+}
+
 @mixin theme-fill-graydark-else-gray25 {
 	@include __theme-fill($gray-dark, $gray25);
 }

--- a/src/styles/_partials/_variables.scss
+++ b/src/styles/_partials/_variables.scss
@@ -30,6 +30,7 @@ $blue25: #d6eef2;
 $blue5: #8fd6e3;
 
 $red: #ef4e65;
+$red-darker: #933140;
 $red-dark: #8c2738;
 $red-dark50: #ba3e51;
 $red75: #f18085;

--- a/src/styles/components/SettingsSidebar.scss
+++ b/src/styles/components/SettingsSidebar.scss
@@ -21,7 +21,7 @@
 			margin: 0 -20px;
 			padding: 0 17px;
 			font-weight: 700;
-			color: $gray75;
+			@include theme-color-gray-else-gray15;
 			@include tracking(40);
 			display: flex;
 			position: relative;

--- a/src/styles/components/TabNav.scss
+++ b/src/styles/components/TabNav.scss
@@ -20,7 +20,7 @@
 		a {
 			@include tracking(40);
 			font-weight: 700;
-			color: $gray25;
+			@include theme-color-gray-else-gray25;
 			text-decoration: none;
 			padding: 6px 10px 14px;
 			transition: .1s color ease 0s, .1s border-bottom-color ease 0s;

--- a/src/styles/containers/SiteInfo.scss
+++ b/src/styles/containers/SiteInfo.scss
@@ -71,7 +71,7 @@
 			}
 
 			p {
-				@include theme-color-gray75-else-gray25;
+				@include theme-color-gray-else-gray25;
 				margin: 5px 0 0;
 				line-height: 1.25;
 

--- a/src/styles/forms.scss
+++ b/src/styles/forms.scss
@@ -140,7 +140,7 @@
 
 			a {
 				margin-left: auto;
-				@include theme-color-gray75-else-gray25;
+				@include theme-color-gray-else-gray25;
 				display: flex;
 				align-items: center;
 


### PR DESCRIPTION
This PR searches for `$gray25` and `$gray75` text in the app and in most cases replaces it with `gray` in light mode. I also made some small tweaks to other components to pass accessibility standards. In some cases I lightened the gray color used in dark mode as well. 