### PR TITLE
fix: fix react router typings with tsconfig path

### DIFF
--- a/package.json
+++ b/package.json
@@ -136,7 +136,6 @@
     "fstream": ">=1.0.12",
     "tar": ">=2.2.2",
     "lodash": ">=4.17.13",
-    "terser-webpack-plugin": ">=2.2.2",
-	"react-router-dom": "^5.0.1"
+    "terser-webpack-plugin": ">=2.2.2"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
 		"experimentalDecorators": true,
 		"esModuleInterop": true,
 		"target": "es2015",
+		// see https://github.com/storybookjs/storybook/issues/16837#issuecomment-984006866
 		"baseUrl": ".",
 		"paths": {
 			"react-router": ["node_modules/@types/react-router"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,11 @@
 		"strict": true,
 		"experimentalDecorators": true,
 		"esModuleInterop": true,
-		"target": "es2015"
+		"target": "es2015",
+		"baseUrl": ".",
+		"paths": {
+			"react-router": ["node_modules/@types/react-router"]
+		}
 	},
 	"include": [
 		"./src/**/*"


### PR DESCRIPTION
See this[ github issue for context on this fix](https://github.com/storybookjs/storybook/issues/16837#issuecomment-984006866). Essentially, Storybook 6.4 depends on `react-router-dom` v6, which includes a dependency on an updated version of `react-router` that includes typings. We're relying on a version that requires us to use `@types/react-router`, but the types in that package don't take precedence - `react-router` v6's `index.d.ts` does. 

The best fix would be to upgrade `react-router-dom`, but that would require more refactoring and more updates in Local core and maybe even add-ons. We could also update storybook to `v6.5`, but that is still in beta and will probably be a larger update with more problems. So until then, this should fix it, especially since we aren't compiling any code in `node_modules` that would depend on v6 typings afaik. 