### PR TITLE
fix: reenable aria-checked on radioblock due to container component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getflywheel/local-components",
-  "version": "17.6.0",
+  "version": "17.6.1-beta",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/getflywheel/local-components.git"

--- a/src/common/structures/IReactComponentProps.ts
+++ b/src/common/structures/IReactComponentProps.ts
@@ -15,4 +15,5 @@ export default interface IReactComponentProps {
 	ref?: any;
 	role?: string;
 	tabIndex?: number;
+	'aria-checked'?: boolean;
 }

--- a/src/components/inputs/RadioBlock/RadioBlock.tsx
+++ b/src/components/inputs/RadioBlock/RadioBlock.tsx
@@ -66,6 +66,7 @@ const RadioBlockItem: React.FC<IRadioBlockItemProps> = (props: IRadioBlockItemPr
 		<Container
 			{...container}
 			role="checkbox"
+			id={value ?? undefined}
 			aria-checked={selected}
 			tabIndex={selected ? -1 : 0}
 			onClick={handleClick}

--- a/src/components/inputs/RadioBlock/RadioBlock.tsx
+++ b/src/components/inputs/RadioBlock/RadioBlock.tsx
@@ -163,7 +163,7 @@ const RadioBlock: React.FC<IProps> = (props: IProps) => {
 					[styles.RadioBlock__DirectionVert]: direction === 'vert',
 					[styles.RadioBlock__Readonly]: readonly,
 				})}
-				id={id}
+				id={`RadioBlock-${id}`}
 				style={style}
 				{...otherProps}
 			>

--- a/src/components/modules/Container/Container.tsx
+++ b/src/components/modules/Container/Container.tsx
@@ -58,7 +58,7 @@ export const Container = React.forwardRef((props: IContainerProps, ref: React.Fo
 			onKeyDown: props.onKeyDown,
 			tabIndex: props.tabIndex,
 			ref,
-			'aira-checked': props['aria-checked'],
+			'aria-checked': props['aria-checked'],
 		})
 	);
 });

--- a/src/components/modules/Container/Container.tsx
+++ b/src/components/modules/Container/Container.tsx
@@ -40,6 +40,7 @@ export const Container = React.forwardRef((props: IContainerProps, ref: React.Fo
 			onClick={props.onClick}
 			onKeyDown={props.onKeyDown}
 			tabIndex={props.tabIndex}
+			aria-checked={props['aria-checked']}
 			ref={ref}
 		>
 			{props.children}
@@ -57,6 +58,7 @@ export const Container = React.forwardRef((props: IContainerProps, ref: React.Fo
 			onKeyDown: props.onKeyDown,
 			tabIndex: props.tabIndex,
 			ref,
+			'aira-checked': props['aria-checked'],
 		})
 	);
 });


### PR DESCRIPTION
We need to make RadioBlock more accessible. In the meantime, we need it to be selectable by PlayWright, to easily understand whether an option is selected or not via selectors. 

This PR re-enables the `aria-checked` attribute, which was originally being passed until I changed the wrapper component to `Container`. 