### PR TITLE
feat: extend accordian item to hide the header and expand if header is hidden

### DIFF
--- a/src/components/layout/Accordion/AccordionItem.tsx
+++ b/src/components/layout/Accordion/AccordionItem.tsx
@@ -29,6 +29,7 @@ interface PropsBase extends ILocalContainerProps {
 
 interface PropsControlled extends PropsBase {
 	opened: boolean;
+	noHeader?: boolean;
 }
 
 const AccordionItemControlled: React.FC<PropsControlled> = ({
@@ -41,6 +42,7 @@ const AccordionItemControlled: React.FC<PropsControlled> = ({
 	itemId,
 	onToggle,
 	opened,
+	noHeader,
 	style,
 }) => {
 	const onClick = (_: React.MouseEvent<HTMLElement>) => {
@@ -65,7 +67,7 @@ const AccordionItemControlled: React.FC<PropsControlled> = ({
 				{React.Children.map(children?.props?.children || children, (child: React.ReactNode, index: number) => {
 					switch (index) {
 						case 0:
-							return (
+							return noHeader ? null : (
 								<TagSummary
 									className={classnames(styles.AccordionItem_Summary, 'AccordionItem_Summary', {
 										[styles.AccordionItem_Summary__ClickAreaAll]: clickArea === 'all',
@@ -101,7 +103,7 @@ const AccordionItemControlled: React.FC<PropsControlled> = ({
 									animationStateClasses={animationStateClasses}
 									className={classnames('AccordionItem_Content')}
 									duration={200}
-									height={opened ? 'auto' : 0}
+									height={opened || noHeader ? 'auto' : 0}
 								>
 									{child}
 								</AnimateHeight>


### PR DESCRIPTION
For site group work we need to be able to hide the Accordian header. When the header is hidden, we want the item to be expanded. 

This PR adds an optional prop for doing that!