### PR TITLE
feat: update Stepper component and grow steps

### DIFF
--- a/src/components/inputs/RadioBlock/RadioBlock.sass
+++ b/src/components/inputs/RadioBlock/RadioBlock.sass
@@ -46,8 +46,9 @@ $zIndexOptionTooltip: $zIndexOptionSelected + 3
 	flex: 1
 
 	.RadioBlock_Label_Text
+		font-size: 18px
 		pointer-events: none
-		@include theme-color-gray-else-gray15;
+		@include theme-color-gray-else-gray15
 
 	&.RadioBlock_Option__BorderOnHover
 		&:hover:not(.RadioBlock_Option__Disabled) .RadioBlock_Wrapper::before
@@ -69,7 +70,7 @@ $zIndexOptionTooltip: $zIndexOptionSelected + 3
 		transition:  transform .2s ease 0s
 
 		.RadioBlock_Label_Text
-			@include theme-color-graydark-else-white;
+			@include theme-color-graydark-else-white
 
 		.RadioBlock_Wrapper
 			&::before
@@ -82,12 +83,12 @@ $zIndexOptionTooltip: $zIndexOptionSelected + 3
 
 	.RadioBlock_Content
 		display: block
-		height: 100%
-		width: 100%
 
 	.RadioBlock_Wrapper
+		display: flex
+		flex-direction: column
+		justify-content: center
 		cursor: pointer
-		display: block
 		top: 0
 		right: 0
 		bottom: 0

--- a/src/components/menus/Stepper/Stepper.sass
+++ b/src/components/menus/Stepper/Stepper.sass
@@ -19,13 +19,8 @@
 		height: 100%
 		@include theme-stripes-white-else-graydark
 
-	&.__Steps__2 .Step
-		width: calc(20px + 50%)
-
-	&.__Steps__3 .Step
-		width: calc(20px + 33.333333%)
-
 	.Step
+		flex-grow: 1
 		position: relative
 		height: 100%
 		padding: 0 20px 0 40px

--- a/src/components/menus/Stepper/Stepper.tsx
+++ b/src/components/menus/Stepper/Stepper.tsx
@@ -18,7 +18,7 @@ interface IStepProps {
 	children?: React.ReactNode;
 	active?: boolean;
 	disabled?: boolean;
-	done: boolean;
+	done?: boolean;
 	number: number;
 }
 

--- a/src/components/menus/Stepper/Stepper.tsx
+++ b/src/components/menus/Stepper/Stepper.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
-import IReactComponentProps from '../../../common/structures/IReactComponentProps';
 import classnames from 'classnames';
+import IReactComponentProps from '../../../common/structures/IReactComponentProps';
 import CompleteSVG from '../../../svg/complete.svg';
 import * as styles from './Stepper.sass';
 
@@ -8,56 +8,31 @@ interface IProps extends IReactComponentProps {
 	children: React.ReactNode;
 }
 
-export class Stepper extends React.Component<IProps> {
-	render () {
-		return (
-			<div
-				className={classnames(
-					styles.Stepper,
-					{
-						[styles.__Steps__2]: (this.props.children as React.ReactNode[]).length === 2,
-						[styles.__Steps__3]: (this.props.children as React.ReactNode[]).length === 3,
-					},
-					this.props.className,
-				)}
-				id={this.props.id}
-				style={this.props.style}
-			>
-				{this.props.children}
-			</div>
-		);
-	}
-}
+export const Stepper: React.FC<IProps> = ({ children, className, ...otherProps }: IProps) => (
+	<div className={classnames(styles.Stepper, className)} {...otherProps}>
+		{children}
+	</div>
+);
 
-interface IStepProps extends IReactComponentProps {
+interface IStepProps {
+	children?: React.ReactNode;
 	active?: boolean;
 	disabled?: boolean;
 	done: boolean;
 	number: number;
 }
 
-export class Step extends React.Component<IStepProps> {
-	render () {
-		return (
-			<div
-				className={classnames(
-					styles.Step,
-					{
-						[styles.Step__Done]: this.props.done,
-						[styles.Step__Active]: this.props.active,
-						[styles.Step__Disabled]: this.props.disabled,
-					},
-				)}
-			>
-				{
-					!this.props.done
-						?
-						<span>{this.props.number}</span>
-						:
-						<CompleteSVG />
-				}
-				{this.props.children}
-			</div>
-		);
-	}
-}
+export const Step: React.FC<IStepProps> = ({ done, active, disabled, number, children }: IStepProps) => {
+	return (
+		<div
+			className={classnames(styles.Step, {
+				[styles.Step__Done]: done,
+				[styles.Step__Active]: active,
+				[styles.Step__Disabled]: disabled,
+			})}
+		>
+			{!done ? <span>{number}</span> : <CompleteSVG />}
+			{children}
+		</div>
+	);
+};


### PR DESCRIPTION
This PR adds a `flex-grow: 1` to the `Step` component in `Stepper`. Before, we were calculating the width of the steps based on the number of steps, though I think this change will be much more flexible. Also, I think it still looks really good if the screen is small enough to start adapting to the size each individual step.

I also updated the component in general to a functional component using best practices. 

Also includes further tweaks to RadioBlock styling per Tyson's feedback.