### PR TITLE
feat: add maxHeightOffest option for Combobox

### DIFF
--- a/src/components/inputs/Combobox/Combobox.scss
+++ b/src/components/inputs/Combobox/Combobox.scss
@@ -111,6 +111,7 @@
 	}
 
 	.Combobox_Options {
+		overflow: hidden;
 		position: absolute;
 		top: calc(var(--inputHeight) + 1px);
 		left: 0;

--- a/src/components/inputs/Combobox/Combobox.stories.mdx
+++ b/src/components/inputs/Combobox/Combobox.stories.mdx
@@ -179,6 +179,8 @@ import { Tooltip } from "../../overlays/Tooltip/Tooltip";
 
 ## Complex Example:
 
+To see the maxHeightOffset prop in action, expand the combobox and resize your window so that the dropdown overflows. You should see the height adjust to above the window height based on the default + maxHeightOffset value.
+
 <Canvas>
 	<Story name="Connect">
 		<div style={{ width: "90%", height: "660px" }}>

--- a/src/components/inputs/Combobox/Combobox.tsx
+++ b/src/components/inputs/Combobox/Combobox.tsx
@@ -125,6 +125,8 @@ export interface IComboboxProps extends ILocalContainerProps {
 	invalid?: boolean;
 	/** Message shown below text input when combobox is invalid */
 	invalidMessage?: string;
+	/** Offset for the max height of the combobox options dropdown. The max height defaults to 75px above the bottom of the window. */
+	maxHeightOffset?: number;
 }
 
 /**
@@ -144,6 +146,7 @@ const Combobox = (props: IComboboxProps) => {
 		onChange,
 		options = {},
 		optionHeight = 's',
+		maxHeightOffset = 0,
 		inputHeight = 'l',
 		optionsLoader,
 		optionGroups,
@@ -297,7 +300,9 @@ const Combobox = (props: IComboboxProps) => {
 
 	const handleResize = () => {
 		setMaxHeight(
-			containerRef.current ? window.innerHeight - 75 - containerRef.current.getBoundingClientRect().top : 0
+			containerRef.current
+				? window.innerHeight - 75 - maxHeightOffset - containerRef.current.getBoundingClientRect().top
+				: 0
 		);
 	};
 

--- a/src/components/inputs/Combobox/ComboboxConnectExample.tsx
+++ b/src/components/inputs/Combobox/ComboboxConnectExample.tsx
@@ -87,5 +87,6 @@ export const ComboboxConnectExample = () => (
 		onChange={() => console.log('onChange')}
 		placeholder="Select Something!"
 		striped
+		maxHeightOffset={75}
 	/>
 );


### PR DESCRIPTION
I'm going to try and add this component to Cloud backups for backup selection, but the dropdown gets hidden by the stepper, and the top component scrolls. This solution adds an option to adjust the max height, which is dynamically set to 75px above the bottom of the window and is reset on window resize.