### PR TITLE
feat: type out IReactComponentProps more accurately and add onContextMenu

### DIFF
--- a/src/common/structures/IReactComponentProps.ts
+++ b/src/common/structures/IReactComponentProps.ts
@@ -17,4 +17,5 @@ export default interface IReactComponentProps<T = HTMLElement> {
 	tabIndex?: number;
 	'aria-checked'?: boolean;
 	onContextMenu?: React.HTMLProps<T>['onContextMenu'];
+	onDoubleClick?: React.HTMLProps<T>['onDoubleClick'];
 }

--- a/src/common/structures/IReactComponentProps.ts
+++ b/src/common/structures/IReactComponentProps.ts
@@ -1,19 +1,20 @@
 import * as React from 'react';
 
-export default interface IReactComponentProps {
-	onKeyDown?: any;
-	children?: React.ReactNode;
+export default interface IReactComponentProps<T = HTMLElement> {
+	onKeyDown?: React.HTMLProps<T>['onKeyDown'];
+	children?: React.DOMAttributes<T>['children'];
 	className?: string;
 	key?: string | number;
 	id?: string;
 	innerRef?: (element: HTMLElement) => void | string;
-	onClick?: any;
-	onMouseDown?: any;
-	onBlur?: any;
-	onFocus?: any;
+	onClick?: React.HTMLProps<T>['onClick'];
+	onMouseDown?: React.HTMLProps<T>['onMouseDown'];
+	onBlur?: React.HTMLProps<T>['onBlur'];
+	onFocus?: React.HTMLProps<T>['onFocus'];
 	style?: object;
 	ref?: any;
 	role?: string;
 	tabIndex?: number;
 	'aria-checked'?: boolean;
+	onContextMenu?: React.HTMLProps<T>['onContextMenu'];
 }

--- a/src/components/layout/Accordion/AccordionItem.tsx
+++ b/src/components/layout/Accordion/AccordionItem.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
 import classnames from 'classnames';
+import AnimateHeight from 'react-animate-height';
 import styles from './AccordionItem.scss';
 import { Container } from '../../modules/Container/Container';
 import ILocalContainerProps from '../../../common/structures/ILocalContainerProps';
-import AnimateHeight from 'react-animate-height';
 import { CaretIcon, CheckmarkMixedIcon } from '../../icons/Icons';
 
 const animationStateClasses = {
@@ -17,10 +17,10 @@ const animationStateClasses = {
 	staticHeightZero: 'AccordionItem_Content__staticHeightZero',
 	staticHeightAuto: 'AccordionItem_Content__staticHeightAuto',
 	staticHeightSpecific: 'AccordionItem_Content__staticHeightSpecific',
-}
+};
 
 interface PropsBase extends ILocalContainerProps {
-	children: React.ReactNode & {props?: any[]} | null;
+	children: (React.ReactNode & { props?: any[] }) | null;
 	clickArea?: 'icon' | 'all';
 	icon?: boolean | React.ReactNode;
 	itemId?: string;
@@ -60,94 +60,66 @@ const AccordionItemControlled: React.FC<PropsControlled> = ({
 
 	return (
 		<Container {...container}>
-			<div
-				className={classnames(
-					styles.AccordionItem,
-					'AccordionItem',
-					className,
-				)}
-				id={id}
-				style={style}
-			>
-				<>
-					{/* need to unwrap children because of potential extra 'child' wrapper (plus this works with fragments) */}
-					{ React.Children.map(children?.props?.children || children, (child: React.ReactNode, index: number) => {
-						switch(index) {
-							case 0:
-								return (
-									<TagSummary
-										className={classnames(
-											styles.AccordionItem_Summary,
-											'AccordionItem_Summary',
-											{
-												[styles.AccordionItem_Summary__ClickAreaAll]: clickArea === 'all',
-												['AccordionItem_Summary__ClickAreaAll']: clickArea === 'all',
-											}
-										)}
-										onClick={onClickSummary}
-									>
-										{React.cloneElement(child as React.ReactElement, {})}
-										{/* don't render if icon is disabled otherwise this can be tabbed to */}
-										{icon !== false && (
-											<button
-												className={classnames(
-													styles.AccordionItem_Summary_Action,
-													'AccordionItem_Summary_Action',
-													{
-														// allow developers to override for custom open/close styles
-														['AccordionItem_Summary_Action__Opened']: opened,
-													}
-												)}
-												onClick={onClick}
-												type="button"
-											>
-												{!opened && icon === true && (
-													<CaretIcon />
-												)}
-												{opened && icon === true && (
-													<CheckmarkMixedIcon width={14} height={3} />
-												)}
-												{typeof icon === "object" && (
-													<>
-														{icon}
-													</>
-												)}
-											</button>
-										)}
-									</TagSummary>
-								);
-							case 1:
-								return (
-									<AnimateHeight
-										animationStateClasses={animationStateClasses}
-										className={classnames(
-											'AccordionItem_Content',
-										)}
-										duration={ 200 }
-										height={ opened ? 'auto' : 0 }
-									>
-										{child}
-									</AnimateHeight>
-								);
-							default:
-								return React.cloneElement(child as React.ReactElement, {});
-						}
-					})}
-				</>
+			<div className={classnames(styles.AccordionItem, 'AccordionItem', className)} id={id} style={style}>
+				{/* need to unwrap children because of potential extra 'child' wrapper (plus this works with fragments) */}
+				{React.Children.map(children?.props?.children || children, (child: React.ReactNode, index: number) => {
+					switch (index) {
+						case 0:
+							return (
+								<TagSummary
+									className={classnames(styles.AccordionItem_Summary, 'AccordionItem_Summary', {
+										[styles.AccordionItem_Summary__ClickAreaAll]: clickArea === 'all',
+										AccordionItem_Summary__ClickAreaAll: clickArea === 'all',
+									})}
+									onClick={onClickSummary}
+								>
+									{React.cloneElement(child as React.ReactElement, {})}
+									{/* don't render if icon is disabled otherwise this can be tabbed to */}
+									{icon !== false && (
+										<button
+											className={classnames(
+												styles.AccordionItem_Summary_Action,
+												'AccordionItem_Summary_Action',
+												{
+													// allow developers to override for custom open/close styles
+													AccordionItem_Summary_Action__Opened: opened,
+												}
+											)}
+											onClick={onClick}
+											type="button"
+										>
+											{!opened && icon === true && <CaretIcon />}
+											{opened && icon === true && <CheckmarkMixedIcon width={14} height={3} />}
+											{typeof icon === 'object' && <>{icon}</>}
+										</button>
+									)}
+								</TagSummary>
+							);
+						case 1:
+							return (
+								<AnimateHeight
+									animationStateClasses={animationStateClasses}
+									className={classnames('AccordionItem_Content')}
+									duration={200}
+									height={opened ? 'auto' : 0}
+								>
+									{child}
+								</AnimateHeight>
+							);
+						default:
+							return React.cloneElement(child as React.ReactElement, {});
+					}
+				})}
 			</div>
 		</Container>
 	);
 };
 
 interface PropsUncontrolled extends PropsBase {
-	openedDefault?: boolean,
+	openedDefault?: boolean;
 }
 
-const AccordionItemUncontrolled: React.FC<PropsUncontrolled> = ({
-	openedDefault,
-	onToggle,
-	...otherProps
-}) => {
+const AccordionItemUncontrolled: React.FC<PropsUncontrolled> = ({ openedDefault, onToggle, ...otherProps }) => {
 	const [isOpen, setIsOpen] = React.useState(openedDefault ?? false);
 
 	const onClick = (itemId: PropsBase['itemId']) => {
@@ -162,22 +134,18 @@ const AccordionItemUncontrolled: React.FC<PropsUncontrolled> = ({
 };
 
 function instanceOfPropsControlled(object: any): object is PropsControlled {
-    return 'opened' in object;
+	return 'opened' in object;
 }
 
 /**
  * This is a factory of sorts that determines whether to use the controlled or uncontrolled variation.
  * Uses controlled-specific prop(s) to determine whether the parent is trying to "control" state or not.
  */
-const AccordionItem : React.FC<PropsControlled | PropsUncontrolled> = (props) => {
+const AccordionItem: React.FC<PropsControlled | PropsUncontrolled> = (props) => {
 	return instanceOfPropsControlled(props) ? (
-		<AccordionItemControlled
-			{...props}
-		/>
+		<AccordionItemControlled {...props} />
 	) : (
-		<AccordionItemUncontrolled
-			{...props}
-		/>
+		<AccordionItemUncontrolled {...props} />
 	);
 };
 


### PR DESCRIPTION
This PR adds better types to `IReactComponentProps`, specifically the handler functions, by pulling in types from React itself. Interfaces extending this interface can now optionally pass a generic type for the kind of HTMLElement, but just `HTMLElement` should be good for the type. I also added in `onContextMenu`. 

This approach of adding what we need when we need it is I think better than just extending `React.HTMLProps`, because that's a lot of props that we sometimes use the names of in our own components but with different types, so it would throw incorrect overload errors.

I also linted the `AccordianItem` component.