### PR TITLE
feat: use IconButton in AccordianItem and spread rest of props

### DIFF
--- a/src/components/layout/Accordion/AccordionItem.stories.mdx
+++ b/src/components/layout/Accordion/AccordionItem.stories.mdx
@@ -80,7 +80,7 @@ Customize the `icon` used to open and close the item.
 	<Story name="AccordionItem New Icon">
 		<div className="Story__Padding">
 			<AccordionItem
-				icon={<CircleInfoIcon />}
+				icon={CircleInfoIcon}
 			>
 				<Title>
 					Is the default icon not your jam?

--- a/src/components/layout/Accordion/AccordionItem.tsx
+++ b/src/components/layout/Accordion/AccordionItem.tsx
@@ -23,7 +23,7 @@ const animationStateClasses = {
 interface PropsBase extends ILocalContainerProps {
 	children: (React.ReactNode & { props?: any[] }) | null;
 	clickArea?: 'icon' | 'all';
-	/** Defaults to "true" for default carot icons. Set to "false" for no icon, set to ReactNode for custom icon */
+	/** Defaults to "true" for default caret icons. Set to "false" for no icon, set to ReactNode for custom icon. */
 	icon?: boolean | React.ReactNode;
 	itemId?: string;
 	onToggle?: (id: PropsControlled['itemId'] | undefined) => void;

--- a/src/components/layout/Accordion/AccordionItem.tsx
+++ b/src/components/layout/Accordion/AccordionItem.tsx
@@ -64,43 +64,26 @@ const AccordionItemControlled: React.FC<PropsControlled> = ({
 	const TagSummary: any = clickArea === 'all' ? 'button' : 'div';
 
 	const renderIconButton = () => {
-		const buttonClassName = classnames(styles.AccordionItem_Summary_Action, 'AccordionItem_Summary_Action', {
-			// allow developers to override for custom open/close styles
-			AccordionItem_Summary_Action__Opened: opened,
-		});
+		if (!icon) {
+			return null;
+		}
 
-		// Default Caret icons
+		let iconForButton = icon;
 		if (icon === true) {
-			return !opened ? (
-				<IconButton
-					onClick={onClick}
-					icon={CaretIcon}
-					privateOptions={{ color: 'gray' }}
-					className={buttonClassName}
-				/>
-			) : (
-				<IconButton
-					privateOptions={{ color: 'gray' }}
-					icon={React.memo(() => (
-						<CheckmarkMixedIcon width={14} height={3} />
-					))}
-					onClick={onClick}
-					className={buttonClassName}
-				/>
-			);
+			iconForButton = opened ? React.memo(() => <CheckmarkMixedIcon width={14} height={3} />) : CaretIcon;
 		}
 
-		// Custom icon
-		if (icon) {
-			return (
-				<button className={buttonClassName} onClick={onClick} type="button">
-					{typeof icon === 'object' && icon}
-				</button>
-			);
-		}
-
-		// No icon if icon === false
-		return null;
+		return (
+			<IconButton
+				onClick={onClick}
+				icon={iconForButton}
+				privateOptions={{ color: 'gray' }}
+				className={classnames(styles.AccordionItem_Summary_Action, 'AccordionItem_Summary_Action', {
+					// allow developers to override for custom open/close styles
+					AccordionItem_Summary_Action__Opened: opened,
+				})}
+			/>
+		);
 	};
 
 	return (


### PR DESCRIPTION
We have a new IconButton component that handles placing an icon in a button tag, along with hover and active color states.

This commit pulls out the icon button render logic into a separate function and simplifies it a bit.

I also spread the ...restProps onto the wrapping div, giving us things like `onClick`, etc.