### PR TITLE
fix: change focus in iconcheckbox to focus-visible

### DIFF
--- a/src/components/inputs/IconCheckbox/IconCheckbox.scss
+++ b/src/components/inputs/IconCheckbox/IconCheckbox.scss
@@ -73,7 +73,7 @@
 	opacity: 0;
 	cursor: pointer;
 
-	&:focus + .IconCheckbox_Icon {
+	&:focus-visible + .IconCheckbox_Icon {
 		@include defaultOutline;
 	}
 }


### PR DESCRIPTION
Oops! Focus-visible only shows on keyboard nav, which is what we want.