### PR TITLE
feat: Close ContextMenu when clicking a clickable item

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@electron/remote": "^2.0.8",
     "@popperjs/core": "^2.9.2",
     "@types/lz-string": "^1.3.34",
+    "@types/shortid": "^0.0.29",
     "@types/untildify": "^3.0.0",
     "classnames": "^2.2.6",
     "clipboard-copy": "^3.1.0",
@@ -34,6 +35,7 @@
     "react-router-dom": "^5.0.1",
     "react-toastify": "^9.1.1",
     "react-truncate-markup": "^3.0.0",
+    "shortid": "^2.2.16",
     "untildify": "^4.0.0"
   },
   "scripts": {

--- a/src/common/structures/global.d.ts
+++ b/src/common/structures/global.d.ts
@@ -1,0 +1,7 @@
+export {};
+
+declare global {
+	interface DocumentEventMap {
+		hideTooltip: CustomEvent<{ id: string }>;
+	}
+}

--- a/src/components/menus/ContextMenu/ContextMenu.tsx
+++ b/src/components/menus/ContextMenu/ContextMenu.tsx
@@ -35,7 +35,7 @@ const ContextMenu = (props: IContextMenuProps) => {
 	const { className, classNameList, classNameListItem, items, onShow, onHide, noBG, bgOnHover, id, ...otherProps } =
 		props;
 
-	const menuId = useRef(`${id ?? 'contextMenu'}-${shortid.generate()}`);
+	const menuId = useRef(id ?? `${'contextMenu'}-${shortid.generate()}`);
 
 	const [isShowing, setIsShowing] = React.useState(false);
 

--- a/src/components/overlays/Tooltip/Tooltip.scss
+++ b/src/components/overlays/Tooltip/Tooltip.scss
@@ -13,6 +13,10 @@ $borderThickness: 1px;
 
 .Tooltip_Popper_PositionContainer {
 	z-index: 10;
+
+	&:focus {
+		outline: none;
+	}
 }
 
 .Tooltip_Popper_VisualContainer {

--- a/src/components/overlays/Tooltip/Tooltip.stories.mdx
+++ b/src/components/overlays/Tooltip/Tooltip.stories.mdx
@@ -1,4 +1,5 @@
-import { Tooltip } from "./Tooltip";
+import { Tooltip, hideTooltip } from "./Tooltip";
+import { TextButton } from "../../buttons/TextButton/TextButton";
 import { Meta, Story, Canvas } from "@storybook/addon-docs/blocks";
 
 <Meta title="Overlays/Tooltip" component={Tooltip} />
@@ -110,6 +111,35 @@ Turn off the delay before showing the tooltip along with the delay for hiding it
 				showDelay={0}
             >
                 <div style={{cursor: 'pointer'}}>Hover over me</div>
+            </Tooltip>
+        </div>
+	</Story>
+</Canvas>
+
+We can hide a tooltip using the exported `hideTooltip` function, passing along the ID of the tooltip. This is pretty much only useful
+for closing a click-triggered tooltip from within the tooltip itself. Click-triggered tooltips don't close when clicking the popper content.
+> Using this method gives us animations and doesn't mess up internal state. Changig the `hideTooltip` prop to `true` from the parent component
+> will hide it, but we lose animations. Internal state also gets behind if we hide via the prop, then trigger, in an attempt to do a "controlled" tooltip.
+
+<Canvas>
+	<Story name="Hide via hideTooltip">
+        <div style={{ height: '200px', display: 'flex', alignItems: 'center' }}>
+            <Tooltip
+				id="hideableTooltip"
+				useClickInsteadOfHover
+                content={(
+					<div>
+						<div>Clicking the content doesn't close!</div>
+						<TextButton onClick={() => hideTooltip("hideableTooltip")}>
+							Click me to close
+						</TextButton>
+					</div>
+				)}
+				hideDelay={0}
+				position={'right'}
+				showDelay={0}
+            >
+                <div style={{cursor: 'pointer'}}>Click me</div>
             </Tooltip>
         </div>
 	</Story>

--- a/src/index.ts
+++ b/src/index.ts
@@ -94,7 +94,7 @@ export { default as FlyModal } from './components/overlays/FlyModal/FlyModal';
 export { default as FlyTooltip } from './components/overlays/FlyTooltip/FlyTooltip';
 export { default as Popup } from './components/overlays/Popup/Popup';
 export { ScrollShadow } from './components/overlays/ScrollShadow/ScrollShadow';
-export { Tooltip } from './components/overlays/Tooltip/Tooltip';
+export { Tooltip, hideTooltip } from './components/overlays/Tooltip/Tooltip';
 export { default as Badge } from './components/overlays/Badge/Badge';
 // Tables
 export { TableList, TableListRow } from './components/tables/TableList/TableList';

--- a/yarn.lock
+++ b/yarn.lock
@@ -3699,6 +3699,11 @@
     "@types/mime" "^1"
     "@types/node" "*"
 
+"@types/shortid@^0.0.29":
+  version "0.0.29"
+  resolved "https://registry.yarnpkg.com/@types/shortid/-/shortid-0.0.29.tgz#8093ee0416a6e2bf2aa6338109114b3fbffa0e9b"
+  integrity sha512-9BCYD9btg2CY4kPcpMQ+vCR8U6V8f/KvixYD5ZbxoWlkhddNF5IeZMVL3p+QFUkg+Hb+kPAG9Jgk4bnnF1v/Fw==
+
 "@types/sockjs@^0.3.33":
   version "0.3.33"
   resolved "https://registry.yarnpkg.com/@types/sockjs/-/sockjs-0.3.33.tgz#570d3a0b99ac995360e3136fd6045113b1bd236f"
@@ -10399,6 +10404,11 @@ nan@^2.12.1:
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.16.0.tgz#664f43e45460fb98faf00edca0bb0d7b8dce7916"
   integrity sha512-UdAqHyFngu7TfQKsCBgAA6pWDkT8MAO7d0jyOecVhN5354xbLqdn8mV9Tat9gepAupm0bt2DbeaSC8vS52MuFA==
 
+nanoid@^2.1.0:
+  version "2.1.11"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-2.1.11.tgz#ec24b8a758d591561531b4176a01e3ab4f0f0280"
+  integrity sha512-s/snB+WGm6uwi0WjsZdaVcuf3KJXlfGl2LcxgwkEwJF0D/BWzVWAZW/XY4bFaiR7s0Jk3FPvlnepg1H1b1UwlA==
+
 nanoid@^3.3.1, nanoid@^3.3.4:
   version "3.3.4"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.4.tgz#730b67e3cd09e2deacf03c027c81c9d9dbc5e8ab"
@@ -12678,6 +12688,13 @@ shelljs@^0.8.5:
     glob "^7.0.0"
     interpret "^1.0.0"
     rechoir "^0.6.2"
+
+shortid@^2.2.16:
+  version "2.2.16"
+  resolved "https://registry.yarnpkg.com/shortid/-/shortid-2.2.16.tgz#b742b8f0cb96406fd391c76bfc18a67a57fe5608"
+  integrity sha512-Ugt+GIZqvGXCIItnsL+lvFJOiN7RYqlGy7QE41O3YC1xbNSeDGIRO7xg2JJXIAj1cAGnOeC1r7/T9pgrtQbv4g==
+  dependencies:
+    nanoid "^2.1.0"
 
 shx@^0.3.2:
   version "0.3.4"


### PR DESCRIPTION
This PR adds a method for closing a tooltip via a custom JS event. This is different than using the hideTooltip prop because we get the animations. 

Using hideTooltip and forceShow to mimic a controlled tooltip loses animations and the ability to still get the trigger, such as a click. Also, using both at the same time creates some wonkiness in the internal state (i.e. closing via the prop then opening and trying to close via the trigger doesn't work right away).

This is a workaround inspired by our `react-toastify` library - a JS event will dispatch state updates to the tooltip stage, triggering the closing animations. We also need to remove listeners for clicks on that event. It works well!

Finally, we close the ContextMenu on clicking any clickable item, something we've been wanting for a while. This more closely mimics real contextMenus. This also opens the possibility for closing the menu on other events, such as scroll.