### PR TITLE
fix: inject toast styles instead of importing them

### DIFF
--- a/src/components/alerts/ToastContainer/ToastContainer.tsx
+++ b/src/components/alerts/ToastContainer/ToastContainer.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { toast as toastDefault, ToastContainer as ToastContainerDefault, ToastContainerProps } from 'react-toastify';
-import 'react-toastify/dist/ReactToastify.css';
+import { injectStyle } from 'react-toastify/dist/inject-style';
+
+injectStyle();
 
 const ToastContainer = (props: ToastContainerProps) => {
 	const defaultProps: ToastContainerProps = {


### PR DESCRIPTION
Importing the toast styles causes problems when installed in Core due to our use of css modules. For some reason, adding an `exclude` field to core's webpack rules does not work! Luckily, `react-toastify` exports a function to inject the styles on demand. I am calling this once in the ToastContainer.tsx file, and that should just inject the styles once, if we place ToastContainer high enough (in App.tsx) 