### PR TITLE
feat: tweak BannerCarousel to shore up bugs when implemented

### DIFF
--- a/src/components/alerts/BannerCarousel/BannerCarouselExample.tsx
+++ b/src/components/alerts/BannerCarousel/BannerCarouselExample.tsx
@@ -50,7 +50,7 @@ const BannerCarouselExample = () => {
 			const id = `banner-${numBanners + 1}`;
 			prev.push(bannerFactory(id, () => dismissBanner(id), numBanners));
 			setNumBanners((old) => old + 1);
-			return prev;
+			return [...prev];
 		});
 	};
 


### PR DESCRIPTION
This PR adds a few tweaks that solve a few bugs that cropped up while implementing the `BannerCarousel` with our MobX banner store in Local Core. 

Namely, banners were being added/removed so quickly that state wasn't getting set in time, which means `useEffect`s weren't seeing changes, and things like height weren't being properly set. I fixed this by setting the `gettingHeight` state variable inside of a `setTimeout` function - this is a hack to ensure things fire off synchronously. We can't just put the code for resetting the height inside of a function, because we're grabbing the height from a dummy DOM element that conditionally renders based on `gettingHeight`, and we need to watch for changes in that state variable to properly leverage `useLayoutEffect`. That way the right code is run at the right time - we can't do that just using functions. 

I also changed the timeout from being stored in state to a ref to hopefully prevent unwanted re-renders. 