### PR TITLE
Fix: Improve VerticalNav a11y

### DIFF
--- a/src/components/modules/VerticalNav/VerticalNav.tsx
+++ b/src/components/modules/VerticalNav/VerticalNav.tsx
@@ -6,12 +6,17 @@ import IReactComponentProps from '../../../common/structures/IReactComponentProp
 import styles from './VerticalNav.scss';
 import FlyTooltip from '../../overlays/FlyTooltip/FlyTooltip';
 
-export const VerticalNav = (props: IReactComponentProps) => {
-	const { className, id, children, style } = props;
+interface INavProps extends IReactComponentProps {
+	title?: string | undefined;
+}
+
+export const VerticalNav = (props: INavProps) => {
+	const { className, id, children, style, title } = props;
+
 	return (
-		<div className={classnames(styles.VerticalNav, className)} id={id} style={style}>
+		<nav aria-label={title} className={classnames(styles.VerticalNav, className)} id={id} style={style}>
 			{children}
-		</div>
+		</nav>
 	);
 };
 

--- a/src/components/overlays/FlyTooltip/FlyTooltip.tsx
+++ b/src/components/overlays/FlyTooltip/FlyTooltip.tsx
@@ -48,6 +48,7 @@ export default class FlyTooltip extends React.Component<IProps> {
 					)}
 					id={this.props.id}
 					style={this.props.style}
+					aria-hidden
 				>
 					{
 						this.props.exclamation


### PR DESCRIPTION
## Summary

- As a `nav` instead of a div, it serves as a landmark for screen readers (and possible later improvement for keyboard navigation)
- Adds a title for use as an `aria-label` with the vertical nav
- When using arrow keys and a screen reader within the nav, this prevents the tooltip from being read out in addition to the `aria-label` on the link in the vertical nav

## Technical

Should be tested with [this branch in flywheel-local](https://github.com/getflywheel/flywheel-local/tree/jb/fix/vertical-nav).

To start (or stop) VoiceOver, press Command-F5. 

## Screenshots / Text Samples

Screen readers now see the `nav` as a landmark and the title/aria-label is read.
<img width="613" alt="Screenshot 2023-09-27 at 12 57 23 PM" src="https://github.com/getflywheel/local-components/assets/1271053/0666df97-980b-48fb-9af8-b141fec07666">

<img width="94" alt="Screenshot 2023-09-27 at 12 56 38 PM" src="https://github.com/getflywheel/local-components/assets/1271053/3e723e4c-6e14-4421-934c-4eb4f1e78d1e">

## Reference

- [LOC-5321](https://wpengine.atlassian.net/browse/LOC-5321)

## Notes

- The Avatar login tab & link popup is not accessible. [Issue in backlog](https://wpengine.atlassian.net/browse/LOC-5340).



[LOC-5321]: https://wpengine.atlassian.net/browse/LOC-5321?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ