### PR TITLE
feat: site group tweaks

### DIFF
--- a/src/common/structures/IReactComponentProps.ts
+++ b/src/common/structures/IReactComponentProps.ts
@@ -9,6 +9,7 @@ export default interface IReactComponentProps<T = HTMLElement> {
 	innerRef?: (element: HTMLElement) => void | string;
 	onClick?: React.HTMLProps<T>['onClick'];
 	onMouseDown?: React.HTMLProps<T>['onMouseDown'];
+	onMouseUp?: React.HTMLProps<T>['onMouseUp'];
 	onBlur?: React.HTMLProps<T>['onBlur'];
 	onFocus?: React.HTMLProps<T>['onFocus'];
 	style?: object;

--- a/src/components/buttons/ThreeDotButton/ThreeDotButton.scss
+++ b/src/components/buttons/ThreeDotButton/ThreeDotButton.scss
@@ -12,6 +12,6 @@
 }
 
 .ThreeDot_BgOnHover {
-	@include setThemeVar('--Button_SvgPathFillColor', $gray, $gray75);
+	@include setThemeVar('--Button_SvgPathFillColor', $gray75, $gray75);
 	@include setThemeVar('--Button_IfFill__Background', transparent);
 }

--- a/src/components/buttons/_private/ButtonBase/ButtonBase.scss
+++ b/src/components/buttons/_private/ButtonBase/ButtonBase.scss
@@ -240,7 +240,7 @@ $disabled-text-dark-fill: $gray;
 	@include setThemeVar('--Button_IfFill__TextColor_Hover', $white, $gray-dark);
 	@include setThemeVar('--Button_IfFill__Background_Active', $gray-dark, $gray25);
 	@include setThemeVar('--Button_IfFill__TextColor_Active', $white, $gray-dark);
-	@include setThemeVar('--Button_IfText__TextColor', $gray, $gray75);
+	@include setThemeVar('--Button_IfText__TextColor', $gray75, $gray75);
 	@include setThemeVar('--Button_IfText__TextColor_Hover', $gray-dark50, $gray15);
 	@include setThemeVar('--Button_IfText__TextColor_Active', $gray-dark, $gray25);
 }

--- a/src/components/buttons/_private/ButtonBase/ButtonBase.tsx
+++ b/src/components/buttons/_private/ButtonBase/ButtonBase.tsx
@@ -84,6 +84,8 @@ export interface IButtonCommonProps extends ILocalContainerProps {
 	svgStyle?: ButtonSvgStyle | keyof typeof ButtonSvgStyle;
 	/** Display inline-flex vs flex */
 	inline?: boolean;
+	/** Stop propagation - prevents button keydown event from bubbling up to wrapping elements with potential listeners */
+	stopKeyDownPropagation?: boolean;
 }
 
 /**
@@ -137,6 +139,7 @@ const ButtonBase = (props: IButtonBaseProps) => {
 		leftIcon,
 		rightIcon,
 		svgStyle,
+		stopKeyDownPropagation,
 		...otherProps
 	} = props;
 
@@ -147,6 +150,10 @@ const ButtonBase = (props: IButtonBaseProps) => {
 	const [isActive, setIsActive] = React.useState(active);
 
 	const handleKeyDown = (e: React.KeyboardEvent) => {
+		if (stopKeyDownPropagation) {
+			e.stopPropagation();
+		}
+
 		if (e.key === 'Enter' && !active) {
 			setIsActive(true);
 		}

--- a/src/components/layout/Accordion/AccordionItem.tsx
+++ b/src/components/layout/Accordion/AccordionItem.tsx
@@ -61,8 +61,6 @@ const AccordionItemControlled: React.FC<PropsControlled> = ({
 		}
 	};
 
-	const TagSummary: any = clickArea === 'all' ? 'button' : 'div';
-
 	const renderIconButton = () => {
 		if (!icon) {
 			return null;
@@ -99,17 +97,27 @@ const AccordionItemControlled: React.FC<PropsControlled> = ({
 					switch (index) {
 						case 0:
 							return noHeader ? null : (
-								<TagSummary
+								<div
+									{...(clickArea === 'all' && {
+										role: 'button',
+										onClick: onClickSummary,
+										tabIndex: 0,
+										onKeyDown: (e: React.KeyboardEvent) => {
+											if (e.key === 'Enter' || e.key === ' ') {
+												e.preventDefault();
+												onClickSummary();
+											}
+										},
+									})}
 									className={classnames(styles.AccordionItem_Summary, 'AccordionItem_Summary', {
 										[styles.AccordionItem_Summary__ClickAreaAll]: clickArea === 'all',
 										AccordionItem_Summary__ClickAreaAll: clickArea === 'all',
 									})}
-									onClick={onClickSummary}
 								>
 									{React.cloneElement(child as React.ReactElement, {})}
 									{/* don't render if icon is disabled otherwise this can be tabbed to */}
 									{renderIconButton()}
-								</TagSummary>
+								</div>
 							);
 						case 1:
 							return (


### PR DESCRIPTION
These changes are necessary following feedback from Tyson on the Site Group work.

Includes:
- Accessibly changing the `AccordionItem` header from a `button` to a `div` when the `clickArea` is `"all"`.
- Optionally stopping the propagation of a button's `onKeyDown` handler via a new prop
- Gray mode color tweaks for `IconButton` (the only button using this color mode)

