### PR TITLE
fix: replace deprecated shortid with nanoid

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "@electron/remote": "^2.0.8",
     "@popperjs/core": "^2.9.2",
     "@types/lz-string": "^1.3.34",
-    "@types/shortid": "^0.0.29",
     "@types/untildify": "^3.0.0",
     "classnames": "^2.2.6",
     "clipboard-copy": "^3.1.0",
@@ -25,6 +24,7 @@
     "lodash.isequal": "^4.5.0",
     "lz-string": "^1.4.4",
     "memoize-one": "^6.0.0",
+    "nanoid": "^5.0.1",
     "react-animate-height": "^2.0.23",
     "react-lowlight": "^2.0.0",
     "react-markdown": "^4.0.3",
@@ -35,7 +35,6 @@
     "react-router-dom": "^5.0.1",
     "react-toastify": "^9.1.1",
     "react-truncate-markup": "^3.0.0",
-    "shortid": "^2.2.16",
     "untildify": "^4.0.0"
   },
   "scripts": {

--- a/src/components/menus/ContextMenu/ContextMenu.test.tsx
+++ b/src/components/menus/ContextMenu/ContextMenu.test.tsx
@@ -5,6 +5,10 @@ import ContextMenu, { IContextMenuProps, IMenuItem } from './ContextMenu';
 
 const mockOnClick = jest.fn();
 
+jest.mock('nanoid', () => ({
+	nanoid: () => 'a-fixed-random-id',
+}));
+
 const menuItems: IMenuItem[] = [
 	{
 		label: 'View site',

--- a/src/components/menus/ContextMenu/ContextMenu.tsx
+++ b/src/components/menus/ContextMenu/ContextMenu.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import classnames from 'classnames';
-import shortid from 'shortid';
+import { nanoid } from 'nanoid';
 import { useEffect, useRef, useState } from 'react';
 import styles from './ContextMenu.scss';
 import { FunctionGeneric } from '../../../common/structures/Generics';
@@ -99,7 +99,7 @@ const ContextMenu = (props: IContextMenuProps) => {
 		...otherProps
 	} = props;
 
-	const menuId = useRef(id ?? `${'contextMenu'}-${shortid.generate()}`);
+	const menuId = useRef(id ?? `${'contextMenu'}-${nanoid()}`);
 
 	const [isShowing, setIsShowing] = useState(false);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3699,11 +3699,6 @@
     "@types/mime" "*"
     "@types/node" "*"
 
-"@types/shortid@^0.0.29":
-  version "0.0.29"
-  resolved "https://registry.yarnpkg.com/@types/shortid/-/shortid-0.0.29.tgz#8093ee0416a6e2bf2aa6338109114b3fbffa0e9b"
-  integrity sha512-9BCYD9btg2CY4kPcpMQ+vCR8U6V8f/KvixYD5ZbxoWlkhddNF5IeZMVL3p+QFUkg+Hb+kPAG9Jgk4bnnF1v/Fw==
-
 "@types/sockjs@^0.3.33":
   version "0.3.33"
   resolved "https://registry.yarnpkg.com/@types/sockjs/-/sockjs-0.3.33.tgz#570d3a0b99ac995360e3136fd6045113b1bd236f"
@@ -10480,15 +10475,15 @@ nan@^2.12.1:
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.16.0.tgz#664f43e45460fb98faf00edca0bb0d7b8dce7916"
   integrity sha512-UdAqHyFngu7TfQKsCBgAA6pWDkT8MAO7d0jyOecVhN5354xbLqdn8mV9Tat9gepAupm0bt2DbeaSC8vS52MuFA==
 
-nanoid@^2.1.0:
-  version "2.1.11"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-2.1.11.tgz#ec24b8a758d591561531b4176a01e3ab4f0f0280"
-  integrity sha512-s/snB+WGm6uwi0WjsZdaVcuf3KJXlfGl2LcxgwkEwJF0D/BWzVWAZW/XY4bFaiR7s0Jk3FPvlnepg1H1b1UwlA==
-
 nanoid@^3.3.1, nanoid@^3.3.4:
   version "3.3.4"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.4.tgz#730b67e3cd09e2deacf03c027c81c9d9dbc5e8ab"
   integrity sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==
+
+nanoid@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-5.0.1.tgz#3e95d775a8bc8a98afbf0a237e2bbc6a71b0662e"
+  integrity sha512-vWeVtV5Cw68aML/QaZvqN/3QQXc6fBfIieAlu05m7FZW2Dgb+3f0xc0TTxuJW+7u30t7iSDTV/j3kVI0oJqIfQ==
 
 nanomatch@^1.2.9:
   version "1.2.13"
@@ -12799,13 +12794,6 @@ shelljs@^0.8.5:
     glob "^7.0.0"
     interpret "^1.0.0"
     rechoir "^0.6.2"
-
-shortid@^2.2.16:
-  version "2.2.16"
-  resolved "https://registry.yarnpkg.com/shortid/-/shortid-2.2.16.tgz#b742b8f0cb96406fd391c76bfc18a67a57fe5608"
-  integrity sha512-Ugt+GIZqvGXCIItnsL+lvFJOiN7RYqlGy7QE41O3YC1xbNSeDGIRO7xg2JJXIAj1cAGnOeC1r7/T9pgrtQbv4g==
-  dependencies:
-    nanoid "^2.1.0"
 
 shx@^0.3.2:
   version "0.3.4"


### PR DESCRIPTION
Shortid has been deprecated and they recommend nanoid [^1]

While upgrading, I tried running the ContextMenu.test.tsx tests without mocking nanoid, but kept getting an error:

```
FAIL src/components/menus/ContextMenu/ContextMenu.test.tsx
  ● Test suite failed to run

    Jest encountered an unexpected token

    Jest failed to parse a file..
	...
	Details:

    /Users/ben.turner/src/local/local-components/node_modules/nanoid/index.browser.js:1
    ({"Object.<anonymous>":function(module,exports,require,__dirname,__filename,jest){export { urlAlphabet } from './url-alphabet/index.js'
                                                                                      ^^^^^^

    SyntaxError: Unexpected token 'export'

      1 | import * as React from 'react';
      2 | import classnames from 'classnames';
    > 3 | import { nanoid } from 'nanoid';
        | ^
      4 | import { useEffect, useRef, useState } from 'react';
      5 | import styles from './ContextMenu.scss';
      6 | import { FunctionGeneric } from '../../../common/structures/Generics';

      at Runtime.createScriptFromCode (node_modules/jest-runtime/build/index.js:1796:14)
      at Object.<anonymous> (src/components/menus/ContextMenu/ContextMenu.tsx:3:1)
```

Nanoid uses ESM for newer versions, which has some issues with running in Jest and the `jsdom` environment. [^2]

There were a few things in the comments for that thread that might have worked, but since I was only changing one implementation which didn't really need to test a fully random thing, I opted to just mock nanoid and be done with it.

[^1]: https://www.npmjs.com/package/shortid
[^2]: https://github.com/ai/nanoid/issues/395