### PR TITLE
feat: improve BannerCarousel to prevent extra rerenders

### DIFF
--- a/src/components/alerts/BannerCarousel/BannerCarousel.stories.mdx
+++ b/src/components/alerts/BannerCarousel/BannerCarousel.stories.mdx
@@ -10,33 +10,49 @@ import BannerCarouselExample from "./BannerCarouselExample";
 
 <Canvas>
 	<Story name="BannerCarousel">
-        <BannerCarousel>
-			<Banner
-				variant="neutral"
-				buttonText="Complete Setup"
-				buttonOnClick={() => console.log("buttonOnClick")}
-				onDismiss={() => console.log("onDismiss")}
-			>
-				<strong>Typewriter!</strong> Poke or <TextButtonExternal>learn more</TextButtonExternal>.
-			</Banner>
-			<Banner
-				variant="error"
-				buttonText="Retry"
-				onDismiss={() => console.log("onDismiss")}
-				buttonOnClick={() => console.log("buttonOnClick")}
-			>
-				<strong>Typewriter!</strong> Poke selvage fam retro pug, offal
-				butcher occupy or <TextButtonExternal>learn more</TextButtonExternal>.
-			</Banner>
-			<Banner
-				variant="success"
-				buttonText="Celebrate good times"
-				onDismiss={() => console.log("onDismiss")}
-				buttonOnClick={() => console.log("buttonOnClick")}
-			>
-				<strong>Typewriter!</strong> Poke selvage fam retro pug, offal
-				butcher occupy or <TextButtonExternal>learn more</TextButtonExternal>.
-			</Banner>
+        <BannerCarousel banners={[
+			{
+				id: 'banner1',
+				component: (
+					<Banner
+						variant="neutral"
+						buttonText="Complete Setup"
+						buttonOnClick={() => console.log("buttonOnClick")}
+						onDismiss={() => console.log("onDismiss")}
+					>
+						<strong>Typewriter!</strong> Poke or <TextButtonExternal>learn more</TextButtonExternal>.
+					</Banner>
+				)
+			},
+			{
+				id: 'banner2',
+				component: (
+					<Banner
+						variant="error"
+						buttonText="Retry"
+						onDismiss={() => console.log("onDismiss")}
+						buttonOnClick={() => console.log("buttonOnClick")}
+					>
+						<strong>Typewriter!</strong> Poke selvage fam retro pug, offal
+						butcher occupy or <TextButtonExternal>learn more</TextButtonExternal>.
+					</Banner>
+				)
+			},
+			{
+				id: 'banner3',
+				component: (
+					<Banner
+						variant="success"
+						buttonText="Celebrate good times"
+						onDismiss={() => console.log("onDismiss")}
+						buttonOnClick={() => console.log("buttonOnClick")}
+					>
+						<strong>Typewriter!</strong> Poke selvage fam retro pug, offal
+						butcher occupy or <TextButtonExternal>learn more</TextButtonExternal>.
+					</Banner>
+				)
+			}
+		]}>
         </BannerCarousel>
     </Story>
 </Canvas>

--- a/src/components/alerts/BannerCarousel/BannerCarouselExample.tsx
+++ b/src/components/alerts/BannerCarousel/BannerCarouselExample.tsx
@@ -6,7 +6,7 @@ import BannerCarousel from './BannerCarousel';
 
 interface IBanner {
 	id: string;
-	component: any;
+	component: React.ReactNode;
 }
 
 const loremIpsum =
@@ -56,12 +56,7 @@ const BannerCarouselExample = () => {
 
 	return (
 		<div style={{ display: 'flex', flexDirection: 'column' }}>
-			<BannerCarousel id="interactive">
-				{banners.map((banner) => {
-					const BannerComponent = banner.component;
-					return <BannerComponent key={banner.id} id={banner.id} />;
-				})}
-			</BannerCarousel>
+			<BannerCarousel id="interactive" banners={banners} />
 			<Button style={{ marginTop: '20px' }} onClick={addBanner}>
 				Click to add Banner.
 			</Button>


### PR DESCRIPTION
The BannerCarousel is good, but it can be better!

This PR changes the carousel to use a `banners` prop instead of the `children` prop, so that we can see more clearly when the banners in the carousel have changed. This is easy because in Core we already have an array of this type that we modify in order to pass to BannerCarousel, so this will simplify things in core a little. 

I was previously just relying on a count, but sometimes the banners in a carousel will change without the number of banners changing. In that case, I had a stopgap to just update the children array, but when implemented in Core, we have a bunch of rerenders that would clear timeouts when switching between sites, for example. In that case the banner would just disappear while being hidden. 

With this change, the banner dismissal timeout will complete properly! I also added in some checks to allow us to pass raw JSX (type `React.ReactNode`) as the banner component or a function that returns JSX (like a render prop).