### PR TITLE
fix: more robust tableListRow centering

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getflywheel/local-components",
-  "version": "17.6.1",
+  "version": "17.6.2-beta.1",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/getflywheel/local-components.git"

--- a/src/components/tables/TableList/TableList.sass
+++ b/src/components/tables/TableList/TableList.sass
@@ -43,7 +43,9 @@
 		> strong + p
 			display: table-cell
 			padding: 0 30px 0 0
-			vertical-align: middle
+
+			&.TableListRow__AlignMiddle
+				vertical-align: middle
 
 		> div,
 		> p

--- a/src/components/tables/TableList/TableList.stories.mdx
+++ b/src/components/tables/TableList/TableList.stories.mdx
@@ -1,4 +1,5 @@
 import { TableListRow, TableList } from './TableList';
+import Switch from '../../inputs/Switch/Switch'
 import { Meta, Story, Canvas } from "@storybook/addon-docs/blocks";
 
 <Meta title="Tables/TableList" component={TableList} />
@@ -9,6 +10,8 @@ import { Meta, Story, Canvas } from "@storybook/addon-docs/blocks";
             <TableListRow label="Label">Some Content</TableListRow>
             <TableListRow label="Another Label">More Content</TableListRow>
             <TableListRow label="And Another Label">Some More Content</TableListRow>
+			<TableListRow label="A switch not centered"><Switch tiny flat/></TableListRow>
+			<TableListRow alignMiddle label="A switch centered"><Switch tiny flat/></TableListRow>
         </TableList>
 	</Story>
 </Canvas>

--- a/src/components/tables/TableList/TableList.tsx
+++ b/src/components/tables/TableList/TableList.tsx
@@ -31,10 +31,11 @@ export const TableList = (props: IProps) => {
 interface ITableListRowProps extends IReactComponentProps {
 	label?: string;
 	selectable?: boolean;
+	alignMiddle?: boolean;
 }
 
 export const TableListRow = (props: ITableListRowProps) => {
-	const { className, label, selectable, children } = props;
+	const { className, label, selectable, children, alignMiddle, style } = props;
 
 	return (
 		<li
@@ -43,10 +44,11 @@ export const TableListRow = (props: ITableListRowProps) => {
 				'TableListRow', // this also needs to be globally accessible so other component styles can reference it
 				className
 			)}
+			style={style}
 		>
 			{label && <strong>{label}</strong>}
 
-			<div>
+			<div className={alignMiddle ? styles.TableListRow__AlignMiddle : ''}>
 				{selectable && typeof children !== 'object' ? (
 					<input type="text" readOnly value={children as string | string[] | number} />
 				) : (


### PR DESCRIPTION
I had a PR that added in `vertical-align: middle` to child divs of `TableListRow` by default, but that made the preferences table in Core look really wonky. What I really want is an option to vertically align some table list rows. This PR adds that and spreads the style prop to `TableListRow`.