### PR TITLE
Fix: Add aria-label to `NavLink` for improved a11y of main menu

### DIFF
--- a/src/components/modules/VerticalNav/VerticalNav.tsx
+++ b/src/components/modules/VerticalNav/VerticalNav.tsx
@@ -53,6 +53,7 @@ export const VerticalNavItem = (props: IProps) => {
 			<NavLink
 				to={routeTo || ''}
 				exact={false}
+				aria-label={tooltip || undefined}
 				activeClassName={navLinkActiveClassName || '__Active'}
 				className={classnames(navLinkClass, additionalNavLinkClass, {
 					__Active: navLinkActive,


### PR DESCRIPTION
## Summary

Labels are currently not associated with their buttons, so screenreader users hear prompts such as “link, image, app.html” instead of “Local Site” or “Blueprints”, making it very difficult to navigate Local. This includes the “Add Local site” button.

Instead, these should read:
- link, Local sites
- link, Connect
- link, Blueprints
- link, Add-ons
- link, Support,
- link, Add Local site

## Technical

Uses the existing tooltip text to add `aria-label` to the `NavLink` for screen readers.

Should be tested with [this branch in flywheel-local](https://github.com/getflywheel/flywheel-local/tree/jb/LOC-5279/a11y-hide-svg).

To start (or stop) VoiceOver, press Command-F5. 

## Screenshots / Text Samples

Before/After
<img width="335" alt="Screenshot 2023-09-15 at 1 35 04 PM" src="https://github.com/getflywheel/local-components/assets/1271053/c3efe3a0-f5bc-4281-98f9-daa97750accf">

<img width="316" alt="Screenshot 2023-09-15 at 1 29 50 PM" src="https://github.com/getflywheel/local-components/assets/1271053/d74c281c-3a42-4a74-970f-e93866096e93">

Markup
<img width="418" alt="Screenshot 2023-09-15 at 1 23 02 PM" src="https://github.com/getflywheel/local-components/assets/1271053/1a563bff-e919-4cfb-a8d3-c6501fe1306b">

## Reference

- [LOC-5279](https://wpengine.atlassian.net/browse/LOC-5279)


## Notes

- It's difficult to navigate local without other structural changes. The main vertical menu should be a `nav` with better keyboard navigation. The Avatar login tab & link popup is also not accessible.

[LOC-5279]: https://wpengine.atlassian.net/browse/LOC-5279?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ