### PR TITLE
feat: Add ThreeDot button component

### DIFF
--- a/src/common/structures/IReactComponentProps.ts
+++ b/src/common/structures/IReactComponentProps.ts
@@ -18,4 +18,6 @@ export default interface IReactComponentProps<T = HTMLElement> {
 	'aria-checked'?: boolean;
 	onContextMenu?: React.HTMLProps<T>['onContextMenu'];
 	onDoubleClick?: React.HTMLProps<T>['onDoubleClick'];
+	onMouseEnter?: React.HTMLProps<T>['onMouseEnter'];
+	onMouseLeave?: React.HTMLProps<T>['onMouseLeave'];
 }

--- a/src/components/buttons/PrimaryButton/PrimaryButton.tsx
+++ b/src/components/buttons/PrimaryButton/PrimaryButton.tsx
@@ -4,7 +4,8 @@ import {
 	ButtonBase,
 	ButtonPropColor,
 	ButtonPropForm,
-	ButtonPropPadding, IButtonBaseProps,
+	ButtonPropPadding,
+	IButtonBaseProps,
 	IButtonCommonProps,
 } from '../_private/ButtonBase/ButtonBase';
 
@@ -19,20 +20,11 @@ interface IProps extends IButtonCommonProps {
 }
 
 export const PrimaryButton = (props: IProps) => {
-	const {
-		className,
-		id,
-		intent,
-		privateOptions,
-		...otherProps
-	} = props;
+	const { className, id, intent, privateOptions, ...otherProps } = props;
 
 	return (
 		<ButtonBase
-			className={classnames(
-				className,
-				'PrimaryButton',
-			)}
+			className={classnames(className, 'PrimaryButton')}
 			color={intent === PrimaryButtonPropIntent.destructive ? ButtonPropColor.red : ButtonPropColor.green}
 			id={id}
 			form={ButtonPropForm.fill}

--- a/src/components/buttons/ThreeDotButton/ThreeDotButton.scss
+++ b/src/components/buttons/ThreeDotButton/ThreeDotButton.scss
@@ -2,11 +2,16 @@
 @import '../../../common/styles/themeUtils';
 
 
-.ContextMenu_Trigger {
+.ThreeDot {
 	@include setThemeVar('--Button_IfFill__Background', $gray5, $gray-darker);
 	@include setThemeVar('--Button_IfFill__TextColor', $green-dark, $green);
 }
 
-.ContextMenu_Trigger_NoBG {
+.ThreeDot_NoBG {
 	@include setThemeVar('--Button_SvgPathFillColor', $gray, $green);
+}
+
+.ThreeDot_BgOnHover {
+	@include setThemeVar('--Button_SvgPathFillColor', $gray, $gray75);
+	@include setThemeVar('--Button_IfFill__Background', transparent);
 }

--- a/src/components/buttons/ThreeDotButton/ThreeDotButton.scss
+++ b/src/components/buttons/ThreeDotButton/ThreeDotButton.scss
@@ -1,0 +1,12 @@
+@import "../../../styles/_partials/index";
+@import '../../../common/styles/themeUtils';
+
+
+.ContextMenu_Trigger {
+	@include setThemeVar('--Button_IfFill__Background', $gray5, $gray-darker);
+	@include setThemeVar('--Button_IfFill__TextColor', $green-dark, $green);
+}
+
+.ContextMenu_Trigger_NoBG {
+	@include setThemeVar('--Button_SvgPathFillColor', $gray, $green);
+}

--- a/src/components/buttons/ThreeDotButton/ThreeDotButton.stories.mdx
+++ b/src/components/buttons/ThreeDotButton/ThreeDotButton.stories.mdx
@@ -14,3 +14,9 @@ import { Meta, Story, Canvas } from "@storybook/addon-docs/blocks";
         <ThreeDotButton noBG onClick={() => console.log('Button clicked!')} />
 	</Story>
 </Canvas>
+
+<Canvas>
+	<Story name="ThreeDotButton background on hover">
+        <ThreeDotButton bgOnHover onClick={() => console.log('Button clicked!')} />
+	</Story>
+</Canvas>

--- a/src/components/buttons/ThreeDotButton/ThreeDotButton.stories.mdx
+++ b/src/components/buttons/ThreeDotButton/ThreeDotButton.stories.mdx
@@ -1,0 +1,16 @@
+import { ThreeDotButton } from "./ThreeDotButton";
+import { Meta, Story, Canvas } from "@storybook/addon-docs/blocks";
+
+<Meta title="Buttons/ThreeDotButton" component={ThreeDotButton} />
+
+<Canvas>
+	<Story name="ThreeDotButton">
+        <ThreeDotButton onClick={() => console.log('Button clicked!')} />
+	</Story>
+</Canvas>
+
+<Canvas>
+	<Story name="ThreeDotButton no background">
+        <ThreeDotButton noBG onClick={() => console.log('Button clicked!')} />
+	</Story>
+</Canvas>

--- a/src/components/buttons/ThreeDotButton/ThreeDotButton.tsx
+++ b/src/components/buttons/ThreeDotButton/ThreeDotButton.tsx
@@ -8,17 +8,19 @@ import { DotsIcon } from '../../icons/Icons';
 interface IThreeDotButtonProps extends IButtonCommonProps {
 	noBG?: boolean;
 	privateOptions?: IButtonBaseProps;
+	bgOnHover?: boolean;
 }
 
 export const ThreeDotButton = (props: IThreeDotButtonProps) => {
-	const { noBG, privateOptions, ...restProps } = props;
+	const { noBG, privateOptions, bgOnHover, ...restProps } = props;
 
 	return (
 		<PrimaryButton
 			aria-label="Open context menu"
 			className={classnames({
-				[styles.ContextMenu_Trigger]: !noBG,
-				[styles.ContextMenu_Trigger_NoBG]: noBG,
+				[styles.ThreeDot]: !noBG,
+				[styles.ThreeDot_NoBG]: noBG && !bgOnHover,
+				[styles.ThreeDot_BgOnHover]: bgOnHover,
 			})}
 			privateOptions={{ style: { padding: '6px' }, form: noBG ? 'text' : 'fill', ...privateOptions }}
 			{...restProps}

--- a/src/components/buttons/ThreeDotButton/ThreeDotButton.tsx
+++ b/src/components/buttons/ThreeDotButton/ThreeDotButton.tsx
@@ -1,0 +1,29 @@
+import * as React from 'react';
+import classnames from 'classnames';
+import { IButtonBaseProps, IButtonCommonProps } from '../_private/ButtonBase/ButtonBase';
+import { PrimaryButton } from '../PrimaryButton/PrimaryButton';
+import styles from './ThreeDotButton.scss';
+import { DotsIcon } from '../../icons/Icons';
+
+interface IThreeDotButtonProps extends IButtonCommonProps {
+	noBG?: boolean;
+	privateOptions?: IButtonBaseProps;
+}
+
+export const ThreeDotButton = (props: IThreeDotButtonProps) => {
+	const { noBG, privateOptions, ...restProps } = props;
+
+	return (
+		<PrimaryButton
+			aria-label="Open context menu"
+			className={classnames({
+				[styles.ContextMenu_Trigger]: !noBG,
+				[styles.ContextMenu_Trigger_NoBG]: noBG,
+			})}
+			privateOptions={{ style: { padding: '6px' }, form: noBG ? 'text' : 'fill', ...privateOptions }}
+			{...restProps}
+		>
+			<DotsIcon />
+		</PrimaryButton>
+	);
+};

--- a/src/components/buttons/_private/ButtonBase/ButtonBase.scss
+++ b/src/components/buttons/_private/ButtonBase/ButtonBase.scss
@@ -240,7 +240,7 @@ $disabled-text-dark-fill: $gray;
 	@include setThemeVar('--Button_IfFill__TextColor_Hover', $white, $gray-dark);
 	@include setThemeVar('--Button_IfFill__Background_Active', $gray-dark, $gray25);
 	@include setThemeVar('--Button_IfFill__TextColor_Active', $white, $gray-dark);
-	@include setThemeVar('--Button_IfText__TextColor', $gray, $white);
+	@include setThemeVar('--Button_IfText__TextColor', $gray, $gray75);
 	@include setThemeVar('--Button_IfText__TextColor_Hover', $gray-dark50, $gray15);
 	@include setThemeVar('--Button_IfText__TextColor_Active', $gray-dark, $gray25);
 }

--- a/src/components/menus/ContextMenu/ContextMenu.scss
+++ b/src/components/menus/ContextMenu/ContextMenu.scss
@@ -29,15 +29,6 @@
 	margin: 5px 0;
 }
 
-.ContextMenu_Trigger {
-	@include setThemeVar('--Button_IfFill__Background', $gray5, $gray-darker);
-	@include setThemeVar('--Button_IfFill__TextColor', $green-dark, $green);
-}
-
-.ContextMenu_Trigger_NoBG {
-	@include setThemeVar('--Button_SvgPathFillColor', $gray, $green);
-}
-
 .ContextMenu_Items {
 	left: auto;
 	border-radius: 4px;

--- a/src/components/menus/ContextMenu/ContextMenu.tsx
+++ b/src/components/menus/ContextMenu/ContextMenu.tsx
@@ -1,11 +1,10 @@
 import * as React from 'react';
 import classnames from 'classnames';
 import styles from './ContextMenu.scss';
-import { DotsIcon } from '../../icons/Icons';
 import { FunctionGeneric } from '../../../common/structures/Generics';
 import { Tooltip, TooltipProps } from '../../overlays/Tooltip/Tooltip';
-import { PrimaryButton } from '../../buttons/PrimaryButton/PrimaryButton';
 import { TextButton } from '../../buttons/TextButton/TextButton';
+import { ThreeDotButton } from '../../buttons/ThreeDotButton/ThreeDotButton';
 
 export interface IMenuItem {
 	color?: 'red' | 'none';
@@ -53,6 +52,7 @@ const ContextMenu = (props: IContextMenuProps) => {
 			{items
 				.filter((item: IMenuItem) => Object.keys(item).length !== 0)
 				.map((item: IMenuItem, i: number) => (
+					// eslint-disable-next-line react/no-array-index-key
 					<li key={i} className={classnames(styles.ContextMenu_Item, classNameListItem, item.className)}>
 						{item.type === 'separator' ? (
 							<div className={styles.ContextMenu_Divider} />
@@ -91,17 +91,7 @@ const ContextMenu = (props: IContextMenuProps) => {
 			{...otherProps}
 			content={content}
 		>
-			<PrimaryButton
-				aria-label="Open context menu"
-				active={isShowing}
-				className={classnames({
-					[styles.ContextMenu_Trigger]: !noBG,
-					[styles.ContextMenu_Trigger_NoBG]: noBG,
-				})}
-				privateOptions={{ style: { padding: '6px' }, form: noBG ? 'text' : 'fill' }}
-			>
-				<DotsIcon />
-			</PrimaryButton>
+			<ThreeDotButton aria-label="Open context menu" active={isShowing} />
 		</Tooltip>
 	);
 };

--- a/src/components/menus/ContextMenu/ContextMenu.tsx
+++ b/src/components/menus/ContextMenu/ContextMenu.tsx
@@ -25,6 +25,8 @@ export interface IContextMenuProps extends Omit<TooltipProps, 'content'> {
 	items: IMenuItem[];
 	/** whether to have background behind 3 dots - set to false for low key 3 dot dropdowns */
 	noBG?: boolean;
+	/** whether to have background behind 3 dots - set to false for low key 3 dot dropdowns */
+	bgOnHover?: boolean;
 }
 
 const ContextMenu = (props: IContextMenuProps) => {
@@ -36,6 +38,7 @@ const ContextMenu = (props: IContextMenuProps) => {
 		onShow,
 		onHide,
 		noBG,
+		bgOnHover,
 		useClickInsteadOfHover,
 		...otherProps
 	} = props;
@@ -91,7 +94,7 @@ const ContextMenu = (props: IContextMenuProps) => {
 			{...otherProps}
 			content={content}
 		>
-			<ThreeDotButton aria-label="Open context menu" active={isShowing} />
+			<ThreeDotButton aria-label="Open context menu" active={isShowing} noBG={noBG} bgOnHover={bgOnHover} />
 		</Tooltip>
 	);
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ export { default as Close } from './components/buttons/Close/Close';
 export { PrimaryButton } from './components/buttons/PrimaryButton/PrimaryButton';
 export { TextButton, ITextButtonProps } from './components/buttons/TextButton/TextButton';
 export { IconButton, IIconButtonProps } from './components/buttons/IconButton/IconButton';
+export { ThreeDotButton } from './components/buttons/ThreeDotButton/ThreeDotButton';
 export { default as TextButtonExternal } from './components/buttons/TextButtonExternal/TextButtonExternal';
 export { CopyButton } from './components/buttons/CopyButton/CopyButton';
 export { RefreshButton } from './components/buttons/RefreshButton/RefreshButton';


### PR DESCRIPTION
For the Site Group work, we need the standalone three dot button from the `ContextMenu` component in order to trigger a system menu. This PR pulls that out into its own component.

I also use it in the `ContextMenu` component and just linted the `PrimaryButton` component.