### PR TITLE
feat: TextButtonExternal and further tweaks

### DIFF
--- a/src/components/buttons/TextButtonExternal/TextButtonExternal.stories.mdx
+++ b/src/components/buttons/TextButtonExternal/TextButtonExternal.stories.mdx
@@ -25,7 +25,7 @@ Setting the `underline` prop to true means the link will always be underlined. T
 	</Story>
 </Canvas>
 
-Finally, to fully remove the underline, explicity set the `unerline` prop to `false`
+Finally, to fully remove the underline, explicity set the `underline` prop to `false`
 
 <Canvas>
 	<Story name="No underline">

--- a/src/components/buttons/TextButtonExternal/TextButtonExternal.stories.mdx
+++ b/src/components/buttons/TextButtonExternal/TextButtonExternal.stories.mdx
@@ -17,7 +17,11 @@ Setting the `underline` prop to true means the link will always be underlined. T
 
 <Canvas>
 	<Story name="Underlined and Heavy">
-		<TextButtonExternal href="javascript:;" underline heavy>I'm a heavy undelrined link</TextButtonExternal>!
+		<p>
+			Here is some text with an&nbsp;
+		<TextButtonExternal href="javascript:;" underline heavy>inline heavy underlined link</TextButtonExternal>
+		!
+		</p>
 	</Story>
 </Canvas>
 

--- a/src/components/buttons/TextButtonExternal/TextButtonExternal.stories.mdx
+++ b/src/components/buttons/TextButtonExternal/TextButtonExternal.stories.mdx
@@ -1,0 +1,31 @@
+import { Meta, Story, Canvas } from "@storybook/addon-docs/blocks";
+import TextButtonExternal from "./TextButtonExternal"
+
+<Meta title="Buttons/TextButtonExternal" component={TextButtonExternal} />
+
+# Examples
+
+The default underline behavior of TextButtonExternal is to underline on hover. This is adequate for links that stand alone in a design, outside of the context of any other text.
+
+<Canvas>
+	<Story name="Default">
+        <TextButtonExternal href="javascript:;">I'm a default TextButtonExternal</TextButtonExternal>
+	</Story>
+</Canvas>
+
+Setting the `underline` prop to true means the link will always be underlined. This is suitable for links that exist in the context of surrounding text.
+
+<Canvas>
+	<Story name="Underlined and Heavy">
+		<TextButtonExternal href="javascript:;" underline heavy>I'm a heavy undelrined link</TextButtonExternal>!
+	</Story>
+</Canvas>
+
+Finally, to fully remove the underline, explicity set the `unerline` prop to `false`
+
+<Canvas>
+	<Story name="No underline">
+        <TextButtonExternal href="javascript:;" underline={false}>I'm a default TextButtonExternal</TextButtonExternal>
+	</Story>
+</Canvas>
+

--- a/src/components/buttons/TextButtonExternal/TextButtonExternal.tsx
+++ b/src/components/buttons/TextButtonExternal/TextButtonExternal.tsx
@@ -4,7 +4,6 @@ import { IButtonBaseProps } from '../_private/ButtonBase/ButtonBase';
 
 interface TextButtonExternalProps extends ITextButtonProps {
 	href?: string;
-	// trackKey?: TrackIdElementKeyType;
 	/** Undefined deafults to underlineOnHover, to stop all underlines, set explicitly to false */
 	underline?: boolean;
 	heavy?: boolean;

--- a/src/components/buttons/TextButtonExternal/TextButtonExternal.tsx
+++ b/src/components/buttons/TextButtonExternal/TextButtonExternal.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { TextButton, ITextButtonProps } from '../TextButton/TextButton';
+import { IButtonBaseProps } from '../_private/ButtonBase/ButtonBase';
+
+interface TextButtonExternalProps extends ITextButtonProps {
+	href?: string;
+	// trackKey?: TrackIdElementKeyType;
+	/** Undefined deafults to underlineOnHover, to stop all underlines, set explicitly to false */
+	underline?: boolean;
+	heavy?: boolean;
+	padding?: IButtonBaseProps['padding'];
+}
+
+const TextButtonExternal = (props: TextButtonExternalProps) => {
+	const {
+		children,
+		href,
+		onClick,
+		privateOptions,
+		underline,
+		heavy = false,
+		padding = 'none',
+		...otherProps
+	} = props;
+
+	return (
+		<TextButton
+			tag="a"
+			tagProps={{ href }}
+			privateOptions={{
+				// eslint-disable-next-line no-nested-ternary
+				textDecoration: underline ? 'underline'
+					: underline === false ? 'none' : 'underlineOnHover',
+				fontWeight: heavy ? 'heavy' : 'medium',
+				padding,
+				...privateOptions,
+			}}
+			onClick={onClick}
+			{...otherProps}
+		>
+			{children}
+		</TextButton>
+	);
+};
+
+export default TextButtonExternal;

--- a/src/components/buttons/TextButtonExternal/TextButtonExternal.tsx
+++ b/src/components/buttons/TextButtonExternal/TextButtonExternal.tsx
@@ -25,6 +25,7 @@ const TextButtonExternal = (props: TextButtonExternalProps) => {
 
 	return (
 		<TextButton
+			inline
 			tag="a"
 			tagProps={{ href }}
 			privateOptions={{

--- a/src/components/overlays/Tooltip/Tooltip.tsx
+++ b/src/components/overlays/Tooltip/Tooltip.tsx
@@ -328,7 +328,7 @@ export const Tooltip = (props: TooltipProps) => {
 
 	const popperRefCallback = (element: HTMLDivElement) => {
 		setPopperRef(element);
-		if (element) {
+		if (element && stages.isStage2FadingInToShow) {
 			element.focus();
 		}
 	};

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ export { Button } from './components/buttons/Button/Button';
 export { default as Close } from './components/buttons/Close/Close';
 export { PrimaryButton } from './components/buttons/PrimaryButton/PrimaryButton';
 export { TextButton, ITextButtonProps } from './components/buttons/TextButton/TextButton';
+export { default as TextButtonExternal } from './components/buttons/TextButtonExternal/TextButtonExternal';
 export { CopyButton } from './components/buttons/CopyButton/CopyButton';
 export { RefreshButton } from './components/buttons/RefreshButton/RefreshButton';
 // Inputs

--- a/src/styles/util.scss
+++ b/src/styles/util.scss
@@ -92,6 +92,11 @@
 		color: $gray25;
 	}
 
+	.__Site__Label {
+		@include theme-color-gray-else-gray15;
+		font-weight: 700;
+	}
+
 	.__NoAnimation {
 		animation: none !important;
 	}


### PR DESCRIPTION
This PR moves TextButtonExternal from Local core to Local Components. 

It also creates a utility class for site labels, which in Local Core were often just using `__Color__Green`, which conflicted with the updated styles.

Finally, I made a tweak to the tooltip `focus()` mechanism, so that it only focuses once when showing. Before, we were focusing it on every change to the popper element, which was pulling focus away from inputs in modals that were popped by the `ContextMenu` component.