### PR TITLE
feat: use @electron/remote for BrowseInput

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getflywheel/local-components",
-  "version": "17.6.1-beta.6",
+  "version": "17.6.1-beta.7",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/getflywheel/local-components.git"

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@popperjs/core": "^2.9.2",
     "@types/lz-string": "^1.3.34",
     "@types/untildify": "^3.0.0",
+	"@electron/remote": "^2.0.8",
     "classnames": "^2.2.6",
     "clipboard-copy": "^3.1.0",
     "fuse.js": "^6.6.2",

--- a/src/components/inputs/BrowseInput/BrowseInput.tsx
+++ b/src/components/inputs/BrowseInput/BrowseInput.tsx
@@ -10,7 +10,7 @@ let remote: any;
 let dialog: any;
 
 try {
-	remote = require('electron').remote;
+	remote = require('@electron/remote');
 	dialog = remote.dialog;
 } catch (e) {
 	console.warn(`Electron wasn't detected so BrowseInput won't function normally.`);

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -1,6 +1,7 @@
 const path = require('path');
 const MiniCSSExtractPlugin = require('mini-css-extract-plugin');
 const nodeExternals = require('webpack-node-externals');
+const webpack = require('webpack');
 const sharedRules = require('./webpack/shared-rules');
 
 module.exports = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1764,6 +1764,11 @@
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz#1d572bfbbe14b7704e0ba0f39b74815b84870d70"
   integrity sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==
 
+"@electron/remote@^2.0.8":
+  version "2.0.8"
+  resolved "https://registry.yarnpkg.com/@electron/remote/-/remote-2.0.8.tgz#85ff321f0490222993207106e2f720273bb1a5c3"
+  integrity sha512-P10v3+iFCIvEPeYzTWWGwwHmqWnjoh8RYnbtZAb3RlQefy4guagzIwcWtfftABIfm6JJTNQf4WPSKWZOpLmHXw==
+
 "@eslint/eslintrc@^1.2.3":
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-1.2.3.tgz#fcaa2bcef39e13d6e9e7f6271f4cc7cae1174886"


### PR DESCRIPTION
This is the only blocker for the Electron upgrade in Local Components. 

BrowseInput needs to access the remote module to launch a file Explorer dialog. I added the dependency to `package.json` - previously, `electron` didn't need to be a dependency because that was the target for webpack. However, since this is a separate package, we need the dependency - I tried just ignoring it in Webpack via that IgnorePlugin, but linking it up didn't work. 