### PR TITLE
feat: remove forked memoize-one dependency in favor of regular package

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@getflywheel/memoize-one-ts": "^0.0.2",
     "@popperjs/core": "^2.9.2",
     "@types/lz-string": "^1.3.34",
     "@types/untildify": "^3.0.0",
@@ -19,6 +18,7 @@
     "highlight.js": "^10.4.1",
     "lodash.isequal": "^4.5.0",
     "lz-string": "^1.4.4",
+    "memoize-one": "^6.0.0",
     "react-animate-height": "^2.0.23",
     "react-lowlight": "^2.0.0",
     "react-markdown": "^4.0.3",
@@ -123,7 +123,7 @@
     "webpack-node-externals": "^1.7.2"
   },
   "resolutions": {
-	"trim": "^0.0.3",
+    "trim": "^0.0.3",
     "@types/react": "^16.14.26",
     "fstream": ">=1.0.12",
     "tar": ">=2.2.2",

--- a/src/components/modules/VirtualTable/helpers/VirtualTableHelper.ts
+++ b/src/components/modules/VirtualTable/helpers/VirtualTableHelper.ts
@@ -1,11 +1,9 @@
+/* eslint-disable class-methods-use-this */
 import * as React from 'react';
+import memoizeOne from 'memoize-one';
 import * as styles from '../VirtualTable.scss';
-import {
-	IVirtualTableProps,
-	VirtualTableDataType, VirtualTableHeaderObjectType,
-} from '../VirtualTable';
+import { IVirtualTableProps, VirtualTableDataType, VirtualTableHeaderObjectType } from '../VirtualTable';
 import { IVirtualTableRowProps } from '../components/VirtualTableRow';
-import { memoizeOne } from '@getflywheel/memoize-one-ts';
 
 export interface VirtualTableHelperCalculations {
 	columnClassNames: VirtualTableHeaderObjectType['className'][];
@@ -16,9 +14,8 @@ export interface VirtualTableHelperCalculations {
 }
 
 export class VirtualTableHelper {
-
-	public getRowHeight (ref: React.RefObject<HTMLTableElement>): Promise<number | null> {
-		return new Promise(resolve => {
+	public getRowHeight(ref: React.RefObject<HTMLTableElement>): Promise<number | null> {
+		return new Promise((resolve) => {
 			const rowHeight: number | null = this._getRowHeight(ref);
 
 			// if value is found, then return it
@@ -35,38 +32,43 @@ export class VirtualTableHelper {
 		});
 	}
 
-	public _getRowHeight (ref: React.RefObject<HTMLTableElement>): number | null {
+	public _getRowHeight(ref: React.RefObject<HTMLTableElement>): number | null {
 		if (ref.current) {
 			// get table descendent for this specific instance of the component
 			// note: can't set ref directly on table because it isn't available in time for 'onDid...' events
 			const tableEl = ref.current.querySelector(`.${styles.VirtualTable}`);
 
 			if (tableEl) {
-				const cssRowHeight: number = parseInt(getComputedStyle(tableEl).getPropertyValue(styles.CSSVARNAME_ROWHEIGHT));
+				const cssRowHeight: number = parseInt(
+					getComputedStyle(tableEl).getPropertyValue(styles.CSSVARNAME_ROWHEIGHT)
+				);
 
-				if(isNaN(cssRowHeight)) {
+				if (isNaN(cssRowHeight)) {
 					return null;
 				}
 
 				return cssRowHeight;
 			}
-			else {
-				// todo - crum: must throw error
-			}
-		}
-		else {
+
+			// todo - crum: must throw error
+		} else {
 			// todo - crum: must throw error
 		}
 
 		return null;
 	}
 
-	@memoizeOne
-	public getDataCalculationsMemoized (props: IVirtualTableProps): VirtualTableHelperCalculations {
-		const headersNormalized = this.normalizeHeadersMemoized(props.headers);
-		const dataKeyToColIndexLookup = this.createColumnIndexLookupMemoized(props.data, headersNormalized);
-		const dataKeysOrderedColumns = Array.from((dataKeyToColIndexLookup.keys() as any) as (string | number)[]);
-		const {columnFlexWidths, columnClassNames} = this.getColumnFlexWidthsMemoized(props.headers, dataKeysOrderedColumns);
+	public getDataCalculationsMemoized = memoizeOne((props: IVirtualTableProps): VirtualTableHelperCalculations => {
+		const headersNormalized = VirtualTableHelper.normalizeHeadersMemoized(props.headers);
+		const dataKeyToColIndexLookup = VirtualTableHelper.createColumnIndexLookupMemoized(
+			props.data,
+			headersNormalized
+		);
+		const dataKeysOrderedColumns = Array.from(dataKeyToColIndexLookup.keys() as any as (string | number)[]);
+		const { columnFlexWidths, columnClassNames } = VirtualTableHelper.getColumnFlexWidthsMemoized(
+			props.headers,
+			dataKeysOrderedColumns
+		);
 
 		return {
 			columnFlexWidths,
@@ -74,116 +76,127 @@ export class VirtualTableHelper {
 			dataKeyToColIndexLookup,
 			headersNormalized,
 			columnClassNames,
-		}
-	}
+		};
+	});
 
-	@memoizeOne
-	public getColumnFlexWidthsMemoized (headers: IVirtualTableProps['headers'], dataKeysOrderedColumns: VirtualTableHelperCalculations['dataKeysOrderedColumns']) {
-		if (!headers || (headers.length && typeof(headers[0]) === 'string')) {
-			return {columnClassNames: [], columnFlexWidths: []};
-		}
-
-		const columnClassNames: string[] = [];
-		const columnFlexWidths: string[] = [];
-		let header: VirtualTableHeaderObjectType;
-		let key: number;
-
-		for (const index in headers) {
-			header = headers[index] as VirtualTableHeaderObjectType;
-			key = dataKeysOrderedColumns.indexOf(header.key);
-
-			// if flex is defined for the header, the key is valid, and the key exists as a value in the list of ordered column keys
-			if (header.flex && header.key && dataKeysOrderedColumns.includes(header.key)) {
-				// set flex string value to the ordered index so it matches the column order
-				columnFlexWidths[key] = header.flex;
+	public static getColumnFlexWidthsMemoized = memoizeOne(
+		(
+			headers: IVirtualTableProps['headers'],
+			dataKeysOrderedColumns: VirtualTableHelperCalculations['dataKeysOrderedColumns']
+		) => {
+			if (!headers || (headers.length && typeof headers[0] === 'string')) {
+				return { columnClassNames: [], columnFlexWidths: [] };
 			}
 
-			// if flex is defined for the header, the key is valid, and the key exists as a value in the list of ordered column keys
-			if (header.className && header.className && dataKeysOrderedColumns.includes(header.key)) {
-				// set flex string value to the ordered index so it matches the column order
-				columnClassNames[key] = header.className || '';
+			const columnClassNames: string[] = [];
+			const columnFlexWidths: string[] = [];
+			let header: VirtualTableHeaderObjectType;
+			let key: number;
+
+			for (const index in headers) {
+				header = headers[index] as VirtualTableHeaderObjectType;
+				key = dataKeysOrderedColumns.indexOf(header.key);
+
+				// if flex is defined for the header, the key is valid, and the key exists as a value in the list of ordered column keys
+				if (header.flex && header.key && dataKeysOrderedColumns.includes(header.key)) {
+					// set flex string value to the ordered index so it matches the column order
+					columnFlexWidths[key] = header.flex;
+				}
+
+				// if flex is defined for the header, the key is valid, and the key exists as a value in the list of ordered column keys
+				if (header.className && header.className && dataKeysOrderedColumns.includes(header.key)) {
+					// set flex string value to the ordered index so it matches the column order
+					columnClassNames[key] = header.className || '';
+				}
 			}
+
+			return { columnFlexWidths, columnClassNames };
 		}
+	);
 
-		return {columnFlexWidths, columnClassNames};
-	}
+	public static normalizeHeadersMemoized = memoizeOne(
+		(headers: IVirtualTableProps['headers']): VirtualTableDataType | undefined => {
+			// if undefined or array of header strings
+			if (!headers || (headers.length && typeof headers[0] === 'string')) {
+				return headers;
+			}
 
-	@memoizeOne
-	public normalizeHeadersMemoized (headers: IVirtualTableProps['headers']): VirtualTableDataType | undefined {
-		// if undefined or array of header strings
-		if (!headers || (headers.length && typeof(headers[0]) === 'string')) {
-			return headers;
+			const headersNormalized: VirtualTableHelperCalculations['headersNormalized'] = (headers || []).reduce(
+				(accumulator: { [key: string]: any }, currentValue: any) => {
+					accumulator[currentValue.key] = currentValue.value;
+					return accumulator;
+				},
+				{}
+			);
+
+			return headersNormalized;
 		}
-
-		const headersNormalized: VirtualTableHelperCalculations['headersNormalized'] = (headers || []).reduce(
-			(accumulator: {[key: string]: any}, currentValue: any) => {
-				accumulator[currentValue.key] = currentValue.value;
-				return accumulator;
-			},
-			{},
-		);
-
-		return headersNormalized;
-	}
+	);
 
 	// map data keys (object strings or array indices) to column order index (number)
 	// note: the lookup is based off the keys in the first data item and any deviations from that won't be accounted for
-	@memoizeOne
-	public createColumnIndexLookupMemoized (data: IVirtualTableProps['data'], headersNormalized: VirtualTableDataType | undefined): VirtualTableHelperCalculations['dataKeyToColIndexLookup'] {
-		const dataKeyToColIndexLookup: VirtualTableHelperCalculations['dataKeyToColIndexLookup'] = new Map();
+	public static createColumnIndexLookupMemoized = memoizeOne(
+		(
+			data: IVirtualTableProps['data'],
+			headersNormalized: VirtualTableDataType | undefined
+		): VirtualTableHelperCalculations['dataKeyToColIndexLookup'] => {
+			const dataKeyToColIndexLookup: VirtualTableHelperCalculations['dataKeyToColIndexLookup'] = new Map();
 
-		if (data && data.length) {
-			let firstRowData: any[] | {[key: string]: any};
+			if (data && data.length) {
+				let firstRowData: any[] | { [key: string]: any };
 
-			if (headersNormalized) {
-				firstRowData = headersNormalized;
-			}
-			else {
-				firstRowData = data[0];
-			}
+				if (headersNormalized) {
+					firstRowData = headersNormalized;
+				} else {
+					firstRowData = data[0];
+				}
 
-			// if data is array-based
-			if (Array.isArray(firstRowData)) {
-				for (let i = 0 ; i < firstRowData.length ; i++) {
-					dataKeyToColIndexLookup.set(i, i);
+				// if data is array-based
+				if (Array.isArray(firstRowData)) {
+					for (let i = 0; i < firstRowData.length; i++) {
+						dataKeyToColIndexLookup.set(i, i);
+					}
+				}
+				// else data is object-based
+				else {
+					let i: number = 0;
+
+					for (const key in firstRowData) {
+						dataKeyToColIndexLookup.set(key, i++);
+					}
 				}
 			}
-			// else data is object-based
-			else {
-				let i: number = 0;
 
-				for (const key in firstRowData) {
-					dataKeyToColIndexLookup.set(key, i++);
-				}
-			}
+			return dataKeyToColIndexLookup;
 		}
+	);
 
-		return dataKeyToColIndexLookup;
-	}
-
-	public getOrderedData (rowData: VirtualTableDataType, headers: IVirtualTableProps['headers'], dataKeyToColIndexLookup: VirtualTableHelperCalculations['dataKeyToColIndexLookup']) {
+	public getOrderedData(
+		rowData: VirtualTableDataType,
+		headers: IVirtualTableProps['headers'],
+		dataKeyToColIndexLookup: VirtualTableHelperCalculations['dataKeyToColIndexLookup']
+	) {
 		const rowDataOrdered: IVirtualTableRowProps['rowDataOrdered'] = [];
 
 		if (Array.isArray(rowData)) {
-			for (let i = 0 ; i < rowData.length ; i++) {
+			for (let i = 0; i < rowData.length; i++) {
 				if (dataKeyToColIndexLookup.has(i)) {
 					rowDataOrdered[dataKeyToColIndexLookup.get(i) as any] = rowData[i];
 				}
 			}
-		}
-		else {
-			if (headers) {
-				for (let i = 0 ; i < headers.length ; i++) {
-					const key: string = typeof(headers[i]) === 'string' ? headers[i] as string : (headers[i] as {[key: string]: string}).key;
-					rowDataOrdered.push(rowData[key] || '');
-				}
+		} else if (headers) {
+			for (let i = 0; i < headers.length; i++) {
+				const key: string =
+					typeof headers[i] === 'string'
+						? (headers[i] as string)
+						: (headers[i] as { [key: string]: string }).key;
+				rowDataOrdered.push(rowData[key] || '');
 			}
-			else {
-				// loop over keys (doesn't matter if it's an object or array)
-				for (const key in rowData) {
-					if (dataKeyToColIndexLookup.has(key)) {
-						rowDataOrdered[dataKeyToColIndexLookup.get(key) as any] = rowData[key];
-					}
+		} else {
+			// loop over keys (doesn't matter if it's an object or array)
+			for (const key in rowData) {
+				if (dataKeyToColIndexLookup.has(key)) {
+					rowDataOrdered[dataKeyToColIndexLookup.get(key) as any] = rowData[key];
 				}
 			}
 		}
@@ -191,7 +204,7 @@ export class VirtualTableHelper {
 		// check for holes if array-based object
 		if (Array.isArray(rowData) && rowData.length < dataKeyToColIndexLookup.size) {
 			// loop over missing indices
-			for (let i: number = rowData.length ; i < dataKeyToColIndexLookup.size ; i++) {
+			for (let i: number = rowData.length; i < dataKeyToColIndexLookup.size; i++) {
 				// add filler empty string so empty column will be rendered
 				// note: this is less intelligent than object-based as it data may be shifted over if accidentally missing items in data array
 				rowDataOrdered[i] = '';
@@ -201,8 +214,8 @@ export class VirtualTableHelper {
 		// note: this should will only happen for object-based data that is missing a property
 		// note: it's important to account for this here because 'Array.map' will skip over these items and what's rendered may be unexpected and columns not align
 		else if (rowDataOrdered.includes(undefined)) {
-			for (let i = rowDataOrdered.length - 1 ; i > -1 ; i--) {
-				if (typeof(rowDataOrdered[i]) === "undefined") {
+			for (let i = rowDataOrdered.length - 1; i > -1; i--) {
+				if (typeof rowDataOrdered[i] === 'undefined') {
 					// replace with empty string so empty column will be rendered
 					rowDataOrdered[i] = '';
 				}
@@ -211,5 +224,4 @@ export class VirtualTableHelper {
 
 		return rowDataOrdered;
 	}
-
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1161,11 +1161,6 @@
   resolved "https://registry.yarnpkg.com/@gar/promisify/-/promisify-1.1.3.tgz#555193ab2e3bb3b6adc3d551c9c030d9e860daf6"
   integrity sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==
 
-"@getflywheel/memoize-one-ts@^0.0.2":
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/@getflywheel/memoize-one-ts/-/memoize-one-ts-0.0.2.tgz#6578948abf140f568736a92ec0940b7a81d8f773"
-  integrity sha512-/GoWclh5ImAx0DJ0CXoASxiEXAP/iL+ZRzKrrQmnjlfWPdJE/t2F4FxagBLccgPZvxX9Ror1M4zHBILllpV7AQ==
-
 "@humanwhocodes/config-array@^0.9.2":
   version "0.9.5"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.9.5.tgz#2cbaf9a89460da24b5ca6531b8bbfc23e1df50c7"
@@ -9185,6 +9180,11 @@ memfs@^3.1.2, memfs@^3.4.1:
   integrity sha512-1c9VPVvW5P7I85c35zAdEr1TD5+F11IToIHIlrVIcflfnzPkJa0ZoYEoEdYDP8KgPFoSZ/opDrUsAoZWym3mtw==
   dependencies:
     fs-monkey "1.0.3"
+
+memoize-one@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-6.0.0.tgz#b2591b871ed82948aee4727dc6abceeeac8c1045"
+  integrity sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw==
 
 memoizerific@^1.11.3:
   version "1.11.3"


### PR DESCRIPTION
This PR removes a dependency on @getflywheel/memoize-one-ts ([see that repo here](https://github.com/getflywheel/memoize-one-ts)). Looks like we forked that repo in order to rewrite it in Typescript and add decorators. However, the current version is mostly Typescript, so I just removed the decorator syntax in favor of wrapped arrow functions.

Seems like `VirtualList` and `VirtualTable` still work fine.