### PR TITLE
fix: make tooltip focusing optional via prop

### DIFF
--- a/src/components/menus/ContextMenu/ContextMenu.tsx
+++ b/src/components/menus/ContextMenu/ContextMenu.tsx
@@ -75,6 +75,7 @@ const ContextMenu = (props: IContextMenuProps) => {
                 onHide?.call(null);
                 setIsShowing(false);
             }}
+			focusOnOpen
             {...otherProps}
             content={content}
         >

--- a/src/components/overlays/Tooltip/Tooltip.tsx
+++ b/src/components/overlays/Tooltip/Tooltip.tsx
@@ -41,6 +41,8 @@ export interface TooltipProps extends IReactComponentProps {
 	onShow?: FunctionGeneric;
 	/** callback run when tooltip hides */
 	onHide?: FunctionGeneric;
+	/** focus the tooltip on opening, useful for dropdowns, contextmenus, etc */
+	focusOnOpen?: boolean;
 }
 
 // whether moving forward to the next stage or reverting back to a previous stage
@@ -303,6 +305,7 @@ export const Tooltip = (props: TooltipProps) => {
 		onHide,
 		onShow,
 		hideArrow,
+		focusOnOpen,
 	} = props;
 
 	const {
@@ -328,7 +331,7 @@ export const Tooltip = (props: TooltipProps) => {
 
 	const popperRefCallback = (element: HTMLDivElement) => {
 		setPopperRef(element);
-		if (element && stages.isStage2FadingInToShow) {
+		if (element && stages.isStage2FadingInToShow && focusOnOpen) {
 			element.focus();
 		}
 	};
@@ -446,4 +449,5 @@ Tooltip.defaultProps = {
 	position: 'top',
 	showDelay: 1000,
 	useClickInsteadOfHover: false,
+	focusOnOpen: false,
 } as Partial<TooltipProps>;


### PR DESCRIPTION
The previous update to Local Components included a change to focus tooltips on opening. This PR makes that optional and only adds it to the ContextMenu component, since focusing all tooltips can interfere with some input events. For example, if entering a new LiveLinks username/password, that can get interrupted by just hovering over a tooltip. This caused functional tests to fail and is also a bad UX. 