### PR TITLE
feat(LOC-3187): clean up IconCheckbox, Popup, and default outline for focus state

### DIFF
--- a/src/components/inputs/IconCheckbox/IconCheckbox.scss
+++ b/src/components/inputs/IconCheckbox/IconCheckbox.scss
@@ -10,7 +10,7 @@
 	&:not(.IconCheckbox__Disabled) {
 		// mouse down
 		&:active {
-			transform: scale(0.9);
+			transform: scale(0.98);
 		}
 
 		// default unchecked and not using icon colors
@@ -72,6 +72,10 @@
 	margin: 0;
 	opacity: 0;
 	cursor: pointer;
+
+	&:focus + .IconCheckbox_Icon {
+		@include defaultOutline;
+	}
 }
 
 .IconCheckbox_Icon {

--- a/src/components/inputs/IconCheckbox/IconCheckbox.tsx
+++ b/src/components/inputs/IconCheckbox/IconCheckbox.tsx
@@ -2,7 +2,6 @@ import React, { useEffect, useState } from 'react';
 import classnames from 'classnames';
 import IReactComponentProps from '../../../common/structures/IReactComponentProps';
 import styles from './IconCheckbox.scss';
-import { FunctionGeneric } from '../../../common/structures/Generics';
 
 interface ISvgProps {
 	className?: string;
@@ -10,11 +9,11 @@ interface ISvgProps {
 
 interface IProps extends IReactComponentProps {
 	checked?: boolean;
-	disabled?: boolean;
+	onChange?: (checked: boolean) => void;
 	Icon: React.FC<ISvgProps>;
+	disabled?: boolean;
 	name?: string;
-	onChange: FunctionGeneric;
-	/** Whether to override svg icon path colors **/
+	/** Whether to override svg icon path colors * */
 	useIconColorsOnChecked?: boolean;
 	useIconColorsOnCheckedHover?: boolean;
 	useIconColorsOnUnchecked?: boolean;
@@ -27,33 +26,37 @@ export const IconCheckbox: React.FC<IProps> = ({
 	Icon,
 	name,
 	onChange,
+	className,
+	id,
+	style,
 	useIconColorsOnChecked,
 	useIconColorsOnCheckedHover,
 	useIconColorsOnUnchecked,
 	useIconColorsOnUncheckedHover,
-	...props
+	...restProps
 }) => {
-	const isCheckedProp = checked === undefined ? false : checked;
-	const [ isChecked, updateCheckedState ] = useState(isCheckedProp);
+	const [isChecked, setIsChecked] = useState(checked);
 	// state to track temporarily disabling hover to make the checked/unchecked effect play nicer with hover
-	const [ disableHoverStyles, setDisableHoverStyles ] = useState(isCheckedProp);
+	const [disableHoverStyles, setDisableHoverStyles] = useState(checked);
 
 	// to allow updates to the state via prop changes, an effect much be used
-	useEffect(() => { updateCheckedState(isCheckedProp)}, [checked] );
+	useEffect(() => {
+		setIsChecked(checked);
+	}, [checked]);
 
 	const handleChange = () => {
-		const checkedUpdate: boolean = !isChecked;
-
 		setDisableHoverStyles(true);
-		updateCheckedState(checkedUpdate);
-		onChange?.(checkedUpdate);
+		setIsChecked((prev) => {
+			onChange?.(!prev);
+			return !prev;
+		});
 	};
 
 	const onMouseLeave = () => {
 		if (disableHoverStyles) {
 			setDisableHoverStyles(false);
 		}
-	}
+	};
 
 	return (
 		<div
@@ -68,13 +71,14 @@ export const IconCheckbox: React.FC<IProps> = ({
 					[styles.IconCheckbox__UseIconColorsOnUnchecked]: useIconColorsOnUnchecked,
 					[styles.IconCheckbox__UseIconColorsOnUncheckedHover]: useIconColorsOnUncheckedHover,
 				},
-				props.className,
+				className
 			)}
 			onMouseLeave={onMouseLeave}
-			style={props.style}
+			style={style}
+			{...restProps}
 		>
 			<input
-				id={props.id}
+				id={id}
 				type="checkbox"
 				className={styles.IconCheckbox_InputHidden}
 				checked={isChecked}

--- a/src/components/overlays/Popup/Popup.sass
+++ b/src/components/overlays/Popup/Popup.sass
@@ -132,9 +132,11 @@
 			background: $green-dark50
 
 	.Popup_BubbleContent
-		transition: opacity $transiton-duration $ease-in $transiton-delay
+		transition: opacity $transiton-duration $ease-in $transiton-delay, visibility $transiton-duration $ease-in $transiton-delay
 		will-change: opacity
 		@include selectors_setAsDefaults()
 			opacity: 0
+			visibility: hidden
 		@include selectors_ifHostHasModifier('.Popup__Open')
 			opacity: 1
+			visibility: visible

--- a/src/styles/_partials/_mixins.scss
+++ b/src/styles/_partials/_mixins.scss
@@ -89,7 +89,7 @@
 }
 
 @mixin defaultOutline {
-	outline: 5px auto -webkit-focus-ring-color; // default chrome outline style
+	outline: 2px auto $green;
 }
 
 // Screen reader only

--- a/src/styles/base.scss
+++ b/src/styles/base.scss
@@ -20,7 +20,7 @@
 			outline: none;
 		}
 
-		&:focus {
+		:focus {
 			@include defaultOutline;
 		}
 	}


### PR DESCRIPTION
Cleans up the IconCheckbox and adds a focus state for keyboard navigation.

Changes the default outline for focused elements to $green (we've been wanting that for awhile)

Correctly selects any focused elements. I think Alexa had accidentally put an ampersand which was only selecting the body, not children.