### PR TITLE
feat: upgrade url-parse and remove it from package json

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,8 +27,7 @@
     "react-resize-observer": "^1.1.1",
     "react-router-dom": "^5.0.1",
     "react-truncate-markup": "^3.0.0",
-    "untildify": "^4.0.0",
-    "url-parse": "^1.4.4"
+    "untildify": "^4.0.0"
   },
   "typescript": {
     "definition": "dist/typings.d.ts"
@@ -79,7 +78,6 @@
     "@types/react-modal": "^3.6.0",
     "@types/react-router-dom": "^5.0.1",
     "@types/resize-observer-browser": "^0.1.6",
-    "@types/url-parse": "^1.4.2",
     "@typescript-eslint/eslint-plugin": "^5.14.0",
     "@typescript-eslint/parser": "^5.14.0",
     "babel-loader": "^8.1.0",

--- a/src/add-styles.ts
+++ b/src/add-styles.ts
@@ -1,34 +1,29 @@
 import * as path from 'path';
 import * as fs from 'fs';
-import urlParse from 'url-parse';
 
 const isStylesheetLoaded = (href: string) => {
+	// eslint-disable-next-line no-restricted-syntax
+	for (const stylesheet of document.styleSheets) {
+		if (stylesheet.href) {
+			const parsedURL = new URL(stylesheet.href);
 
-	for ( const stylesheet of document.styleSheets ) {
-		if (!stylesheet.href) {
-			continue;
-		}
+			try {
+				const a = fs.realpathSync(path.resolve(href));
+				const b = fs.realpathSync(path.resolve(decodeURI(parsedURL.pathname)));
 
-		const parsedURL = urlParse(stylesheet.href);
-
-		try {
-			const a = fs.realpathSync(path.resolve(href));
-			const b = fs.realpathSync(path.resolve(decodeURI(parsedURL.pathname)));
-
-			if (a === b) {
-				return true;
+				if (a === b) {
+					return true;
+				}
+			} catch (e) {
+				console.error(e);
 			}
-		} catch (e) {
-			console.error(e);
 		}
 	}
 
 	return false;
-
 };
 
-export default function () {
-
+const addStyles = () => {
 	/* Do not inject styles on Styleguide */
 	if (!process) {
 		return;
@@ -40,12 +35,14 @@ export default function () {
 		return;
 	}
 
-	const link = document.createElement( 'link' );
+	const link = document.createElement('link');
 
 	link.href = stylesheetPath;
 	link.type = 'text/css';
 	link.rel = 'stylesheet';
 
-	const head = document.getElementsByTagName( 'head' )[0];
-	head.insertBefore( link, head.firstChild );
-}
+	const head = document.getElementsByTagName('head')[0];
+	head.insertBefore(link, head.firstChild);
+};
+
+export default addStyles;

--- a/yarn.lock
+++ b/yarn.lock
@@ -14715,9 +14715,9 @@ url-loader@^4.0.0:
     schema-utils "^2.6.5"
 
 url-parse@^1.4.3, url-parse@^1.4.4:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.5.0.tgz#90aba6c902aeb2d80eac17b91131c27665d5d828"
-  integrity sha512-9iT6N4s93SMfzunOyDPe4vo4nLcSu1yq0IQK1gURmjm8tQNlM6loiuCRrKG1hHGXfB2EWd6H4cGi7tGdaygMFw==
+  version "1.5.9"
+  resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.5.9.tgz#05ff26484a0b5e4040ac64dcee4177223d74675e"
+  integrity sha512-HpOvhKBvre8wYez+QhHcYiVvVmeF6DVnuSOOPhe3cTum3BnqHhvKaZm8FU5yTiOu/Jut2ZpB2rA/SbBA1JIGlQ==
   dependencies:
     querystringify "^2.1.1"
     requires-port "^1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3185,11 +3185,6 @@
   resolved "https://registry.yarnpkg.com/@types/untildify/-/untildify-3.0.0.tgz#cd3e6624e46ccf292d3823fb48fa90dda0deaec0"
   integrity sha512-FTktI3Y1h+gP9GTjTvXBP5v8xpH4RU6uS9POoBcGy4XkS2Np6LNtnP1eiNNth4S7P+qw2c/rugkwBasSHFzJEg==
 
-"@types/url-parse@^1.4.2":
-  version "1.4.3"
-  resolved "https://registry.yarnpkg.com/@types/url-parse/-/url-parse-1.4.3.tgz#fba49d90f834951cb000a674efee3d6f20968329"
-  integrity sha512-4kHAkbV/OfW2kb5BLVUuUMoumB3CP8rHqlw48aHvFy5tf9ER0AfOonBlX29l/DD68G70DmyhRlSYfQPSYpC5Vw==
-
 "@types/webpack-env@^1.15.3":
   version "1.16.0"
   resolved "https://registry.yarnpkg.com/@types/webpack-env/-/webpack-env-1.16.0.tgz#8c0a9435dfa7b3b1be76562f3070efb3f92637b4"
@@ -14714,7 +14709,7 @@ url-loader@^4.0.0:
     mime-types "^2.1.26"
     schema-utils "^2.6.5"
 
-url-parse@^1.4.3, url-parse@^1.4.4:
+url-parse@^1.4.3:
   version "1.5.9"
   resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.5.9.tgz#05ff26484a0b5e4040ac64dcee4177223d74675e"
   integrity sha512-HpOvhKBvre8wYez+QhHcYiVvVmeF6DVnuSOOPhe3cTum3BnqHhvKaZm8FU5yTiOu/Jut2ZpB2rA/SbBA1JIGlQ==


### PR DESCRIPTION
This PR removes the `url-parse` package from `package.json` (it's still installed as a dependency), and replaces it with the newer `URL` api available in browsers. Also includes a commit from dependabot to upgrade to a new minor version.