### PR TITLE
fix: address combobox product review comments from Tyson

### DIFF
--- a/src/components/icons/svgs/CheckmarkIcon.tsx
+++ b/src/components/icons/svgs/CheckmarkIcon.tsx
@@ -5,16 +5,11 @@ import withIconSvg from '../helpers/withIconSvg';
  * Note: need to export interface to avoid error in Icons namespace.
  */
 export interface Props {
-	size?: 's' | 'l',
+	size?: 's' | 'l';
 }
 
 const renderIconSmall = (props: Props) => (
-	<svg
-		height="8"
-		viewBox="0 0 10 8"
-		width="10"
-		{...props}
-	>
+	<svg height="8" viewBox="0 0 10 8" width="10" {...props}>
 		<path
 			d="M39,20a1,1,0,0,1-.707-.293l-3-3a1,1,0,1,1,1.414-1.414l2.226,2.226,4.3-5.159a1,1,0,0,1,1.538,1.28l-5,6a1,1,0,0,1-.724.359Z"
 			transform="translate(-35 -12)"
@@ -24,47 +19,33 @@ const renderIconSmall = (props: Props) => (
 );
 
 const renderIconLarge = (props: Props) => (
-	<svg
-		height="11"
-		viewBox="0 0 14.986 11.0563"
-		width="15"
-		{...props}
-	>
+	<svg height="11" viewBox="0 0 14.986 11.0563" width="15" {...props}>
 		<path d="M5.5 11.056a1.003 1.003 0 0 1-.71-.297L.29 6.203A1 1 0 1 1 1.71 4.796l3.77 3.818L13.256.316a1 1 0 0 1 1.46 1.367L6.23 10.74a1.003 1.003 0 0 1-.717.316z" />
 	</svg>
 );
 
-const Icon: React.FC<Props> = (props) => (
-	({
-		'l': renderIconLarge(props),
-		's': renderIconSmall(props),
-	} as {[key in NonNullable<Props['size']>]: JSX.Element})[props.size!]
-		// @ts-ignore
-		|| (!console.log(`Invalid prop option passed to switch statement for this icon with props`, props)
-	)
-);
+const Icon: React.FC<Props> = (props) =>
+	((
+		{
+			l: renderIconLarge(props),
+			s: renderIconSmall(props),
+		} as { [key in NonNullable<Props['size']>]: JSX.Element }
+	)[props.size!] ||
+	// @ts-ignore
+	!console.log(`Invalid prop option passed to switch statement for this icon with props`, props));
 
 Icon.defaultProps = {
 	size: 's',
 } as Partial<Props>;
 
-export default withIconSvg<Props>(
-	Icon,
-	true,
-	{
-		additionalProps: [
-			{
-				propName: 'size',
-				type: 'select',
-				options: ['s', 'l'], // todo: how to automatically get these options???
-				default: Icon.defaultProps.size,
-			},
-		],
-		tags: [
-			'checkbox',
-			'complete',
-			'done',
-			'yes',
-		],
-	},
-);
+export default withIconSvg<Props>(Icon, true, {
+	additionalProps: [
+		{
+			propName: 'size',
+			type: 'select',
+			options: ['s', 'l'], // todo: how to automatically get these options???
+			default: Icon.defaultProps.size,
+		},
+	],
+	tags: ['checkbox', 'complete', 'done', 'yes'],
+});

--- a/src/components/inputs/Combobox/Combobox.scss
+++ b/src/components/inputs/Combobox/Combobox.scss
@@ -146,6 +146,12 @@
 
 		@include cursorPointer;
 
+		&.Combobox__NoResults {
+			filter: none;
+			opacity: 1;
+			@include theme-color-gray-else-gray25;
+		}
+
 		.Combobox__Right {
 			margin: 0 0 0 auto;
 

--- a/src/components/inputs/Combobox/Combobox.tsx
+++ b/src/components/inputs/Combobox/Combobox.tsx
@@ -31,6 +31,8 @@ export interface ComboboxOption {
 	optionGroup?: string | null;
 	/** Optional secondary text to be displayed to the right of the option labl */
 	secondaryText?: React.ReactNode;
+	/** Classname to be applied to option */
+	className?: string;
 }
 
 /**
@@ -271,7 +273,7 @@ const Combobox = (props: IComboboxProps) => {
 		if (shouldFilter && filter) {
 			const fuse = new Fuse(result, {
 				keys: ['label'],
-				threshold: 0.5,
+				threshold: 0.2,
 			});
 
 			result = fuse.search(filter).map((option) => option.item);
@@ -282,6 +284,7 @@ const Combobox = (props: IComboboxProps) => {
 						label: noResultsMessage,
 						value: noResultsMessage,
 						disabled: true,
+						className: styles.Combobox__NoResults,
 					},
 				];
 			}
@@ -486,8 +489,9 @@ const Combobox = (props: IComboboxProps) => {
 				)}
 				{showCheck && option.value === currentValue && (
 					<CheckmarkIcon
-						width={15}
-						height={15}
+						width={12}
+						height={12}
+						size="l"
 						key={`${id}-${option.value}-checked`}
 						className={styles.Combobox__Check}
 					/>
@@ -547,7 +551,7 @@ const Combobox = (props: IComboboxProps) => {
 				tabIndex={-1}
 				key={`${id}-${option.value}`}
 				data-value={option.value}
-				className={classnames(styles.Combobox_Option, {
+				className={classnames(styles.Combobox_Option, option.className, {
 					[styles.Combobox_Option__Striped]: striped,
 					[styles.Combobox_Option__Focus]: isFocused && !option.disabled,
 					__Disabled: option.disabled,


### PR DESCRIPTION
This PR: 

- Adjusts the threshold of Fuse.js's search to match the Connect Tab in core
- Adjusts checkmark icon to be the "large" version - this makes it look skinnier, which matches FlySelect
- Adjusts colors for the no results option
- Adds optional class name field to the `ComboboxOption` interface