### PR TITLE
fix: add z-index 100 to downloaderoverlay

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getflywheel/local-components",
-  "version": "17.6.1-beta.4",
+  "version": "17.6.1-beta.5",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/getflywheel/local-components.git"

--- a/src/styles/containers/SiteInfo.scss
+++ b/src/styles/containers/SiteInfo.scss
@@ -10,6 +10,7 @@
 	}
 
 	.DownloaderOverlay {
+		z-index: 100;
 		position: absolute;
 		display: flex;
 		flex-direction: column;


### PR DESCRIPTION
We are expanding the DownloaderOverlay in SiteInfo to cover the bottom bar, which has a popup element in the Live Links toggle that utilizes a z-index. 

This PR adds a z-index of 100 to the DownloaderOverlay, which I believe is one of the only reasonable use cases for z-index!