### PR TITLE
fix: scroll to option when navigating via keyboard

### DIFF
--- a/src/components/inputs/Combobox/Combobox.scss
+++ b/src/components/inputs/Combobox/Combobox.scss
@@ -34,7 +34,7 @@
 		position: absolute;
 		margin-left: 15px;
 		opacity: 0;
-		transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+		transition: opacity none;
 	}
 
 	.Combobox__BasicInput {
@@ -44,7 +44,7 @@
 		input {
 			padding: 0;
 			height: var(--inputHeight);
-			transition: padding-left 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+			transition: padding-left none;
 			padding-left: 20px;
 			padding-right: 42px;
 		}
@@ -77,11 +77,13 @@
 		z-index: 5;
 
 		.Combobox__SearchIcon {
+			transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
 			opacity: 1;
 		}
 
 		.Combobox__BasicInput {
 			input {
+				transition: padding-left 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
 				padding-left: 45px;
 				border-radius: 4px 4px 0 0;
 			}

--- a/src/components/inputs/Combobox/Combobox.tsx
+++ b/src/components/inputs/Combobox/Combobox.tsx
@@ -229,7 +229,7 @@ const Combobox = (props: IComboboxProps) => {
 	const [currentValue, setCurrentValue] = useState(value);
 	const [filter, setFilter] = useState('');
 	const [shouldFilter, setShouldFilter] = useState(false);
-	const [maxHeight, setMaxHeight] = useState<number | undefined>(undefined);
+	const [maxHeight, setMaxHeight] = useState<number>(0);
 
 	// SORT AND FILTER:
 
@@ -294,9 +294,7 @@ const Combobox = (props: IComboboxProps) => {
 
 	const handleResize = () => {
 		setMaxHeight(
-			containerRef.current
-				? window.innerHeight - 75 - containerRef.current.getBoundingClientRect().top
-				: undefined
+			containerRef.current ? window.innerHeight - 75 - containerRef.current.getBoundingClientRect().top : 0
 		);
 	};
 
@@ -557,6 +555,11 @@ const Combobox = (props: IComboboxProps) => {
 				onKeyDown={() => {}}
 				onClick={(e) => selectOption(e, option.value)}
 				onMouseEnter={() => setFocusedIndex(filteredOptions.indexOf(option))}
+				ref={(el) => {
+					if (isFocused) {
+						el?.scrollIntoView({ block: 'nearest', inline: 'nearest', behavior: 'smooth' });
+					}
+				}}
 			>
 				{renderItem(option, true)}
 			</div>


### PR DESCRIPTION
We switched up the focus approach when navigating via keyboard in Combobox, resulting in keyboard navigation that focused/hovered options without scrolling to them in a scrollable dropdown. I added a simple solution of using a callback ref to get access to the DOM element on every render, scrolling to the option if it is focused. 

I also changed the default `maxHeight` to 0 instead of undefined to prevent a glitch on initial render that caused the dropdown to fully expand before getting the `maxHeight` applied. 