### PR TITLE
fix: make radioBlockItem key the option value instead of label

### DIFF
--- a/src/components/inputs/RadioBlock/RadioBlock.tsx
+++ b/src/components/inputs/RadioBlock/RadioBlock.tsx
@@ -176,7 +176,7 @@ const RadioBlock: React.FC<IProps> = (props: IProps) => {
 						heightSize={heightSize || options[optionValue].heightSize}
 						label={options[optionValue].label}
 						value={optionValue}
-						key={options[optionValue].label}
+						key={optionValue}
 						readonly={readonly ?? options[optionValue].readonly}
 						svg={options[optionValue].svg}
 						selected={value === optionValue}


### PR DESCRIPTION
This PR is the last one to RadioBlock I swear. Fixes a "unique key in list" console error when using options without labels.