### PR TITLE
fix: fix tooltip trigger on click

### DIFF
--- a/src/common/helpers/useDetectClickOrHoverWithinTargets.ts
+++ b/src/common/helpers/useDetectClickOrHoverWithinTargets.ts
@@ -3,11 +3,13 @@ import { useEffect, useState } from 'react';
 export const useDetectClickOrHoverWithinTargets = ({
 	targetEl, 
 	alwaysBlurOnClick, 
-	useClickInsteadOfHover
+	useClickInsteadOfHover,
+	ignoreClickOn,
 }: { 
 	targetEl: HTMLElement | null, 
 	alwaysBlurOnClick: boolean, 
-	useClickInsteadOfHover: boolean 
+	useClickInsteadOfHover: boolean,
+	ignoreClickOn?: HTMLElement | null,
 }) => {
 	const [isClickFocus, setIsClickFocus] = useState(false);
 	const [isHover, setIsHover] = useState(false);
@@ -32,11 +34,12 @@ export const useDetectClickOrHoverWithinTargets = ({
 					if (!targetEl || targetEl.contains(event.target)) {
 						return;
 					}
-
-					document.removeEventListener('click', listener);
-					document.removeEventListener('touchend', listener);
-
-					setIsClickFocus(false);
+	
+					if (!ignoreClickOn || !ignoreClickOn.contains(event.target)) {
+						document.removeEventListener('click', listener);
+						document.removeEventListener('touchend', listener);
+						setIsClickFocus(false);
+					}
 				};
 
 				const onClick = () => {
@@ -66,7 +69,7 @@ export const useDetectClickOrHoverWithinTargets = ({
 				};
 			}
 		},
-		[targetEl, alwaysBlurOnClick, useClickInsteadOfHover],
+		[targetEl, alwaysBlurOnClick, useClickInsteadOfHover, ignoreClickOn],
 	);
 
 	return useClickInsteadOfHover ? isClickFocus : isHover;

--- a/src/components/overlays/Tooltip/Tooltip.tsx
+++ b/src/components/overlays/Tooltip/Tooltip.tsx
@@ -253,7 +253,7 @@ const useTooltip = ({
 	const [ triggerElement, setReferenceElement ] = useState<HTMLElement | null>(null);
 	const [ popperElement, setPopperElement ] = useState<HTMLElement | null>(null);
 	const [ transitionElement, setTransitionElement ] = useState<HTMLElement | null>(null);
-	const isHoverTarget = useDetectClickOrHoverWithinTargets({targetEl: triggerElement, alwaysBlurOnClick: true, useClickInsteadOfHover})
+	const isHoverTarget = useDetectClickOrHoverWithinTargets({targetEl: triggerElement, alwaysBlurOnClick: true, useClickInsteadOfHover, ignoreClickOn: popperElement})
 	const isHoverPopper= useDetectClickOrHoverWithinTargets({targetEl: popperElement, alwaysBlurOnClick: false, useClickInsteadOfHover}) // pass nulls to bypass otherwise this will conflict with other click detects (above)
 
 	const isTransitionEnd = useDetectTransitionEnd(transitionElement, transitionEndPropName);


### PR DESCRIPTION
This PR fixes a bug where clicking the trigger element for a click-trigger tooltip opens the tooltip, but clicking inside the tooltip and clicking the trigger again doesn't close it until the second click. 

The tooltip component uses a custom function to set up hooks for the trigger and popper elements to determine whether to close or open the popper: `useDetectClickOrHoverWithinTargets`. When `useClickInsteadOfHover` is `true`, there are extra listeners and handlers to determine when to to close the popper using a state variable called `isClickFocus`.

6 months ago I consolidated the two separate functions into just this one, and introduced a bug where clicking the open popper messes up the state for `isClickFocus` for the trigger element. This PR adds another optional argument to the function called `ignoreClickOn`, where an element can be passed on which clicks will be ignored when setting that state and removing event listeners. 