### PR TITLE
deps: replace nanoid with randomId util

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "lodash.isequal": "^4.5.0",
     "lz-string": "^1.4.4",
     "memoize-one": "^6.0.0",
-    "nanoid": "^5.0.1",
     "react-animate-height": "^2.0.23",
     "react-lowlight": "^2.0.0",
     "react-markdown": "^4.0.3",

--- a/src/components/menus/ContextMenu/ContextMenu.test.tsx
+++ b/src/components/menus/ContextMenu/ContextMenu.test.tsx
@@ -5,10 +5,6 @@ import ContextMenu, { IContextMenuProps, IMenuItem } from './ContextMenu';
 
 const mockOnClick = jest.fn();
 
-jest.mock('nanoid', () => ({
-	nanoid: () => 'a-fixed-random-id',
-}));
-
 const menuItems: IMenuItem[] = [
 	{
 		label: 'View site',

--- a/src/components/menus/ContextMenu/ContextMenu.tsx
+++ b/src/components/menus/ContextMenu/ContextMenu.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import classnames from 'classnames';
-import { nanoid } from 'nanoid';
 import { useEffect, useRef, useState } from 'react';
+import randomId from '../../../utils/randomId';
 import styles from './ContextMenu.scss';
 import { FunctionGeneric } from '../../../common/structures/Generics';
 import { Tooltip, TooltipProps, hideTooltip, showTooltip } from '../../overlays/Tooltip/Tooltip';
@@ -99,7 +99,7 @@ const ContextMenu = (props: IContextMenuProps) => {
 		...otherProps
 	} = props;
 
-	const menuId = useRef(id ?? `${'contextMenu'}-${nanoid()}`);
+	const menuId = useRef(id ?? `${'contextMenu'}-${randomId()}`);
 
 	const [isShowing, setIsShowing] = useState(false);
 

--- a/src/utils/randomId.test.ts
+++ b/src/utils/randomId.test.ts
@@ -1,0 +1,21 @@
+import randomId from './randomId';
+
+describe('randomId', () => {
+	it('should return a string of default length when no arguments are passed', () => {
+		const result = randomId();
+		expect(result).toHaveLength(21);
+	});
+
+	it('should return a string of specified length when an argument is provided', () => {
+		const result = randomId(10);
+		expect(result).toHaveLength(10);
+	});
+
+	it('should return unique values across multiple calls', () => {
+		const sampleSize = 100;
+		const ids = Array.from({ length: sampleSize }, randomId);
+		const uniqueIds = new Set(ids);
+
+		expect(uniqueIds.size).toEqual(sampleSize);
+	});
+});

--- a/src/utils/randomId.ts
+++ b/src/utils/randomId.ts
@@ -1,0 +1,14 @@
+/**
+ * Creates a random URL-safe string for IDs and unique fallback values.
+ *
+ * @param len Length of the string to generate.
+ */
+export default function randomId(len: number = 21): string {
+	const charset = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_-';
+	let result = '';
+	for (let i = 0; i < len; i += 1) {
+		const randomIndex = Math.floor(Math.random() * charset.length);
+		result += charset[randomIndex];
+	}
+	return result;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -10480,11 +10480,6 @@ nanoid@^3.3.1, nanoid@^3.3.4:
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.4.tgz#730b67e3cd09e2deacf03c027c81c9d9dbc5e8ab"
   integrity sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==
 
-nanoid@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-5.0.1.tgz#3e95d775a8bc8a98afbf0a237e2bbc6a71b0662e"
-  integrity sha512-vWeVtV5Cw68aML/QaZvqN/3QQXc6fBfIieAlu05m7FZW2Dgb+3f0xc0TTxuJW+7u30t7iSDTV/j3kVI0oJqIfQ==
-
 nanomatch@^1.2.9:
   version "1.2.13"
   resolved "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.13.tgz#b87a8aa4fc0de8fe6be88895b38983ff265bd119"


### PR DESCRIPTION
## Summary
When linking the current master branch of local-components in development, our use of nanoid causes the error below and prevents Local from loading. (We have [not yet released this change in local-components](https://github.com/getflywheel/local-components/compare/17.7.2...master), which is why we have not seen it in Local itself yet.)

## How this PR fixes it

I removed `nanoid` and created a simple `randomId` function instead.

## Alternative approaches

1. Downgrade from nanoid 5.x to 3.3.5: https://github.com/ai/nanoid/issues/422#issuecomment-1553393904

2. Refactor to use a dynamic import as the error output suggests (but this potentially infects all call sites with `await` and [recolors](https://journal.stuffwithstuff.com/2015/02/01/what-color-is-your-function/) parent functions as async).

3. Switch from `"module": "commonjs"` to `"module": "ESNext"` in our `tsconfig.json` and deal with the impact of that change.

4. Upgrade to React 18 to gain [useId()](https://react.dev/reference/react/useId) (we're still on 16).

5. Replace the random ID with an incremental one instead. 

    ```diff
    + let menuCounter = 0;

    const ContextMenu = (props: IContextMenuProps) => {
    ...
    -   const menuId = useRef(id ?? `${'contextMenu'}-${randomId()}`);
    +   const menuId = useRef(id ?? `contextMenu-${(menuCounter += 1)}`);
    ...
    };
    ```
    
    This seemed promising but may have hidden issues around overflows and uniqueness.


## Error example

The nanoid error in getflywheel-local I was seeing after running nps components.link and nps.build, then opening the app:

```
 require() of ES Module /Users/nick.cernis/localdev/local-components/node_modules/nanoid/index.js from
/Users/nick.cernis/localdev/local-components/dist/index.js not supported.
Instead change the require of /Users/nick.cernis/localdev/local-components/node_modules/nanoid/index.js in
/Users/nick.cernis/localdev/local-components/dist/index.js to a dynamic import() which is available in all CommonJS modules.
```

## To test

Includes tests for the new `randomId` function.

```
> yarn test randomId.test.ts
yarn run v1.22.19
$ jest randomId.test.ts
 PASS  src/utils/randomId.test.ts
  randomId
    ✓ should return a string of default length when no arguments are passed (2 ms)
    ✓ should return a string of specified length when an argument is provided
    ✓ should return unique values across multiple calls (2 ms)

Test Suites: 1 passed, 1 total
Tests:       3 passed, 3 total
Snapshots:   0 total
Time:        4.853 s
Ran all test suites matching /randomId.test.ts/i.
✨  Done in 6.44s.
```

### To reproduce the error manually

1. In this repo:
    - `git checkout master`
    - `yarn && yarn build`
    - `yarn link` (only needed one time or after unlinking)
3. In `getflywheel-local`
    - Be sure to pull the latest from master, which includes [Adam's components.link fix](https://github.com/getflywheel/flywheel-local/pull/1806).
    - `nps components.link`
    - `nps build.dev`
5. Start Local. You should see an error like this one and Local will fail to load:

    <img width="1312" alt="failed-build-with-nanoid" src="https://github.com/getflywheel/local-components/assets/647669/d556031d-c663-4175-b4a4-6233aa4dba19">

### To test the fix

1. In this repo:
    - `git checkout nc/deps/remove-nanoid`
    - `yarn && yarn build`
    - `yarn link` (only needed if you have not already linked in the previous test, or if you unlinked from getflywheel-local)
2. In `getflywheel-local`
    - `nps build.dev` (If this is still running, you should not need to re-run; just refresh in your dev build of Local).
3. Open or refresh Local. It should load with context menus (the error pictured is unrelated to nanoid):

    <img width="1312" alt="successful-build-without-nanoid" src="https://github.com/getflywheel/local-components/assets/647669/cebf110d-98dc-4a61-8536-3648dcf8d434">

## To reset your dev environment after testing

In `getflywheel-local`:

- Stop running build processes.
- Run `nps components.unlink.`
- Run `yarn install --force`.
- Start your build processes.

Local will then download local-components from npm instead of using the one linked on your machine.