### PR TITLE
fix: add z-index to scrollshadow shadow div

### DIFF
--- a/src/components/buttons/Close/Close.tsx
+++ b/src/components/buttons/Close/Close.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import classnames from 'classnames';
 import IReactComponentProps from '../../../common/structures/IReactComponentProps';
-import CloseBigSVG from '../../../svg/close--big.svg';
 import * as styles from './Close.scss';
 import { FunctionGeneric } from '../../../common/structures/Generics';
 import { CloseIcon } from '../../icons/Icons';

--- a/src/components/overlays/ScrollShadow/ScrollShadow.scss
+++ b/src/components/overlays/ScrollShadow/ScrollShadow.scss
@@ -1,7 +1,6 @@
 @import '../../../styles/_partials/index';
 
-
-.ScrollableContent {
+.ScrollableContent_ScrollingDiv {
 	overflow: auto;
 	height: 100%;
 }
@@ -14,6 +13,7 @@
 	left: 0;
 	overflow: hidden;
 	pointer-events: none;
+	z-index: 100;
 
 	.ScrollShadow {
 		position: absolute;
@@ -23,7 +23,7 @@
 		height: 25px;
 		transform: translateY(100%);
 		transition: box-shadow 0.4s;
-		
+
 		&.ScrollShadow__Show {
 			@include theme-overlay-boxshadow;
 			transition: box-shadow 0.2s;

--- a/src/components/overlays/ScrollShadow/ScrollShadow.tsx
+++ b/src/components/overlays/ScrollShadow/ScrollShadow.tsx
@@ -1,6 +1,6 @@
-import IReactComponentProps from '../../../common/structures/IReactComponentProps';
 import classnames from 'classnames';
 import React, { useState, useEffect, useCallback } from 'react';
+import IReactComponentProps from '../../../common/structures/IReactComponentProps';
 import styles from './ScrollShadow.scss';
 import { FunctionGeneric } from '../../../common/structures/Generics';
 
@@ -11,14 +11,15 @@ interface IProps extends IReactComponentProps {
 }
 
 export const ScrollShadow = (props: IProps) => {
+	const { refCallback, shadowClassName, children, className, ...otherProps } = props;
+
 	const [scrollableContent, setScrollableContent] = useState<HTMLDivElement | null>(null);
 	const [showScrollShadow, setShowScrollShadow] = useState(false);
 
 	const canScroll = (el: Element) => el.scrollHeight > el.clientHeight;
 
 	const handleScroll = (e: any) => {
-		const hideShadow = !canScroll(e.target)
-			|| ((e.target.scrollHeight - e.target.scrollTop) === e.target.clientHeight);
+		const hideShadow = !canScroll(e.target) || e.target.scrollHeight - e.target.scrollTop === e.target.clientHeight;
 		setShowScrollShadow(!hideShadow);
 	};
 
@@ -43,30 +44,30 @@ export const ScrollShadow = (props: IProps) => {
 		};
 	}, [scrollableContent]);
 
-	const setScrollableContentRef = useCallback((element: HTMLDivElement | null) => {
-		setScrollableContent(element);
-		if (props.refCallback) props.refCallback(element);
-	}, [props.refCallback]);
+	const setScrollableContentRef = useCallback(
+		(element: HTMLDivElement | null) => {
+			setScrollableContent(element);
+			if (refCallback) refCallback(element);
+		},
+		[refCallback]
+	);
 
 	return (
 		<>
-			<div 
-				className={classnames(styles.ScrollableContent, props.className)} 
-				id={props.id}
-				style={props.style}
+			<div
+				className={classnames(styles.ScrollableContent_ScrollingDiv, className)}
+				{...otherProps}
 				ref={setScrollableContentRef}
 			>
-				{props.children}
+				{children}
 			</div>
-			<div className={classnames(styles.ScrollShadow__Container, props.shadowClassName)}>
+			<div className={classnames(styles.ScrollShadow__Container, shadowClassName)}>
 				<div
 					className={classnames(styles.ScrollShadow, {
 						[styles.ScrollShadow__Show]: showScrollShadow,
 					})}
 				/>
 			</div>
-
 		</>
-
 	);
 };


### PR DESCRIPTION
This PR adds a z-index to the scroll shadow's shadow div. Also linted the ScrollShadow component. 

I attempted to do a larger refactor because implementing the scrollshadow component is pretty complicated and requires a wrapping div with `position: relative; overflow: hidden` on it, and the children contents to be contained in a single wrapping div. 

I was going to pull those wrappers into the ScrollShadow component, but it was really messing with existing implementations, so I may just tackle that in the future. 