### PR TITLE
feat: update components per design review

### DIFF
--- a/src/components/buttons/_private/ButtonBase/ButtonBase.scss
+++ b/src/components/buttons/_private/ButtonBase/ButtonBase.scss
@@ -2,11 +2,11 @@
 @import '../../../../common/styles/themeUtils';
 
 $disabled-background-light: $gray25;
-$disabled-background-dark: $gray25;
+$disabled-background-dark: $gray75;
 $disabled-text-light: $gray25;
-$disabled-text-light-alt-hard: $gray75;
-$disabled-text-dark: $gray;
-$disabled-text-dark-alt-hard: $gray75;
+$disabled-text-light-fill: $gray75;
+$disabled-text-dark: $gray75;
+$disabled-text-dark-fill: $gray;
 
 .ButtonBase {
 	// base styles
@@ -97,6 +97,10 @@ $disabled-text-dark-alt-hard: $gray75;
 		&.ButtonBase_SVG_Right {
 			margin: 0 0 0 10px;
 		}
+
+		&.ButtonBase_SVG_MarginBottom {
+			margin-bottom: 1px;
+		}
 	}
 
 	&.ButtonBase__SVG_Fill svg {
@@ -144,8 +148,8 @@ $disabled-text-dark-alt-hard: $gray75;
 
 	&[disabled] {
 		@include setThemeVar('--Button_Background', $disabled-background-light, $disabled-background-dark);
-		@include setThemeVar('--Button_TextColor', $disabled-text-light-alt-hard, $disabled-text-dark-alt-hard);
-		@include setThemeVar('--Button_SvgPathFillColor', $disabled-text-light-alt-hard, $disabled-text-dark-alt-hard);
+		@include setThemeVar('--Button_TextColor', $disabled-text-light-fill, $disabled-text-dark-fill);
+		@include setThemeVar('--Button_SvgPathFillColor', $disabled-text-light-fill, $disabled-text-dark-fill);
 	}
 }
 
@@ -170,8 +174,8 @@ $disabled-text-dark-alt-hard: $gray75;
 
 	&[disabled] {
 		@include setThemeVar('--Button_Background', $disabled-background-light, $disabled-background-dark);
-		@include setThemeVar('--Button_TextColor', $disabled-text-light-alt-hard, $disabled-text-dark-alt-hard);
-		@include setThemeVar('--Button_SvgPathFillColor', $disabled-text-light-alt-hard, $disabled-text-dark-alt-hard);
+		@include setThemeVar('--Button_TextColor', $disabled-text-light-fill, $disabled-text-dark-fill);
+		@include setThemeVar('--Button_SvgPathFillColor', $disabled-text-light-fill, $disabled-text-dark-fill);
 	}
 }
 

--- a/src/components/buttons/_private/ButtonBase/ButtonBase.tsx
+++ b/src/components/buttons/_private/ButtonBase/ButtonBase.tsx
@@ -220,11 +220,15 @@ const ButtonBase = (props: IButtonBaseProps) => {
 				{...tagProps}
 			>
 				{leftIcon && (
-					<LeftIcon className={styles.ButtonBase_SVG_Left}/>
+					<LeftIcon className={classnames(styles.ButtonBase_SVG_Left, {
+						[styles.ButtonBase_SVG_MarginBottom]: !!children,
+					})}/>
 				)}
 				{children}
 				{rightIcon && (
-					<RightIcon className={styles.ButtonBase_SVG_Right}/>
+					<RightIcon className={classnames(styles.ButtonBase_SVG_Right, {
+						[styles.ButtonBase_SVG_MarginBottom]: !!children,
+					})}/>
 				)}
 			</Tag>
 		</Container>

--- a/src/components/menus/ContextMenu/ContextMenu.scss
+++ b/src/components/menus/ContextMenu/ContextMenu.scss
@@ -34,6 +34,10 @@
 	@include setThemeVar('--Button_IfFill__TextColor', $green-dark, $green);
 }
 
+.ContextMenu_Trigger_NoBG {
+	@include setThemeVar('--Button_SvgPathFillColor', $gray, $green);
+}
+
 .ContextMenu_Items {
 	left: auto;
 	border-radius: 4px;

--- a/src/components/menus/ContextMenu/ContextMenu.tsx
+++ b/src/components/menus/ContextMenu/ContextMenu.tsx
@@ -6,6 +6,7 @@ import { FunctionGeneric } from '../../../common/structures/Generics';
 import { Tooltip, TooltipProps } from '../../overlays/Tooltip/Tooltip';
 import { PrimaryButton } from '../../buttons/PrimaryButton/PrimaryButton';
 import { TextButton } from '../../buttons/TextButton/TextButton';
+import classNames from 'classnames';
 
 export interface IMenuItem {
     color?: 'red' | 'none';
@@ -24,10 +25,12 @@ export interface IContextMenuProps extends Omit<TooltipProps, 'content'> {
     classNameListItem?: string;
     /** array of menu items */
     items: IMenuItem[];
+	/** whether to have background behind 3 dots - set to false for low key 3 dot dropdowns */
+	noBG?: boolean;
 }
 
 const ContextMenu = (props: IContextMenuProps) => {
-    const { className, classNameList, classNameListItem, items, onShow, onHide, ...otherProps } = props;
+    const { className, classNameList, classNameListItem, items, onShow, onHide, noBG, ...otherProps } = props;
 
     const onClickItem = (event: React.MouseEvent<HTMLLIElement, MouseEvent>, item: IMenuItem) => {
         item.onClick?.call(null);
@@ -81,8 +84,11 @@ const ContextMenu = (props: IContextMenuProps) => {
             <PrimaryButton
                 aria-label="Open context menu"
                 active={isShowing}
-                className={styles.ContextMenu_Trigger}
-                privateOptions={{ style: { padding: '6px' } }}
+                className={classNames({
+					[styles.ContextMenu_Trigger]: !noBG,
+					[styles.ContextMenu_Trigger_NoBG]: noBG,
+				})}
+                privateOptions={{ style: { padding: '6px' }, form: noBG ? 'text' : 'fill' }}
             >
                 <DotsIcon />
             </PrimaryButton>

--- a/src/styles/containers/AddSitePage.scss
+++ b/src/styles/containers/AddSitePage.scss
@@ -84,7 +84,7 @@
 
 			.EnvironmentSpaceRequired { // needed for distributed Environments
 				margin: 30px 0 0;
-				color: $gray75;
+				@include theme-color-gray-else-gray75;
 				font-weight: 300;
 				text-align: center;
 			}


### PR DESCRIPTION
This PR updates the button colors and SVG margins per design feedback and the Local design system Figma doc.

It also adds a prop to ContextMenu to make the background option for a more lowkey dropdown menu.

Finally, we adjust a global style that was tageting the "Heads up" message when downloading a lightning service.