### PR TITLE
feat: add resolution for trim package

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,6 +123,7 @@
     "webpack-node-externals": "^1.7.2"
   },
   "resolutions": {
+	"trim": "^0.0.3",
     "@types/react": "^16.14.26",
     "fstream": ">=1.0.12",
     "tar": ">=2.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12724,10 +12724,10 @@ trim-trailing-lines@^1.0.0:
   resolved "https://registry.yarnpkg.com/trim-trailing-lines/-/trim-trailing-lines-1.1.4.tgz#bd4abbec7cc880462f10b2c8b5ce1d8d1ec7c2c0"
   integrity sha512-rjUWSqnfTNrjbB9NQWfPMH/xRK1deHeGsHoVfpxJ++XeYXE0d6B1En37AHfw3jtfTU7dzMzZL2jjpe8Qb5gLIQ==
 
-trim@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/trim/-/trim-0.0.1.tgz#5858547f6b290757ee95cccc666fb50084c460dd"
-  integrity sha1-WFhUf2spB1fulczMZm+1AITEYN0=
+trim@0.0.1, trim@^0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/trim/-/trim-0.0.3.tgz#05243a47a3a4113e6b49367880a9cca59697a20b"
+  integrity sha512-h82ywcYhHK7veeelXrCScdH7HkWfbIT1D/CgYO+nmDarz3SGNssVBMws6jU16Ga60AJCRAvPV6w6RLuNerQqjg==
 
 trough@^1.0.0:
   version "1.0.5"


### PR DESCRIPTION
This PR adds a resolution for the `trim` package to use `^0.0.3`, fixing a dependabot security issue. Storybook still working, which is why this package was here in the first place.