### PR TITLE
feat: adjust radioblock container and add z-index to tooltip popper

### DIFF
--- a/src/common/structures/IReactComponentProps.ts
+++ b/src/common/structures/IReactComponentProps.ts
@@ -1,6 +1,7 @@
 import * as React from 'react';
 
 export default interface IReactComponentProps {
+	onKeyDown?: any;
 	children?: React.ReactNode;
 	className?: string;
 	key?: string | number;

--- a/src/components/inputs/RadioBlock/RadioBlock.stories.mdx
+++ b/src/components/inputs/RadioBlock/RadioBlock.stories.mdx
@@ -35,7 +35,7 @@ import { default as radioBlockOptions } from './RadioBlockContentExample'
 			default={"test1"}
 			options={{
 				test1: {
-					label: "Test 2",
+					label: "Test 1",
 					content: (
 						<>
 							<Text>
@@ -67,6 +67,68 @@ import { default as radioBlockOptions } from './RadioBlockContentExample'
 							</TextButtonExternal>
 						</>
 					),
+				},
+			}}
+		/>
+	</Story>
+</Canvas>
+
+# RadioBlock with description disabled tooltip example
+
+<Canvas>
+	<Story name="RadioBlock Description Disabled Tooltip">
+		<RadioBlock
+			onChange={() => console.log("onChange")}
+			default={"test1"}
+			options={{
+				test1: {
+					label: "Test 1",
+					content: (
+						<>
+							<Text>
+								This is a description for option 1, Test 1
+							</Text>
+							<TextButtonExternal
+								underline
+								inline={false}
+								onClick={(event) => {event.stopPropagation();}}
+							>
+								Click me!
+							</TextButtonExternal>
+						</>
+					),
+				},
+				test2: {
+					label: "Test 2",
+					disabled: true,
+					content: (
+						<>
+							<Text>
+								This is a description for option 2, Test 2
+							</Text>
+							<TextButtonExternal
+								underline
+								inline={false}
+								onClick={(event) => {event.stopPropagation();}}
+							>
+								Click me!
+							</TextButtonExternal>
+						</>
+					),
+					container: {
+						element: (
+							<Tooltip
+								forceShow
+								content={
+									<div>
+										Hey, this option's disabled.
+										<br />
+										<a>Here's why</a>
+									</div>
+								}
+							/>
+						),
+					},
 				},
 			}}
 		/>

--- a/src/components/inputs/RadioBlock/RadioBlock.tsx
+++ b/src/components/inputs/RadioBlock/RadioBlock.tsx
@@ -54,6 +54,7 @@ const RadioBlockItem: React.FC<IRadioBlockItemProps> = (props: IRadioBlockItemPr
 
 	const onKeyDown = (event: any) => {
 		if (event.key === ' ' || event.key === 'Enter') {
+			event.preventDefault();
 			event.target.click();
 		}
 	};
@@ -62,41 +63,40 @@ const RadioBlockItem: React.FC<IRadioBlockItemProps> = (props: IRadioBlockItemPr
 
 	return (
 		// wrap in optional container
-		<Container {...container}>
+		<Container
+			{...container}
+			role="checkbox"
+			aria-checked={selected}
+			tabIndex={selected ? -1 : 0}
+			onClick={handleClick}
+			onKeyDown={onKeyDown}
+			className={classnames(styles.RadioBlock_Option, className, {
+				[styles.RadioBlock_Option__Disabled]: disabled,
+				[styles.RadioBlock_Option__Warn]: warn,
+				[styles.RadioBlock_Option__HeightSizeNone]: heightSize === 'none',
+				[styles.RadioBlock_Option__HeightSizeMedium]: heightSize === 'm',
+				[styles.RadioBlock_Option__Readonly]: readonly,
+				[styles.RadioBlock_Option__Selected]: selected,
+				[styles.RadioBlock_Option__BorderOnHover]: borderOnHover,
+			})}
+			{...otherProps}
+		>
 			<div
-				role="checkbox"
-				aria-checked={selected}
-				tabIndex={selected ? -1 : 0}
-				onClick={handleClick}
-				onKeyDown={onKeyDown}
-				className={classnames(styles.RadioBlock_Option, className, {
-					[styles.RadioBlock_Option__Disabled]: disabled,
-					[styles.RadioBlock_Option__Warn]: warn,
-					[styles.RadioBlock_Option__HeightSizeNone]: heightSize === 'none',
-					[styles.RadioBlock_Option__HeightSizeMedium]: heightSize === 'm',
-					[styles.RadioBlock_Option__Readonly]: readonly,
-					[styles.RadioBlock_Option__Selected]: selected,
-					[styles.RadioBlock_Option__BorderOnHover]: borderOnHover,
+				className={classnames(styles.RadioBlock_Wrapper, {
+					[styles.RadioBlock_Option_Wrapper_Center]: centerContent,
 				})}
-				{...otherProps}
 			>
-				<div
-					className={classnames(styles.RadioBlock_Wrapper, {
-						[styles.RadioBlock_Option_Wrapper_Center]: centerContent,
-					})}
-				>
-					{label && (
-						<Title size={TitlePropSize.s} className={styles.RadioBlock_Label_Text}>
-							{label}
-						</Title>
-					)}
-					{content && (
-						<div style={{ marginTop: label && '10px' }} className={styles.RadioBlock_Content}>
-							{content}
-						</div>
-					)}
-					<div className={styles.RadioBlock_Arrow}>{svg}</div>
-				</div>
+				{label && (
+					<Title size={TitlePropSize.s} className={styles.RadioBlock_Label_Text}>
+						{label}
+					</Title>
+				)}
+				{content && (
+					<div style={{ marginTop: label && '10px' }} className={styles.RadioBlock_Content}>
+						{content}
+					</div>
+				)}
+				<div className={styles.RadioBlock_Arrow}>{svg}</div>
 			</div>
 		</Container>
 	);

--- a/src/components/menus/TertiaryNav/TertiaryNav.scss
+++ b/src/components/menus/TertiaryNav/TertiaryNav.scss
@@ -39,7 +39,6 @@
 			padding: 1px 20px 0;
 			border-radius: 4px;
 			@include theme-color-gray-else-gray25;
-			font-weight: 700;
 			font-size: 14px;
 			@include tracking(40);
 
@@ -49,6 +48,7 @@
 		}
 
 		a.TertiaryNavItem__Active {
+			font-weight: 700;
 			@include theme-color-graydark-else-white;
 			@include if-theme-light() {
 				background: $gray5;

--- a/src/components/modules/Container/Container.tsx
+++ b/src/components/modules/Container/Container.tsx
@@ -21,46 +21,41 @@ const defaultProps: Partial<IContainerProps> = {};
 export const Container = (props: IContainerProps) => {
 	const Tag: any = props.element || 'div';
 	const element: React.ReactElement = props.element as React.ReactElement;
-	const propsWithoutDefaults: Partial<IContainerProps> = {...props};
+	const propsWithoutDefaults: Partial<IContainerProps> = { ...props };
 	delete propsWithoutDefaults.children;
 	delete propsWithoutDefaults.disabled;
 	const doRenderOnlyChildren: boolean = props.disabled === true || Object.keys(propsWithoutDefaults).length === 0;
 	const doRenderContainerWithTagName: boolean = typeof props.element === 'string' || props.element === undefined;
 
-	return (
-		doRenderOnlyChildren
-			?
-			<>
-				{props.children}
-			</>
-			:
-				doRenderContainerWithTagName
-				?
-				<Tag
-					className={classnames(
-						props.className,
-					)}
-					id={props.id}
-					style={{
-						...props.style,
-						...ContainerMarginHelper.getContainerMarginStyle(props),
-					}}
-				>
-					{props.children}
-				</Tag>
-				:
-				React.cloneElement(
-					element,
-					{
-						children: Array(props.children || []).concat(element.props.children || []),
-						className: classnames(props.className, element.props.className),
-						style: {
-							...props.style,
-							...element.props.style,
-							...ContainerMarginHelper.getContainerMarginStyle(props),
-						},
-					},
-				)
+	return doRenderOnlyChildren ? (
+		<>{props.children}</>
+	) : doRenderContainerWithTagName ? (
+		<Tag
+			className={classnames(props.className)}
+			id={props.id}
+			style={{
+				...props.style,
+				...ContainerMarginHelper.getContainerMarginStyle(props),
+			}}
+			onClick={props.onClick}
+			onKeyDown={props.onKeyDown}
+			tabIndex={props.tabIndex}
+		>
+			{props.children}
+		</Tag>
+	) : (
+		React.cloneElement(element, {
+			children: Array(props.children || []).concat(element.props.children || []),
+			className: classnames(props.className, element.props.className),
+			style: {
+				...props.style,
+				...element.props.style,
+				...ContainerMarginHelper.getContainerMarginStyle(props),
+			},
+			onClick: props.onClick,
+			onKeyDown: props.onKeyDown,
+			tabIndex: props.tabIndex,
+		})
 	);
 };
 

--- a/src/components/overlays/Tooltip/Tooltip.scss
+++ b/src/components/overlays/Tooltip/Tooltip.scss
@@ -11,6 +11,10 @@ $borderThickness: 1px;
 	box-shadow: 0 0 5px 0 rgba(0, 0, 0, 0.14);
 }
 
+.Tooltip_Popper_PositionContainer {
+	z-index: 10;
+}
+
 .Tooltip_Popper_VisualContainer {
 	padding: 10px 15px;
 	font-weight: 300;

--- a/src/components/overlays/Tooltip/Tooltip.tsx
+++ b/src/components/overlays/Tooltip/Tooltip.tsx
@@ -430,7 +430,6 @@ export const Tooltip = (props: TooltipProps) => {
 Tooltip.defaultProps = {
 	hideDelay: 500,
 	forceShow: false,
-	offsetPopper: [0, 10],
 	position: 'top',
 	showDelay: 1000,
 	useClickInsteadOfHover: false,

--- a/src/components/overlays/Tooltip/Tooltip.tsx
+++ b/src/components/overlays/Tooltip/Tooltip.tsx
@@ -1,23 +1,23 @@
 import * as React from 'react';
-import IReactComponentProps from '../../../common/structures/IReactComponentProps';
 import classnames from 'classnames';
-import * as styles from './Tooltip.scss';
 import { usePopper } from 'react-popper';
-import {  useEffect, useState, useRef } from 'react';
+import { useEffect, useState, useRef } from 'react';
+import { Options } from '@popperjs/core/lib/modifiers/arrow';
+import { Options as OffsetOptions } from '@popperjs/core/lib/modifiers/offset';
+import IReactComponentProps from '../../../common/structures/IReactComponentProps';
+import * as styles from './Tooltip.scss';
 import { Portal } from '../../../common/helpers/Portal';
 import { useDetectTransitionEnd } from '../../../common/helpers/useDetectTransitionEnd';
 import { useSwappableTimeout } from '../../../common/helpers/useTimeout';
 import { useDetectClickOrHoverWithinTargets } from '../../../common/helpers/useDetectClickOrHoverWithinTargets';
-import { Options } from '@popperjs/core/lib/modifiers/arrow';
-import { Options as OffsetOptions } from '@popperjs/core/lib/modifiers/offset';
 import { FunctionGeneric } from '../../../common/structures/Generics';
 
 export interface TooltipProps extends IReactComponentProps {
-	/** the content that should show the tooltip upon the user's mouse entering it **/
+	/** the content that should show the tooltip upon the user's mouse entering it * */
 	content?: React.ReactElement;
-	/** whether to force the tooltip to show and ignore mouse events **/
+	/** whether to force the tooltip to show and ignore mouse events * */
 	forceShow?: boolean;
-	/** the number of milliseconds to delay hiding the tooltip after the user's mouse leaves this component **/
+	/** the number of milliseconds to delay hiding the tooltip after the user's mouse leaves this component * */
 	hideDelay?: number;
 	/** hide the tooltip arrow */
 	hideArrow?: boolean;
@@ -26,14 +26,29 @@ export interface TooltipProps extends IReactComponentProps {
 	/** Additional popper offset modifier to reposition the popper tooltip [position's direction, perpendicular direction] */
 	popperOffsetModifier?: Partial<OffsetOptions>;
 	/** className to tweak popper container styles */
-	popperContainerClassName?: string,
+	popperContainerClassName?: string;
 	/** className to tweak popper visual container styles */
-	popperVisualContainerClassName?: string,
-	/** the position/placement of the tooltip relative to the content **/
-	position?: 'top' | 'top-start' | 'top-end' | 'right' | 'right-start' | 'right-end' | 'bottom' | 'bottom-start' | 'bottom-end' | 'left' | 'left-start' | 'left-end' | 'auto' | 'auto-start' | 'auto-end';
-	/** the number of milliseconds to delay showing the tooltip once the user's mouse enters this component **/
+	popperVisualContainerClassName?: string;
+	/** the position/placement of the tooltip relative to the content * */
+	position?:
+		| 'top'
+		| 'top-start'
+		| 'top-end'
+		| 'right'
+		| 'right-start'
+		| 'right-end'
+		| 'bottom'
+		| 'bottom-start'
+		| 'bottom-end'
+		| 'left'
+		| 'left-start'
+		| 'left-end'
+		| 'auto'
+		| 'auto-start'
+		| 'auto-end';
+	/** the number of milliseconds to delay showing the tooltip once the user's mouse enters this component * */
 	showDelay?: number;
-	//** whether to change default hover tooltip interaction to click/blur */
+	//* * whether to change default hover tooltip interaction to click/blur */
 	useClickInsteadOfHover?: boolean;
 	/** whether to hide tooltip from dom */
 	hideTooltip?: boolean;
@@ -49,21 +64,15 @@ export interface TooltipProps extends IReactComponentProps {
 type ReducerStageDirection = 'prev' | 'stopped' | 'next';
 
 interface ReducerState {
-	stage:
-	| '0Hidden'
-	| '1WaitingToFadeIn'
-	| '2FadingInToShow'
-	| '3Showing'
-	| '4WaitingToFadeOut'
-	| '5FadingOutToHide',
-	direction: ReducerStageDirection,
+	stage: '0Hidden' | '1WaitingToFadeIn' | '2FadingInToShow' | '3Showing' | '4WaitingToFadeOut' | '5FadingOutToHide';
+	direction: ReducerStageDirection;
 }
 
 type ReducerAction =
-| { type: 'onDelayComplete' }
-| { type: 'onMouseOff' }
-| { type: 'onMouseOver' }
-| { type: 'onTransitionEnd' }
+	| { type: 'onDelayComplete' }
+	| { type: 'onMouseOff' }
+	| { type: 'onMouseOver' }
+	| { type: 'onTransitionEnd' };
 
 /**
  * a reducer that handles revelant events changes the tooltip stage accordingly
@@ -74,7 +83,7 @@ type ReducerAction =
  * @param action
  */
 function reducer(prevState: ReducerState, action: ReducerAction): ReducerState {
-	const newState = {...prevState};
+	const newState = { ...prevState };
 	const { type } = action;
 
 	switch (prevState.stage) {
@@ -88,12 +97,10 @@ function reducer(prevState: ReducerState, action: ReducerAction): ReducerState {
 			if (type === 'onDelayComplete' || (newState.direction === 'prev' && type === 'onMouseOver')) {
 				newState.direction = 'next';
 				newState.stage = '2FadingInToShow';
-			}
-			else if (type === 'onMouseOff') {
+			} else if (type === 'onMouseOff') {
 				newState.direction = 'stopped';
 				newState.stage = '0Hidden';
-			}
-			else if (prevState.direction === 'prev') {
+			} else if (prevState.direction === 'prev') {
 				newState.direction = 'stopped';
 				newState.stage = '0Hidden';
 			}
@@ -102,8 +109,7 @@ function reducer(prevState: ReducerState, action: ReducerAction): ReducerState {
 			if (type === 'onTransitionEnd') {
 				newState.direction = 'next';
 				newState.stage = '3Showing';
-			}
-			else if (type === 'onMouseOff') {
+			} else if (type === 'onMouseOff') {
 				newState.direction = 'prev';
 				newState.stage = '1WaitingToFadeIn';
 			}
@@ -118,8 +124,7 @@ function reducer(prevState: ReducerState, action: ReducerAction): ReducerState {
 			if (type === 'onDelayComplete' || (newState.direction === 'prev' && type === 'onMouseOff')) {
 				newState.direction = 'next';
 				newState.stage = '5FadingOutToHide';
-			}
-			else if (prevState.direction === 'prev') {
+			} else if (prevState.direction === 'prev') {
 				newState.stage = '3Showing';
 			}
 			break;
@@ -127,8 +132,7 @@ function reducer(prevState: ReducerState, action: ReducerAction): ReducerState {
 			if (type === 'onTransitionEnd') {
 				newState.direction = 'stopped';
 				newState.stage = '0Hidden';
-			}
-			else if (type === 'onMouseOver') {
+			} else if (type === 'onMouseOver') {
 				newState.direction = 'prev';
 				newState.stage = '4WaitingToFadeOut';
 			}
@@ -163,10 +167,10 @@ const useTooltipStage = (
 	isHoverTarget: boolean,
 	isHoverPopper: boolean,
 	hideDelay: number | undefined,
-	showDelay: number | undefined,
+	showDelay: number | undefined
 ) => {
 	// manage the complex, bi-directional stages of the tooltip state
-	const [ state, dispatchState ] = React.useReducer(reducer, reducerInitialState);
+	const [state, dispatchState] = React.useReducer(reducer, reducerInitialState);
 	// use a single timer that when swapped out automatically cancels the active timeout if any exist
 	const { swapTimeout, clearTimeoutRef } = useSwappableTimeout();
 
@@ -185,43 +189,35 @@ const useTooltipStage = (
 
 	// process and handle timers for show and hide delays
 	useEffect(() => {
-		switch(state.stage) {
+		switch (state.stage) {
 			case '1WaitingToFadeIn':
 				if (state.direction === 'next') {
-					swapTimeout(
-						() => callback1.current(),
-						showDelay ?? 1000,
-					);
-				}
-				else {
+					swapTimeout(() => callback1.current(), showDelay ?? 1000);
+				} else {
 					// stop timeout since we're interupting and don't want it to finish
 					clearTimeoutRef();
 				}
 				break;
 			case '4WaitingToFadeOut':
 				if (state.direction === 'next') {
-					swapTimeout(
-						() => callback4.current(isHoverTarget || isHoverPopper),
-						hideDelay ?? 500,
-					);
-				}
-				else {
+					swapTimeout(() => callback4.current(isHoverTarget || isHoverPopper), hideDelay ?? 500);
+				} else {
 					// stop timeout since we're interupting and don't want it to finish
 					clearTimeoutRef();
 				}
 				break;
 		}
-	}, [ state.stage, isHoverTarget, isHoverPopper ]);
+	}, [state.stage, isHoverTarget, isHoverPopper]);
 
 	// process and handle transition ends
 	useEffect(() => {
 		isTransitionEnd && dispatchState({ type: 'onTransitionEnd' });
-	}, [ isTransitionEnd ]);
+	}, [isTransitionEnd]);
 
 	// process and handle mouse events
 	useEffect(() => {
 		dispatchState({ type: isHoverTarget || isHoverPopper ? 'onMouseOver' : 'onMouseOff' });
-	}, [ isHoverTarget, isHoverPopper ]);
+	}, [isHoverTarget, isHoverPopper]);
 
 	// make it easier on anything that consumes this by turning each stage into a bool
 	return {
@@ -232,8 +228,8 @@ const useTooltipStage = (
 		isStage4WaitingToFadeOut: state.stage === '4WaitingToFadeOut',
 		isStage5FadingOutToHide: state.stage === '5FadingOutToHide',
 		isVisible: state.stage !== '0Hidden' && state.stage !== '1WaitingToFadeIn',
-	}
-}
+	};
+};
 
 const useTooltip = ({
 	hideDelay,
@@ -244,40 +240,49 @@ const useTooltip = ({
 	transitionEndPropName,
 	useClickInsteadOfHover,
 }: {
-	hideDelay?: number,
-	placement?: TooltipProps['position'],
-	popperArrowModifier?: TooltipProps['popperArrowModifier'],
-	popperOffsetModifier?: TooltipProps['popperOffsetModifier'],
-	showDelay?: number,
-	transitionEndPropName: string,
-	useClickInsteadOfHover: boolean,
+	hideDelay?: number;
+	placement?: TooltipProps['position'];
+	popperArrowModifier?: TooltipProps['popperArrowModifier'];
+	popperOffsetModifier?: TooltipProps['popperOffsetModifier'];
+	showDelay?: number;
+	transitionEndPropName: string;
+	useClickInsteadOfHover: boolean;
 }) => {
-	const [ triggerElement, setReferenceElement ] = useState<HTMLElement | null>(null);
-	const [ popperElement, setPopperElement ] = useState<HTMLElement | null>(null);
-	const [ transitionElement, setTransitionElement ] = useState<HTMLElement | null>(null);
-	const isHoverTarget = useDetectClickOrHoverWithinTargets({targetEl: triggerElement, alwaysBlurOnClick: true, useClickInsteadOfHover, ignoreClickOn: popperElement})
-	const isHoverPopper= useDetectClickOrHoverWithinTargets({targetEl: popperElement, alwaysBlurOnClick: false, useClickInsteadOfHover}) // pass nulls to bypass otherwise this will conflict with other click detects (above)
+	const [triggerElement, setReferenceElement] = useState<HTMLElement | null>(null);
+	const [popperElement, setPopperElement] = useState<HTMLElement | null>(null);
+	const [transitionElement, setTransitionElement] = useState<HTMLElement | null>(null);
+	const isHoverTarget = useDetectClickOrHoverWithinTargets({
+		targetEl: triggerElement,
+		alwaysBlurOnClick: true,
+		useClickInsteadOfHover,
+		ignoreClickOn: popperElement,
+	});
+	const isHoverPopper = useDetectClickOrHoverWithinTargets({
+		targetEl: popperElement,
+		alwaysBlurOnClick: false,
+		useClickInsteadOfHover,
+	}); // pass nulls to bypass otherwise this will conflict with other click detects (above)
 
 	const isTransitionEnd = useDetectTransitionEnd(transitionElement, transitionEndPropName);
 	const stages = useTooltipStage(isTransitionEnd, isHoverTarget, isHoverPopper, hideDelay, showDelay);
-	const [ arrowElement, setArrowElement ] = useState<HTMLElement | null>(null); // the ref for the arrow must be a callback ref
-	const { styles, attributes } = usePopper(triggerElement, popperElement, {
-		placement: placement,
+	const [arrowElement, setArrowElement] = useState<HTMLElement | null>(null); // the ref for the arrow must be a callback ref
+	const { styles: popperStyles, attributes } = usePopper(triggerElement, popperElement, {
+		placement,
 		modifiers: [
 			{
 				name: 'arrow',
 				options: {
 					element: popperArrowModifier?.element ?? arrowElement,
 					padding: popperArrowModifier?.padding ?? 0,
-				}
+				},
 			},
 			{
 				name: 'offset',
 				options: {
 					offset: popperOffsetModifier?.offset || [0, 10],
-				}
-			}
-		]
+				},
+			},
+		],
 	});
 
 	return {
@@ -285,11 +290,11 @@ const useTooltip = ({
 		attributes,
 		setPopperRef: setPopperElement,
 		stages,
-		styles,
+		popperStyles,
 		targetRef: setReferenceElement,
 		transitionRef: setTransitionElement,
 	};
-}
+};
 
 export const Tooltip = (props: TooltipProps) => {
 	const {
@@ -308,15 +313,7 @@ export const Tooltip = (props: TooltipProps) => {
 		focusOnOpen,
 	} = props;
 
-	const {
-		setArrowRef,
-		attributes,
-		setPopperRef,
-		styles: popperStyles,
-		stages,
-		targetRef,
-		transitionRef,
-	} = useTooltip({
+	const { setArrowRef, attributes, setPopperRef, popperStyles, stages, targetRef, transitionRef } = useTooltip({
 		hideDelay: props.hideDelay,
 		placement: props.position,
 		popperArrowModifier: props.popperArrowModifier,
@@ -339,27 +336,20 @@ export const Tooltip = (props: TooltipProps) => {
 	useEffect(() => {
 		if (isFirstRender.current) {
 			isFirstRender.current = false;
+		} else if (isShowing) {
+			onShow?.();
 		} else {
-			if (isShowing) {
-				onShow?.();
-			} else {
-				onHide?.();
-			}
+			onHide?.();
 		}
-	}, [isShowing])
+	}, [isShowing]);
 
 	return (
 		<>
 			<div
-				className={classnames(
-					styles.Tooltip_Target_Container,
-					'Tooltip_Target_Container',
-					className,
-					{
-						[styles.Popper__Showing]: isShowing,
-						'Popper__Showing': isShowing, // this also needs to be globally accessible so other component styles can reference it
-					},
-				)}
+				className={classnames(styles.Tooltip_Target_Container, 'Tooltip_Target_Container', className, {
+					[styles.Popper__Showing]: isShowing,
+					Popper__Showing: isShowing, // this also needs to be globally accessible so other component styles can reference it
+				})}
 				id={id}
 				ref={targetRef}
 				style={style}
@@ -367,9 +357,9 @@ export const Tooltip = (props: TooltipProps) => {
 				{children}
 			</div>
 			{/*
-			  * render if forced or not in the hidden tooltip stage
-			  * note: this needs to render on hover when waiting for initial show delay even those it's not visible
-			*/}
+			 * render if forced or not in the hidden tooltip stage
+			 * note: this needs to render on hover when waiting for initial show delay even those it's not visible
+			 */}
 			{isShowing && (
 				<Portal>
 					{/* this is the dedicated popper container that applies the 3rd party library position styles without conflicting with our custom transition styles */}
@@ -379,9 +369,8 @@ export const Tooltip = (props: TooltipProps) => {
 							'Tooltip_Popper_PositionContainer',
 							popperContainerClassName,
 							{
-								[styles.Popper__Showing]: isShowing,
-								'Popper__Showing': isShowing, // this also needs to be globally accessible so other component styles can reference it
-							},
+								Popper__Showing: isShowing, // this also needs to be globally accessible so other component styles can reference it
+							}
 						)}
 						ref={popperRefCallback}
 						style={popperStyles.popper}
@@ -394,24 +383,15 @@ export const Tooltip = (props: TooltipProps) => {
 								popperVisualContainerClassName,
 								{
 									[styles.Tooltip_Popper_VisualContainer__IsShowing]: stages.isVisible || forceShow,
-									[styles.Tooltip_Popper_VisualContainer__IsTransitionLeaving]: stages.isStage5FadingOutToHide,
-								},
+									[styles.Tooltip_Popper_VisualContainer__IsTransitionLeaving]:
+										stages.isStage5FadingOutToHide,
+								}
 							)}
 							ref={transitionRef}
 							{...attributes.popper}
 						>
-							<div
-								className={classnames(
-									styles.Tooltip_Popper_Inner,
-									'Tooltip_Popper_Inner_Container',
-								)}
-							>
-								<div
-									className={classnames(
-										styles.Tooltip_Popper_Content,
-										'Tooltip_Popper_Content',
-									)}
-								>
+							<div className={classnames(styles.Tooltip_Popper_Inner, 'Tooltip_Popper_Inner_Container')}>
+								<div className={classnames(styles.Tooltip_Popper_Content, 'Tooltip_Popper_Content')}>
 									{props.content}
 								</div>
 							</div>
@@ -419,17 +399,14 @@ export const Tooltip = (props: TooltipProps) => {
 								<div
 									className={classnames(
 										styles.Tooltip_Popper_Arrow_Container,
-										'Tooltip_Popper_Arrow_Container',
+										'Tooltip_Popper_Arrow_Container'
 									)}
 									ref={setArrowRef}
 									style={popperStyles.arrow}
 									{...attributes.popper}
 								>
 									<div
-										className={classnames(
-											styles.Tooltip_Popper_Arrow,
-											'Tooltip_Popper_Arrow',
-										)}
+										className={classnames(styles.Tooltip_Popper_Arrow, 'Tooltip_Popper_Arrow')}
 										{...attributes.popper}
 									/>
 								</div>
@@ -440,7 +417,7 @@ export const Tooltip = (props: TooltipProps) => {
 			)}
 		</>
 	);
-}
+};
 
 Tooltip.defaultProps = {
 	hideDelay: 500,

--- a/src/components/overlays/Tooltip/Tooltip.tsx
+++ b/src/components/overlays/Tooltip/Tooltip.tsx
@@ -311,6 +311,7 @@ export const Tooltip = (props: TooltipProps) => {
 		onShow,
 		hideArrow,
 		focusOnOpen,
+		...otherProps
 	} = props;
 
 	const { setArrowRef, attributes, setPopperRef, popperStyles, stages, targetRef, transitionRef } = useTooltip({
@@ -353,6 +354,7 @@ export const Tooltip = (props: TooltipProps) => {
 				id={id}
 				ref={targetRef}
 				style={style}
+				{...otherProps}
 			>
 				{children}
 			</div>

--- a/src/components/overlays/Tooltip/Tooltip.tsx
+++ b/src/components/overlays/Tooltip/Tooltip.tsx
@@ -311,15 +311,21 @@ export const Tooltip = (props: TooltipProps) => {
 		onShow,
 		hideArrow,
 		focusOnOpen,
+		content,
+		hideDelay,
+		position,
+		popperArrowModifier,
+		popperOffsetModifier,
+		showDelay,
 		...otherProps
 	} = props;
 
 	const { setArrowRef, attributes, setPopperRef, popperStyles, stages, targetRef, transitionRef } = useTooltip({
-		hideDelay: props.hideDelay,
-		placement: props.position,
-		popperArrowModifier: props.popperArrowModifier,
-		popperOffsetModifier: props.popperOffsetModifier,
-		showDelay: props.showDelay,
+		hideDelay,
+		placement: position,
+		popperArrowModifier,
+		popperOffsetModifier,
+		showDelay,
 		transitionEndPropName: 'transform',
 		useClickInsteadOfHover: !!useClickInsteadOfHover,
 	});
@@ -394,7 +400,7 @@ export const Tooltip = (props: TooltipProps) => {
 						>
 							<div className={classnames(styles.Tooltip_Popper_Inner, 'Tooltip_Popper_Inner_Container')}>
 								<div className={classnames(styles.Tooltip_Popper_Content, 'Tooltip_Popper_Content')}>
-									{props.content}
+									{content}
 								</div>
 							</div>
 							{!hideArrow && (

--- a/src/components/tables/TableList/TableList.tsx
+++ b/src/components/tables/TableList/TableList.tsx
@@ -8,59 +8,51 @@ interface IProps extends IReactComponentProps {
 	stripes?: boolean;
 }
 
-export class TableList extends React.Component<IProps> {
-	render () {
-		return (
-			<ul
-				className={classnames(
-					styles.TableList,
-					'TableList', // this also needs to be globally accessible so other component styles can reference it
-					this.props.className,
-					{
-						[styles.Form]: this.props.form,
-						[styles.TableList__NoStripes]: this.props.stripes === false,
-					},
-				)}
-				id={this.props.id}
-				style={this.props.style}
-			>
-				{this.props.children}
-			</ul>
-		);
-	}
-}
+export const TableList = (props: IProps) => {
+	const { className, form, stripes, children, ...otherProps } = props;
+	return (
+		<ul
+			className={classnames(
+				styles.TableList,
+				'TableList', // this also needs to be globally accessible so other component styles can reference it
+				className,
+				{
+					[styles.Form]: form,
+					[styles.TableList__NoStripes]: stripes === false,
+				}
+			)}
+			{...otherProps}
+		>
+			{children}
+		</ul>
+	);
+};
 
 interface ITableListRowProps extends IReactComponentProps {
-	form?: boolean;
 	label?: string;
 	selectable?: boolean;
 }
 
-export class TableListRow extends React.Component<ITableListRowProps> {
-	render () {
-		return (
-			<li
-				className={classnames(
-					styles.TableListRow,
-					'TableListRow', // this also needs to be globally accessible so other component styles can reference it
-					this.props.className,
-				)}
-			>
-				{this.props.label && <strong>{this.props.label}</strong>}
+export const TableListRow = (props: ITableListRowProps) => {
+	const { className, label, selectable, children } = props;
 
-				<div>
-					{
-						this.props.selectable && typeof this.props.children !== 'object'
-							?
-							<input
-								type="text"
-								readOnly={true}
-								value={this.props.children as string | string[] | number}
-							/>
-							: this.props.children
-					}
-				</div>
-			</li>
-		);
-	}
-}
+	return (
+		<li
+			className={classnames(
+				styles.TableListRow,
+				'TableListRow', // this also needs to be globally accessible so other component styles can reference it
+				className
+			)}
+		>
+			{label && <strong>{label}</strong>}
+
+			<div>
+				{selectable && typeof children !== 'object' ? (
+					<input type="text" readOnly value={children as string | string[] | number} />
+				) : (
+					children
+				)}
+			</div>
+		</li>
+	);
+};


### PR DESCRIPTION
This PR adjusts the `RadioBlock` component once again! We were originally placing radio block options inside of an optional `Container` element, so I just moved the outer radio block option wrapper to that `Container` element. So now we will always render that `Container` (defaults to `div`), but we are still able to pass custom options to it. This makes adding a tooltip to a radio block option with content possible without style conflicts!

I also added a z-index to the tooltip popper container, because due to a bad bug fix for the user profile avatar showing up in front of overlayed window components, it was being hidden by a z-index of 10 on the `window` component. I created a ticket to tackle this problem more elegantly in the Popup component (use a tooltip or portal instead of a z-index), but this should work for now. 

I linted a couple files here too, which makes this look a little scarier.