### PR TITLE
fix: increase drag region

### DIFF
--- a/src/styles/_partials/_mixins.scss
+++ b/src/styles/_partials/_mixins.scss
@@ -84,7 +84,7 @@
 	top: 0;
 	left: 0;
 	right: 0;
-	height: 10px;
+	height: 30px;
 	width: 100%;
 }
 


### PR DESCRIPTION
Does what it says!

I thought we'd need to disallow dragging on any buttons that were underneath the drag area, but something might have changed during an electron upgrade, because now we can click the buttons under the drag area while still dragging there too. I remember that not being the case when I originally changed this to 10px.