### PR TITLE
fix: move toast styles to top of head

### DIFF
--- a/src/components/alerts/Toast/Toast.scss
+++ b/src/components/alerts/Toast/Toast.scss
@@ -10,7 +10,6 @@
 		font-family: unset;
 		@include theme-background-white-else-graydark50;
 		box-shadow: 0px 0px 11px rgb(0 0 0 / 10%);
-		margin-bottom: 20px;
 
 		&.Theme__Inverted {
 			@include theme-background-graydark-else-white;
@@ -60,6 +59,10 @@
 		stroke: var(--Toast_Progress_Color);
 	}
 
+	svg circle {
+		stroke-width: 2px;
+	}
+
 	span {
 		margin: 0;
 		fill: var(--Toast_Progress_Color);
@@ -70,61 +73,48 @@
 	margin-left: 20px;
 }
 
-// Toned down bounce animation - note, we are just using Slide, but I'm keeping the code just in case.
-// Use this transition by setting "transition" on the ToastOptions object as follows:
-//
-// transition: cssTransition({
-// 	enter: styles['Toast__bounce-enter'],
-// 	exit: styles['Toast__bounce-exit'],
-// }),
-//
-// Note - cssTransition imported from `react-toastify`
-
-@keyframes BounceInRight {
+@keyframes SlideInRight {
 	from {
+		transform: translate3d(110%, 0, 0);
 		opacity: 0;
-		transform: translate3d(3000px, 0, 0);
-	}
-
-	50% {
-		opacity: 0;
-	}
-
-	80% {
-		opacity: 1;
-		transform: translate3d(-20px, 0, 0);
-	}
-
-	to {
-		transform: none;
-	}
-}
-
-@keyframes BounceOutRight {
-	20% {
-		opacity: 1;
-		transform: translate3d(-10px, 0, 0);
-	}
+	  }
 
 	50% {
 		opacity: 0;
 	}
 
 	to {
-		opacity: 0;
-		transform: translate3d(2000px, 0, 0);
+		opacity: 1;
+		transform: translate3d(0, 0, 0);
 	}
 }
 
-.Toast__bounce-enter {
-	animation-name: BounceInRight;
+@keyframes SlideOutRight {
+	from {
+		transform: translate3d(0, 0, 0);
+		opacity: 1
+	  }
+
+	40% {
+		opacity: 0;
+	}
+
+	to {
+		opacity: 0;
+		transform: translate3d(110%, 0, 0);
+	}
+}
+
+.Toast__slide-enter, .Toast__slide-exit {
 	animation-fill-mode: both;
-	animation-duration: 0.7s;
+	animation-duration: 0.4s;
 	animation-timing-function: ease-in-out;
 }
 
-.Toast__bounce-exit {
-	animation-name: BounceOutRight;
-	animation-fill-mode: both;
-	animation-duration: 0.7s;
+.Toast__slide-enter {
+	animation-name: SlideInRight;
+}
+
+.Toast__slide-exit {
+	animation-name: SlideOutRight;
 }

--- a/src/components/alerts/Toast/Toast.tsx
+++ b/src/components/alerts/Toast/Toast.tsx
@@ -1,6 +1,6 @@
 import {
 	CloseButtonProps,
-	Slide,
+	cssTransition,
 	toast as toastDefault,
 	ToastContentProps,
 	ToastOptions as ToastOptionsDefault,
@@ -108,14 +108,17 @@ const Content = (props: ContentProps) => {
 };
 
 const toast = (options: ToastOptions) => {
-	const { content, autoClose = 7000, type = 'success', pauseOnHover = false, ...restOptions } = options;
+	const { content, autoClose = 6000, type = 'success', pauseOnHover = false, ...restOptions } = options;
 
 	const toastOptions: ToastOptionsDefault = {
 		closeButton: CloseButton,
 		hideProgressBar: true,
 		className: type === ToastType.cta ? 'Theme__Inverted' : undefined,
 		autoClose: false,
-		transition: Slide,
+		transition: cssTransition({
+			enter: styles['Toast__slide-enter'],
+			exit: styles['Toast__slide-exit'],
+		}),
 		pauseOnHover: false,
 		...restOptions,
 	};

--- a/src/components/alerts/ToastContainer/ToastContainer.tsx
+++ b/src/components/alerts/ToastContainer/ToastContainer.tsx
@@ -2,7 +2,28 @@ import React from 'react';
 import { toast as toastDefault, ToastContainer as ToastContainerDefault, ToastContainerProps } from 'react-toastify';
 import { injectStyle } from 'react-toastify/dist/inject-style';
 
-injectStyle();
+const injectToastStyles = () => {
+	injectStyle();
+	let toastStyleSheet: CSSStyleSheet | undefined;
+	// eslint-disable-next-line no-restricted-syntax
+	for (const sheet of document.styleSheets) {
+		try {
+			if (sheet.cssRules?.[0].cssText.includes(':root') && sheet.cssRules[1]?.cssText.includes('.Toastify')) {
+				toastStyleSheet = sheet;
+				break;
+			}
+		} catch {
+			// eslint-disable-next-line no-continue
+			continue;
+		}
+	}
+
+	const node = toastStyleSheet?.ownerNode;
+	node?.remove();
+	document.head.insertBefore(node as Node, document.head.firstChild);
+};
+
+injectToastStyles();
 
 const ToastContainer = (props: ToastContainerProps) => {
 	const defaultProps: ToastContainerProps = {

--- a/src/components/alerts/ToastContainer/ToastContainer.tsx
+++ b/src/components/alerts/ToastContainer/ToastContainer.tsx
@@ -4,12 +4,15 @@ import { injectStyle } from 'react-toastify/dist/inject-style';
 
 const injectToastStyles = () => {
 	injectStyle();
-	let toastStyleSheet: CSSStyleSheet | undefined;
 	// eslint-disable-next-line no-restricted-syntax
 	for (const sheet of document.styleSheets) {
 		try {
-			if (sheet.cssRules?.[0].cssText.includes(':root') && sheet.cssRules[1]?.cssText.includes('.Toastify')) {
-				toastStyleSheet = sheet;
+			const rules = sheet.cssRules;
+			const node = sheet.ownerNode;
+
+			if (rules?.[0].cssText.includes(':root') && rules[1]?.cssText.includes('.Toastify')) {
+				node?.remove();
+				document.head.insertBefore(node as Node, document.head.firstChild);
 				break;
 			}
 		} catch {
@@ -17,10 +20,6 @@ const injectToastStyles = () => {
 			continue;
 		}
 	}
-
-	const node = toastStyleSheet?.ownerNode;
-	node?.remove();
-	document.head.insertBefore(node as Node, document.head.firstChild);
 };
 
 injectToastStyles();


### PR DESCRIPTION
The `injectStyles()` method provided by `react-toastify` injects the stylesheet at the bottom of `head` via `appendChild`. This is an issue, because in Core, the styles are added via a `link` tag before the injected styles, so the global `Toastify` style overrides are not taking precedence. 

I have opened an issue with the author of that repo [here](https://github.com/fkhadra/style2js/issues/1), but until we get the ability to change that injection method, I have created a workaround to essentially move the offending stylesheet up to the top of `head`. 

The `try/catch` is needed because some style sheets are inaccessible, and trying to access them will throw an error.