### PR TITLE
feat: add highlightText option to BasicInput

### DIFF
--- a/src/common/structures/IReactComponentProps.ts
+++ b/src/common/structures/IReactComponentProps.ts
@@ -1,6 +1,7 @@
 import * as React from 'react';
 
 export default interface IReactComponentProps<T = HTMLElement> {
+	onKeyUp?: React.HTMLProps<T>['onKeyUp'];
 	onKeyDown?: React.HTMLProps<T>['onKeyDown'];
 	children?: React.DOMAttributes<T>['children'];
 	className?: string;

--- a/src/components/inputs/BasicInput/BasicInput.tsx
+++ b/src/components/inputs/BasicInput/BasicInput.tsx
@@ -16,21 +16,27 @@ export interface IBasicInputProps extends ILocalContainerProps {
 	readonly?: boolean;
 	size?: number;
 	spellcheck?: boolean;
-	onKeyUp?: any;
 	invalid?: boolean;
 	invalidMessage?: string;
 	autofocus?: boolean;
 	disabled?: boolean;
+	/** Highlight the text on mount, useful for renaming */
+	highlightText?: boolean;
 }
 
 const BasicInput = React.forwardRef((props: IBasicInputProps, ref: React.ForwardedRef<HTMLInputElement>) => {
-	const { className, id, name, style, invalid, invalidMessage, autofocus, disabled, ...otherProps } = props;
+	const { className, id, name, style, invalid, invalidMessage, autofocus, disabled, highlightText, ...otherProps } =
+		props;
 
 	const input = useForwardedRef(ref);
 
 	React.useEffect(() => {
 		if (autofocus) {
 			input.current?.focus();
+		}
+
+		if (highlightText) {
+			input.current?.select();
 		}
 	}, []);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,7 +41,7 @@ export {
 export * from './components/icons/Icons';
 export { default as IconCheckbox } from './components/inputs/IconCheckbox/IconCheckbox';
 export { default as InputPasswordToggle } from './components/inputs/InputPasswordToggle/InputPasswordToggle';
-export { default as BasicInput } from './components/inputs/BasicInput/BasicInput';
+export { default as BasicInput, IBasicInputProps } from './components/inputs/BasicInput/BasicInput';
 export { default as InputSearch } from './components/inputs/InputSearch/InputSearch';
 export { default as RadioBlock } from './components/inputs/RadioBlock/RadioBlock';
 export { default as Switch } from './components/inputs/Switch/Switch';


### PR DESCRIPTION
Also exports the BasicInput props and adds an onKeyDown event to IReactComponentProps.