### PR TITLE
feat: change from flex grow to width 100

### DIFF
--- a/src/components/alerts/Banner/Banner.scss
+++ b/src/components/alerts/Banner/Banner.scss
@@ -11,7 +11,7 @@
 	justify-content: space-between;
 	background: var(--Banner_Color_Background);
 	box-shadow: inset 0px -10px 10px -10px  $theme-overlay-box-shadow-light;
-	flex-grow: 1;
+	width: 100%;
 	color: $gray-dark;
 
 	.Left_Wrapper .Content a {


### PR DESCRIPTION
I was using `flex-grow: 1` on the banner to fill the banner carousel, but we can feasibly have banners without the carousel (though probably shouldn't). In that case, say it's a flex container with a column direction, the flex grow would affect the height, not the width. I should've used `width: 100%` instead.