### PR TITLE
feat: update banner carousel if number of children doesnt change

### DIFF
--- a/src/components/alerts/BannerCarousel/BannerCarousel.tsx
+++ b/src/components/alerts/BannerCarousel/BannerCarousel.tsx
@@ -162,6 +162,16 @@ const BannerCarousel = (props: IReactComponentProps) => {
 		updateCurrentBanner(next);
 	};
 
+	const updateChildrenArray = (newChildrenArray: ChildrenArray) => {
+		const next = newChildrenArray[currentIndex];
+
+		setChildrenArray(newChildrenArray);
+		safeSetNextBanner(next);
+		resetHeight();
+
+		updateCurrentBanner(next);
+	};
+
 	const switchToIndex = (newIndex: number) => {
 		setSwitching(false);
 
@@ -177,6 +187,10 @@ const BannerCarousel = (props: IReactComponentProps) => {
 	};
 
 	// Handle banners being added/removed, call above functions
+	//
+	// Possible future improvement for finer control: instead of "children", pass in banners as an array of
+	// IBanner objects ({id: string, component: React.ReactNode}) and watch for added/removed ID's.
+	// Then we could replace updateChildrenArray - good for when banners change but the number of banners doesn't
 	useEffect(() => {
 		const newChildrenArray = Children.toArray(children);
 		const newNum = newChildrenArray.length;
@@ -185,19 +199,21 @@ const BannerCarousel = (props: IReactComponentProps) => {
 		const isAddingBanner = newNum > numBanners;
 		const isDismissingBanner = newNum < numBanners && currentIndex !== 0;
 		const isDismissingBannerFromFirst = newNum < numBanners && currentIndex === 0 && newNum !== 0;
-		const isDismissingLastBanner = newNum === 0 && numBanners === 1;
+		const isDismissingLastBanner = newNum === 0;
 
-		// First banner skip slide in
 		if (isAddingFirstBanner) {
 			addFirstBanner(newChildrenArray);
 		} else if (isAddingBanner) {
 			addBanner(newChildrenArray, newNum);
-		} else if (isDismissingBanner) {
-			dismissBanner(newChildrenArray, newNum);
-		} else if (isDismissingBannerFromFirst) {
-			dismissBannerFromFirst(newChildrenArray, newNum);
 		} else if (isDismissingLastBanner) {
 			dismissLastBanner();
+		} else if (isDismissingBannerFromFirst) {
+			dismissBannerFromFirst(newChildrenArray, newNum);
+		} else if (isDismissingBanner) {
+			dismissBanner(newChildrenArray, newNum);
+		} else {
+			// Banners have maybe changed, though number of banners hasn't
+			updateChildrenArray(newChildrenArray);
 		}
 	}, [children]);
 


### PR DESCRIPTION
The BannerCarousel adds or removes banners by watching for changes in the number of Children. However, it's possible that updates to children could happen so quickly (for example, in core, a banner gets added to the banner store right after gets removed), that the banner carousel never actually sees a change in the number of banners. In that case, the new banner would not be displayed, because `currentBanner` is never updated. 

I added a stopgap case that calls a function `updateChildrenArray()` - this method doesn't trigger any slide transitions, because if it did, we'd see a lot of unnecessary sliding between the same banner. Logging shows that in core, this carousel is often re-rendered with identical children due to re-renders of the parent component.

I added a note that says a possible way to avoid this (if we wanted to add sliding in for the case of changing banners but not a change in the number of banners) would be to pass in an array of objects containing an ID and the banner component. Then we could make a sorted string of ID's for example and watch for changes in that string to determine changes in the passed banners. However, I think this is good enough.

Demonstration of problem - first site should have a .dev banner:

https://user-images.githubusercontent.com/62191853/195626158-00afd744-7281-4f4c-91ed-d4104eedc925.mov

Solution - note it's not super visually pleasing because the lightning services banner takes a split second to trigger, it is what it is: 


https://user-images.githubusercontent.com/62191853/195626356-0d6c89b5-0786-4183-aecc-55bb1e149cad.mov


