### PR TITLE
fix: increase z-index for FlyModal and more updates

### DIFF
--- a/src/components/buttons/_private/ButtonBase/ButtonBase.tsx
+++ b/src/components/buttons/_private/ButtonBase/ButtonBase.tsx
@@ -141,8 +141,8 @@ const ButtonBase = (props: IButtonBaseProps) => {
 	} = props;
 
 	const Tag: any = tag;
-	const LeftIcon = leftIcon;
-	const RightIcon = rightIcon;
+	const LeftIcon: any = leftIcon;
+	const RightIcon: any = rightIcon;
 
 	const [isActive, setIsActive] = React.useState(active);
 

--- a/src/components/inputs/BasicInput/BasicInput.tsx
+++ b/src/components/inputs/BasicInput/BasicInput.tsx
@@ -18,46 +18,32 @@ export interface IBasicInputProps extends ILocalContainerProps {
 	onKeyUp?: any;
 	invalid?: boolean;
 	invalidMessage?: string;
+	autofocus?: boolean;
 }
 
-export default class BasicInput extends React.Component<IBasicInputProps> {
-	constructor (props: IBasicInputProps) {
-		super(props);
-	}
+const BasicInput = (props: IBasicInputProps) => {
+	const { className, id, name, style, invalid, invalidMessage, autofocus, ...otherProps } = props;
 
-	render () {
-		const {
-			className,
-			id,
-			name,
-			style,
-			invalid,
-			invalidMessage,
-			...props
-		} = this.props;
+	const input = React.useRef<HTMLInputElement>(null);
 
-		return (
-			<div
-				className={classnames(
-					'BasicInput',
-					styles.BasicInput,
-					this.props.className,
-				)}
-				id={id}
-				style={style}
-			>
-				<input
-					name={name}
-					type='text'
-					className={classnames({[`${styles.__Invalid} __Invalid`]: invalid})}
-					{...props}
-				/>
-				{(invalid && invalidMessage) && (
-					<span>{invalidMessage}</span>
-				)}
-				
+	React.useEffect(() => {
+		if (autofocus) {
+			input.current?.focus();
+		}
+	}, []);
 
-			</div>
-		);
-	}
-}
+	return (
+		<div className={classnames('BasicInput', styles.BasicInput, className)} id={id} style={style}>
+			<input
+				name={name}
+				type="text"
+				className={classnames({ [`${styles.__Invalid} __Invalid`]: invalid })}
+				ref={input}
+				{...otherProps}
+			/>
+			{invalid && invalidMessage && <span>{invalidMessage}</span>}
+		</div>
+	);
+};
+
+export default BasicInput;

--- a/src/components/inputs/FlyDropdown/FlyDropdown.scss
+++ b/src/components/inputs/FlyDropdown/FlyDropdown.scss
@@ -5,6 +5,10 @@
 	display: inline-block;
 	@include cursorPointer;
 
+	> svg {
+		vertical-align: middle;
+	}
+
 	&.FlyDropdown__NavItem {
 		border-bottom: 4px solid transparent;
 		padding: 6px 4px 11px;

--- a/src/components/inputs/FlyDropdown/FlyDropdown.stories.mdx
+++ b/src/components/inputs/FlyDropdown/FlyDropdown.stories.mdx
@@ -21,9 +21,7 @@ Basic:
 				},
 			]}
 		>
-			<TextButton privateOptions={{ color: "gray" }}>
-				Dropdown
-			</TextButton>
+			Dropdown
 		</FlyDropdown>
 	</Story>
 </Canvas>
@@ -52,9 +50,7 @@ No Caret (Top Open):
 					},
 				]}
 			>
-				<TextButton privateOptions={{ color: "gray" }}>
-					Long Title Dropdown (show above)
-				</TextButton>
+				Long Title Dropdown (show above)
 			</FlyDropdown>
 		</div>
 	</Story>

--- a/src/components/inputs/FlyDropdown/FlyDropdown.tsx
+++ b/src/components/inputs/FlyDropdown/FlyDropdown.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react';
 import classnames from 'classnames';
+import { Rect } from '@popperjs/core';
 import * as styles from './FlyDropdown.scss';
 import { CaretIcon, CheckmarkMixedIcon } from '../../icons/Icons';
 import IReactComponentProps from '../../../common/structures/IReactComponentProps';
 import { FunctionGeneric } from '../../../common/structures/Generics';
 import { Tooltip, TooltipProps } from '../../overlays/Tooltip/Tooltip';
-import { Rect } from '@popperjs/core';
-import { TextButton } from '../../buttons/TextButton/TextButton'
+import { TextButton } from '../../buttons/TextButton/TextButton';
 import { DashIcon } from '../../icons/svgs/DashIcon';
 
 interface IItems {
@@ -23,7 +23,7 @@ interface IProps extends IReactComponentProps {
 	classNameList?: string;
 	/** className for an individual list item */
 	classNameListItem?: string;
-	/** whether to force the tooltip to show and ignore mouse events **/
+	/** whether to force the tooltip to show and ignore mouse events * */
 	forceShow?: boolean;
 	/** */
 	items: IItems[];
@@ -32,6 +32,8 @@ interface IProps extends IReactComponentProps {
 	popperOptions?: TooltipProps;
 	position?: 'top' | 'bottom';
 	useClickInsteadOfHover?: boolean;
+	/** Icon to show to the left of the selected item - will not have fill added */
+	selectedIcon?: any;
 }
 
 const setArrowPadding = ({ popper }: { popper: Rect }) => {
@@ -58,18 +60,17 @@ const FlyDropdown = (props: IProps) => {
 		position,
 		style,
 		useClickInsteadOfHover,
+		selectedIcon,
 	} = props;
-	const {
-		popperArrowModifier,
-		popperOffsetModifier,
-		...restPopperOptions
-	} = popperOptions ?? {};
+	const { popperArrowModifier, popperOffsetModifier, ...restPopperOptions } = popperOptions ?? {};
 	const onClickItem = (event: React.MouseEvent<HTMLLIElement, MouseEvent>, item: IItems) => {
 		item.onClick.call(null);
 		event.stopPropagation();
 	};
 
 	const [isShowing, setIsShowing] = React.useState(false);
+
+	const SelectedIcon: any = selectedIcon;
 
 	return (
 		<Tooltip
@@ -80,38 +81,30 @@ const FlyDropdown = (props: IProps) => {
 					[styles.FlyDropdown__NavItem]: navItem,
 					[styles.FlyDropdown__NavItemActive]: navItemActive,
 				},
-				className,
+				className
 			)}
 			content={
-				<ul
-					className={classnames(
-						styles.FlyDropdown_Items,
-						'FlyDropdown_Items',
-						classNameList,
-					)}
-				>
-					{
-						items.map((item: IItems, i: number) => (
-							<li
-								key={i}
-								className={classnames(
-									styles.FlyDropdown_Item,
-									'FlyDropdown_Item',
-									{
-										[styles.FlyDropdown_Item__ColorNone]: item.color === 'none',
-										[styles.FlyDropdown_Item__ColorRed]: item.color === 'red',
-									},
-									classNameListItem,
-									item.className,
-								)}
-								onClick={(event) => onClickItem(event, item)}
-								onMouseDown={(event) => event.preventDefault()}
-							>
-								{item.label}
-								{item.content}
-							</li>
-						))
-					}
+				<ul className={classnames(styles.FlyDropdown_Items, 'FlyDropdown_Items', classNameList)}>
+					{items.map((item: IItems, i: number) => (
+						<li
+							key={i}
+							className={classnames(
+								styles.FlyDropdown_Item,
+								'FlyDropdown_Item',
+								{
+									[styles.FlyDropdown_Item__ColorNone]: item.color === 'none',
+									[styles.FlyDropdown_Item__ColorRed]: item.color === 'red',
+								},
+								classNameListItem,
+								item.className
+							)}
+							onClick={(event) => onClickItem(event, item)}
+							onMouseDown={(event) => event.preventDefault()}
+						>
+							{item.label}
+							{item.content}
+						</li>
+					))}
 				</ul>
 			}
 			forceShow={forceShow}
@@ -121,7 +114,7 @@ const FlyDropdown = (props: IProps) => {
 				...popperArrowModifier,
 			}}
 			popperOffsetModifier={{
-				offset: [ 20, 10 ],
+				offset: [20, 10],
 				...popperOffsetModifier,
 			}}
 			popperVisualContainerClassName={styles.FlyDropdown_PopperVisualContainer}
@@ -134,16 +127,17 @@ const FlyDropdown = (props: IProps) => {
 			onHide={() => setIsShowing(false)}
 			{...restPopperOptions}
 		>
-
+			{selectedIcon && <SelectedIcon />}
 			<TextButton
+				inline
 				rightIcon={caret && (isShowing ? DashIcon : CaretIcon)}
-				privateOptions={{ fontWeight: 'medium', padding: 'none' }}
+				privateOptions={{ padding: 'none' }}
 			>
 				{children}
 			</TextButton>
 		</Tooltip>
 	);
-}
+};
 
 FlyDropdown.defaultProps = {
 	caret: true,

--- a/src/components/inputs/FlyDropdown/FlyDropdown.tsx
+++ b/src/components/inputs/FlyDropdown/FlyDropdown.tsx
@@ -34,6 +34,8 @@ interface IProps extends IReactComponentProps {
 	useClickInsteadOfHover?: boolean;
 	/** Icon to show to the left of the selected item - will not have fill added */
 	selectedIcon?: any;
+	/** Style the trigger textButton as disabled */
+	disabledStyle?: boolean;
 }
 
 const setArrowPadding = ({ popper }: { popper: Rect }) => {
@@ -61,6 +63,7 @@ const FlyDropdown = (props: IProps) => {
 		style,
 		useClickInsteadOfHover,
 		selectedIcon,
+		disabledStyle,
 	} = props;
 	const { popperArrowModifier, popperOffsetModifier, ...restPopperOptions } = popperOptions ?? {};
 	const onClickItem = (event: React.MouseEvent<HTMLLIElement, MouseEvent>, item: IItems) => {
@@ -129,6 +132,7 @@ const FlyDropdown = (props: IProps) => {
 		>
 			{selectedIcon && <SelectedIcon />}
 			<TextButton
+				disabled={disabledStyle}
 				inline
 				rightIcon={caret && (isShowing ? DashIcon : CaretIcon)}
 				privateOptions={{ padding: 'none' }}

--- a/src/components/inputs/RadioBlock/RadioBlock.sass
+++ b/src/components/inputs/RadioBlock/RadioBlock.sass
@@ -7,8 +7,7 @@ $zIndexOptionTooltip: $zIndexOptionSelected + 3
 .RadioBlock
 	display: flex
 	flex-wrap: wrap
-	justify-content: space-between
-	width: 100%
+	justify-content: center
 
 	&.RadioBlock__DirectionVert
 		flex-direction: column

--- a/src/components/inputs/RadioBlock/RadioBlock.sass
+++ b/src/components/inputs/RadioBlock/RadioBlock.sass
@@ -38,7 +38,6 @@ $zIndexOptionTooltip: $zIndexOptionSelected + 3
 
 .RadioBlock_Option
 	position: relative
-	z-index: $zIndexOptionNormal
 	@include theme-background-white-else-graydark
 	@include theme-input-border-box-shadow
 	border-radius: 0

--- a/src/components/overlays/FlyModal/FlyModal.sass
+++ b/src/components/overlays/FlyModal/FlyModal.sass
@@ -12,7 +12,7 @@
 	background: rgba($gray-dark, .85)
 	animation: fadeIn .2s ease 0s
 	font-weight: 300
-	z-index: 9
+	z-index: 10
 
 .FlyModal
 	width: 600px


### PR DESCRIPTION
This PR fixes a bug that was caused by a bug fix in tooltip to a bug caused by a bad bug fix in popup to a bug caused by a z-index there. We've been bumping z-indexes and forgot this one :/ I also:

- Fixed a problem with the RadioBlock outline on hover with > 2 options
- Added a `selectedIcon` to `Flydropdown` for Cloud Backups - will just plop an icon to the left of the trigger TextButton, no real styles added
- Added a `disableStyle` to the `FlyDropdown` trigger `textButton`. Note it won't disable the whole Flydropdown, just make it look disabled.
- Refactired BasicInput to a function component and added `autofocus` capability with Refs!